### PR TITLE
fix: 修复 AI 助手复制与输入历史交互

### DIFF
--- a/frontend/src/__tests__/AIChatInput.test.tsx
+++ b/frontend/src/__tests__/AIChatInput.test.tsx
@@ -59,6 +59,64 @@ describe("AIChatInput", () => {
     expect(mentions).toEqual([expect.objectContaining({ assetId: 42, name: "prod-db" })]);
   });
 
+  it("ArrowUp 在首字符位置接管：取最近一条用户消息", async () => {
+    const editorRef = { current: null as Editor | null };
+    const history = ["最新", "次新", "更早"];
+    render(<AIChatInput onSubmit={vi.fn()} sendOnEnter={true} editorRef={editorRef} userMessageHistory={history} />);
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+    const editor = screen.getByRole("textbox");
+    await userEvent.click(editor);
+    await userEvent.keyboard("{ArrowUp}");
+    await waitFor(() => expect(editorRef.current!.getText()).toBe("最新"));
+  });
+
+  it("重复 ArrowUp 逐步回溯更早的用户消息", async () => {
+    const editorRef = { current: null as Editor | null };
+    const history = ["最新", "次新", "更早"];
+    render(<AIChatInput onSubmit={vi.fn()} sendOnEnter={true} editorRef={editorRef} userMessageHistory={history} />);
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+    const editor = screen.getByRole("textbox");
+    await userEvent.click(editor);
+    await userEvent.keyboard("{ArrowUp}");
+    await waitFor(() => expect(editorRef.current!.getText()).toBe("最新"));
+    await userEvent.keyboard("{ArrowUp}");
+    await waitFor(() => expect(editorRef.current!.getText()).toBe("次新"));
+    await userEvent.keyboard("{ArrowUp}");
+    await waitFor(() => expect(editorRef.current!.getText()).toBe("更早"));
+    // 到达最老记录后再按 ArrowUp 应保持最老一条，不越界
+    await userEvent.keyboard("{ArrowUp}");
+    expect(editorRef.current!.getText()).toBe("更早");
+  });
+
+  it("ArrowDown 向前浏览，最终回到空输入", async () => {
+    const editorRef = { current: null as Editor | null };
+    const history = ["最新", "次新"];
+    render(<AIChatInput onSubmit={vi.fn()} sendOnEnter={true} editorRef={editorRef} userMessageHistory={history} />);
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+    const editor = screen.getByRole("textbox");
+    await userEvent.click(editor);
+    await userEvent.keyboard("{ArrowUp}{ArrowUp}");
+    await waitFor(() => expect(editorRef.current!.getText()).toBe("次新"));
+    await userEvent.keyboard("{ArrowDown}");
+    await waitFor(() => expect(editorRef.current!.getText()).toBe("最新"));
+    await userEvent.keyboard("{ArrowDown}");
+    await waitFor(() => expect(editorRef.current!.getText()).toBe(""));
+  });
+
+  it("光标不在首字符时 ArrowUp 不接管历史", async () => {
+    const editorRef = { current: null as Editor | null };
+    const history = ["history message"];
+    render(<AIChatInput onSubmit={vi.fn()} sendOnEnter={true} editorRef={editorRef} userMessageHistory={history} />);
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+    // 通过 editor API 写入文本并把光标放到末尾，避免 userEvent + contenteditable 的段落偏差影响断言
+    editorRef.current!.chain().focus().insertContent("typing").focus("end").run();
+    const textBefore = editorRef.current!.getText();
+    await userEvent.keyboard("{ArrowUp}");
+    // ArrowUp 不应替换为历史记录；文本保持不变即可证明拦截被跳过
+    expect(editorRef.current!.getText()).toBe(textBefore);
+    expect(editorRef.current!.getText()).not.toBe("history message");
+  });
+
   it("选中 mention 后提交回调 mentions 包含 assetId", async () => {
     const onSubmit = vi.fn();
     const editorRef = { current: null as Editor | null };

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -36,6 +36,8 @@ import { AISetupWizard } from "@/components/ai/AISetupWizard";
 // 常量化 Markdown 插件数组，避免每次渲染创建新引用导致 Markdown 重解析
 const mdRemarkPlugins = [remarkGfm];
 const mdRehypePlugins = [rehypeSanitize];
+// 统一助手消息选中态样式，避免不同气泡的选区反馈不一致。
+const messageSelectionClass = "select-text selection:bg-primary/25 selection:text-foreground";
 
 // 稳定引用的默认值，避免 zustand selector 每次返回新对象导致无限渲染
 const EMPTY_MESSAGES: ChatMessage[] = [];
@@ -105,6 +107,10 @@ export function AIChatContent({
     conversationId != null ? s.conversationStreaming[conversationId] || DEFAULT_STREAMING : DEFAULT_STREAMING
   );
   const { sending, pendingQueue } = streaming;
+  const userMessageHistory = [...messages]
+    .filter((msg) => msg.role === "user" && msg.content.trim())
+    .map((msg) => msg.content)
+    .reverse();
 
   const [regenerateTarget, setRegenerateTarget] = useState<number | null>(null);
   const [empty, setEmpty] = useState(true);
@@ -238,6 +244,7 @@ export function AIChatContent({
                 onSubmit={handleSend}
                 onEmptyChange={setEmpty}
                 sendOnEnter={sendOnEnter}
+                userMessageHistory={userMessageHistory}
                 placeholder={t("ai.sendPlaceholder")}
               />
               <div className="flex items-center justify-between px-3 pb-2">
@@ -361,7 +368,9 @@ const AssistantMessage = memo(function AssistantMessage({
   return (
     <div className="flex flex-col items-start gap-1.5 group/assistant">
       <span className="text-xs font-semibold text-primary tracking-wide">Assistant</span>
-      <div className="rounded-xl rounded-bl-sm bg-muted px-3.5 py-2.5 max-w-[95%] min-w-0 overflow-hidden break-words prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-pre:my-1 prose-pre:overflow-x-auto shadow-sm">
+      <div
+        className={`rounded-xl rounded-bl-sm bg-muted px-3.5 py-2.5 max-w-[95%] min-w-0 overflow-hidden break-words prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-pre:my-1 prose-pre:overflow-x-auto shadow-sm ${messageSelectionClass}`}
+      >
         <Markdown remarkPlugins={mdRemarkPlugins} rehypePlugins={mdRehypePlugins}>
           {msg.content}
         </Markdown>
@@ -391,7 +400,7 @@ const BubbleSegment = memo(function BubbleSegment({
   const maxWidthClass = compactCtx ? "max-w-full" : "max-w-[95%]";
   return (
     <div
-      className={`rounded-xl rounded-bl-sm bg-muted px-3.5 py-3 ${maxWidthClass} min-w-0 overflow-hidden shadow-sm space-y-2`}
+      className={`rounded-xl rounded-bl-sm bg-muted px-3.5 py-3 ${maxWidthClass} min-w-0 overflow-hidden shadow-sm space-y-2 ${messageSelectionClass}`}
     >
       {blocks.map((block, idx) =>
         block.type === "text" ? (

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, memo, useCallback, createContext, useContext } from "react";
+import { useState, useRef, useEffect, useMemo, memo, useCallback, createContext, useContext } from "react";
 import { Loader2, CornerDownLeft, Square, RefreshCw, X, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
@@ -107,10 +107,17 @@ export function AIChatContent({
     conversationId != null ? s.conversationStreaming[conversationId] || DEFAULT_STREAMING : DEFAULT_STREAMING
   );
   const { sending, pendingQueue } = streaming;
-  const userMessageHistory = [...messages]
-    .filter((msg) => msg.role === "user" && msg.content.trim())
-    .map((msg) => msg.content)
-    .reverse();
+  // 从最新到最旧收集非空用户消息，用 useMemo 避免无关渲染也构造新数组。
+  const userMessageHistory = useMemo(() => {
+    const history: string[] = [];
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.role === "user" && msg.content.trim()) {
+        history.push(msg.content);
+      }
+    }
+    return history;
+  }, [messages]);
 
   const [regenerateTarget, setRegenerateTarget] = useState<number | null>(null);
   const [empty, setEmpty] = useState(true);

--- a/frontend/src/components/ai/AIChatInput.tsx
+++ b/frontend/src/components/ai/AIChatInput.tsx
@@ -21,6 +21,7 @@ export interface AIChatInputProps {
   onSubmit: (text: string, mentions: MentionRef[]) => void;
   onEmptyChange?: (empty: boolean) => void;
   sendOnEnter: boolean;
+  userMessageHistory?: string[];
   placeholder?: string;
   disabled?: boolean;
   /** 仅用于测试：暴露 TipTap editor 以便测试代码直接操作富文本。 */
@@ -32,6 +33,17 @@ interface ProseMirrorLikeNode {
   text?: string;
   attrs: Record<string, unknown>;
   descendants: (fn: (node: ProseMirrorLikeNode) => boolean | void) => void;
+}
+
+type InputHistoryDirection = "up" | "down";
+
+interface InputHistoryNavigationOptions {
+  direction: InputHistoryDirection;
+  currentText: string;
+  historyIndex: number;
+  userMessageHistory: string[];
+  canStartHistory: boolean;
+  canContinueHistory: boolean;
 }
 
 /** 从 TipTap doc 提取纯文本 + mention 引用。 */
@@ -58,13 +70,68 @@ function extractTextAndMentions(doc: ProseMirrorLikeNode): {
   return { text: text.replace(/\n+$/g, ""), mentions };
 }
 
+// 仅在首行首字符接管向上历史，避免影响富文本输入的原生光标移动。
+function shouldStartInputHistory(editor: Editor) {
+  const { selection } = editor.state;
+  return selection.empty && selection.from === 1;
+}
+
+// 进入历史浏览后，只要还是折叠光标就允许继续用上下键切换。
+function shouldContinueInputHistory(editor: Editor) {
+  return editor.state.selection.empty;
+}
+
+// 统一计算上下键历史切换的目标内容，避免把判断分散在按键处理中。
+function getInputHistoryNavigationState({
+  direction,
+  currentText,
+  historyIndex,
+  userMessageHistory,
+  canStartHistory,
+  canContinueHistory,
+}: InputHistoryNavigationOptions) {
+  const currentHistoryMessage = historyIndex >= 0 ? userMessageHistory[historyIndex] : null;
+  const isBrowsingHistory = currentHistoryMessage != null && currentText === currentHistoryMessage;
+  const canNavigate = isBrowsingHistory ? canContinueHistory : canStartHistory;
+
+  if (!canNavigate) return null;
+  if (direction === "up" && userMessageHistory.length === 0) return null;
+  if (direction === "down" && (!isBrowsingHistory || historyIndex < 0)) return null;
+
+  const nextHistoryIndex =
+    direction === "up" ? Math.min(historyIndex + 1, userMessageHistory.length - 1) : historyIndex - 1;
+  const nextMessage = nextHistoryIndex >= 0 ? userMessageHistory[nextHistoryIndex] : "";
+
+  return { nextHistoryIndex, nextMessage };
+}
+
+// 把历史消息写回编辑器，并把光标定位到末尾，保证连续切换时体验稳定。
+function applyInputHistoryMessage(editor: Editor, nextMessage: string) {
+  const historyDoc = {
+    type: "doc",
+    content:
+      nextMessage.length > 0
+        ? nextMessage.split("\n").map((line) => ({
+            type: "paragraph",
+            content: line.length > 0 ? [{ type: "text", text: line }] : [],
+          }))
+        : [{ type: "paragraph" }],
+  };
+
+  editor.commands.setContent(historyDoc);
+  editor.commands.focus("end");
+}
+
 export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(function AIChatInput(
-  { onSubmit, onEmptyChange, sendOnEnter, placeholder, disabled, editorRef },
+  { onSubmit, onEmptyChange, sendOnEnter, userMessageHistory = [], placeholder, disabled, editorRef },
   ref
 ) {
   const submitRef = useRef(onSubmit);
   const sendOnEnterRef = useRef(sendOnEnter);
   const onEmptyChangeRef = useRef(onEmptyChange);
+  const historyRef = useRef(userMessageHistory);
+  const historyIndexRef = useRef(-1);
+  const applyingHistoryRef = useRef(false);
 
   useEffect(() => {
     submitRef.current = onSubmit;
@@ -75,6 +142,9 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
   useEffect(() => {
     onEmptyChangeRef.current = onEmptyChange;
   }, [onEmptyChange]);
+  useEffect(() => {
+    historyRef.current = userMessageHistory;
+  }, [userMessageHistory]);
 
   const triggerSubmitRef = useRef<() => void>(() => {});
   // @ 提及弹窗是否处于激活状态。ProseMirror 会先调用 editorProps.handleKeyDown
@@ -153,9 +223,39 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
         role: "textbox",
       },
       handleKeyDown: (_view, event) => {
+        if (!editor) return false;
+
         const shouldSendOnEnter = sendOnEnterRef.current;
         const isEnter = event.key === "Enter";
         const mod = event.ctrlKey || event.metaKey;
+
+        // 在允许的光标位置接管上下键，统一处理用户消息历史切换。
+        if (
+          (event.key === "ArrowUp" || event.key === "ArrowDown") &&
+          !event.altKey &&
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.shiftKey
+        ) {
+          const { text: currentText } = extractTextAndMentions(editor.state.doc as unknown as ProseMirrorLikeNode);
+          const nextHistoryState = getInputHistoryNavigationState({
+            direction: event.key === "ArrowUp" ? "up" : "down",
+            currentText,
+            historyIndex: historyIndexRef.current,
+            userMessageHistory: historyRef.current,
+            canStartHistory: shouldStartInputHistory(editor),
+            canContinueHistory: shouldContinueInputHistory(editor),
+          });
+
+          if (nextHistoryState) {
+            event.preventDefault();
+            historyIndexRef.current = nextHistoryState.nextHistoryIndex;
+            applyingHistoryRef.current = true;
+            applyInputHistoryMessage(editor, nextHistoryState.nextMessage);
+            return true;
+          }
+        }
+
         // 提及弹窗激活时，把 Enter 让给 suggestion 插件用于选中候选项
         if (isEnter && mentionActiveRef.current) {
           return false;
@@ -174,6 +274,11 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
       },
     },
     onUpdate: ({ editor: ed }) => {
+      if (applyingHistoryRef.current) {
+        applyingHistoryRef.current = false;
+      } else {
+        historyIndexRef.current = -1;
+      }
       onEmptyChangeRef.current?.(ed.isEmpty);
     },
     editable: !disabled,
@@ -194,6 +299,7 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
       if (editor.isEmpty) return;
       const { text, mentions } = extractTextAndMentions(editor.state.doc as unknown as ProseMirrorLikeNode);
       if (!text.trim() && mentions.length === 0) return;
+      historyIndexRef.current = -1;
       submitRef.current(text, mentions);
       editor.commands.clearContent();
     };

--- a/frontend/src/components/ai/AIChatInput.tsx
+++ b/frontend/src/components/ai/AIChatInput.tsx
@@ -143,7 +143,9 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
     onEmptyChangeRef.current = onEmptyChange;
   }, [onEmptyChange]);
   useEffect(() => {
+    // 历史列表变化（切换会话、新消息到达等）时复位浏览游标，避免旧 index 落到错位条目。
     historyRef.current = userMessageHistory;
+    historyIndexRef.current = -1;
   }, [userMessageHistory]);
 
   const triggerSubmitRef = useRef<() => void>(() => {});

--- a/frontend/src/components/ai/UserMessage.tsx
+++ b/frontend/src/components/ai/UserMessage.tsx
@@ -32,11 +32,15 @@ function buildSegments(content: string, mentions: MentionRef[] | undefined): Seg
   return segs;
 }
 
-// 统一复制提示，保证按钮复制和右键复制的反馈一致。
-async function copyUserMessageText(text: string, copiedText: string) {
+// 统一复制提示，保证按钮复制和右键复制的反馈一致；剪贴板不可用时给出错误提示，避免 unhandled rejection。
+async function copyUserMessageText(text: string, copiedText: string, failedText: string) {
   if (!text.trim()) return;
-  await navigator.clipboard.writeText(text);
-  toast.success(copiedText, { duration: 1500, position: "top-center" });
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(copiedText, { duration: 1500, position: "top-center" });
+  } catch {
+    toast.error(failedText, { duration: 2000, position: "top-center" });
+  }
 }
 
 export const UserMessage = memo(function UserMessage({ msg }: { msg: ChatMessage }) {
@@ -47,14 +51,14 @@ export const UserMessage = memo(function UserMessage({ msg }: { msg: ChatMessage
 
   // 用户消息复制默认取整条内容，减少额外转换带来的偏差。
   const handleCopy = useCallback(() => {
-    void copyUserMessageText(msg.content, t("ai.copied", "已复制到剪贴板"));
+    void copyUserMessageText(msg.content, t("ai.copied", "已复制到剪贴板"), t("ai.copyFailed", "复制失败"));
   }, [msg.content, t]);
 
   // 右键复制优先保留当前选区，没有选区时回退到整条消息。
   const handleContextCopy = useCallback(() => {
     const selectedText = window.getSelection?.()?.toString().trim() ?? "";
     const copyText = selectedText && msg.content.includes(selectedText) ? selectedText : msg.content;
-    void copyUserMessageText(copyText, t("ai.copied", "已复制到剪贴板"));
+    void copyUserMessageText(copyText, t("ai.copied", "已复制到剪贴板"), t("ai.copyFailed", "复制失败"));
   }, [msg.content, t]);
 
   return (

--- a/frontend/src/components/ai/UserMessage.tsx
+++ b/frontend/src/components/ai/UserMessage.tsx
@@ -1,4 +1,8 @@
-import { memo } from "react";
+import { memo, useCallback } from "react";
+import { Copy } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@opskat/ui";
 import type { ChatMessage, MentionRef } from "@/stores/aiStore";
 import { useCompact } from "@/components/ai/AIChatContent";
 import { openAssetInfoTab } from "@/lib/openAssetInfoTab";
@@ -8,6 +12,9 @@ interface Segment {
   text: string;
   mention?: MentionRef;
 }
+
+// 单独控制用户消息选中态，保证主色气泡里也能明确看到选区范围。
+const userMessageSelectionClass = "select-text selection:bg-white/35 selection:text-primary-foreground";
 
 function buildSegments(content: string, mentions: MentionRef[] | undefined): Segment[] {
   if (!mentions || mentions.length === 0) {
@@ -25,30 +32,69 @@ function buildSegments(content: string, mentions: MentionRef[] | undefined): Seg
   return segs;
 }
 
+// 统一复制提示，保证按钮复制和右键复制的反馈一致。
+async function copyUserMessageText(text: string, copiedText: string) {
+  if (!text.trim()) return;
+  await navigator.clipboard.writeText(text);
+  toast.success(copiedText, { duration: 1500, position: "top-center" });
+}
+
 export const UserMessage = memo(function UserMessage({ msg }: { msg: ChatMessage }) {
   const compact = useCompact();
   const maxWidthClass = compact ? "max-w-[95%]" : "max-w-[85%]";
   const segments = buildSegments(msg.content, msg.mentions);
+  const { t } = useTranslation();
+
+  // 用户消息复制默认取整条内容，减少额外转换带来的偏差。
+  const handleCopy = useCallback(() => {
+    void copyUserMessageText(msg.content, t("ai.copied", "已复制到剪贴板"));
+  }, [msg.content, t]);
+
+  // 右键复制优先保留当前选区，没有选区时回退到整条消息。
+  const handleContextCopy = useCallback(() => {
+    const selectedText = window.getSelection?.()?.toString().trim() ?? "";
+    const copyText = selectedText && msg.content.includes(selectedText) ? selectedText : msg.content;
+    void copyUserMessageText(copyText, t("ai.copied", "已复制到剪贴板"));
+  }, [msg.content, t]);
+
   return (
-    <div className="flex flex-col items-end gap-1.5">
+    <div className="flex flex-col items-end gap-1.5 group/user">
       <span className="text-xs font-semibold text-muted-foreground tracking-wide">You</span>
-      <div
-        className={`inline-block rounded-xl rounded-br-sm bg-primary px-3.5 py-2.5 text-primary-foreground ${maxWidthClass} text-left shadow-sm break-words whitespace-pre-wrap`}
-      >
-        {segments.map((s, i) =>
-          s.type === "text" ? (
-            <span key={i}>{s.text}</span>
-          ) : (
-            <button
-              key={i}
-              type="button"
-              onClick={() => openAssetInfoTab(s.mention!.assetId)}
-              className="inline-flex items-center rounded bg-primary-foreground/20 px-1 py-0.5 text-xs font-medium hover:bg-primary-foreground/30 hover:underline cursor-pointer"
+      <div className={`flex items-start justify-end gap-2 ${maxWidthClass}`}>
+        <button
+          type="button"
+          className="mt-1 text-muted-foreground/70 transition-colors hover:text-foreground"
+          onClick={handleCopy}
+          title={t("action.copy", "复制")}
+          aria-label={t("action.copy", "复制")}
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </button>
+        <ContextMenu>
+          <ContextMenuTrigger className="block">
+            <div
+              className={`inline-block rounded-xl rounded-br-sm bg-primary px-3.5 py-2.5 text-primary-foreground text-left shadow-sm break-words whitespace-pre-wrap ${userMessageSelectionClass}`}
             >
-              {s.text}
-            </button>
-          )
-        )}
+              {segments.map((s, i) =>
+                s.type === "text" ? (
+                  <span key={i}>{s.text}</span>
+                ) : (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => openAssetInfoTab(s.mention!.assetId)}
+                    className="inline-flex items-center rounded bg-primary-foreground/20 px-1 py-0.5 text-xs font-medium hover:bg-primary-foreground/30 hover:underline cursor-pointer"
+                  >
+                    {s.text}
+                  </button>
+                )
+              )}
+            </div>
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem onClick={handleContextCopy}>{t("action.copy", "复制")}</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
       </div>
     </div>
   );


### PR DESCRIPTION
现象：
1. AI 助手中的用户消息缺少就近复制入口，复制时不容易快速确认是否已经复制目标内容。
2. 消息文本被鼠标选中时，选区反馈不明显，复制前难以判断具体选中了哪一段内容。
3. 输入框无法通过上下键连续取回历史用户消息，重复提问或修改上一条输入的成本较高。

原因：
1. 用户消息展示层缺少独立的复制交互，右键复制和复制反馈也没有统一收口。
2. 消息气泡没有补充明确的 selection 样式，导致主色背景和普通背景下的选区都不够清晰。
3. 当前 AI 输入框已经改为独立的富文本组件，但没有补充对应的历史导航子流程，导致上下键仍只走编辑器默认行为。

修复：
1. 在用户消息左侧补充复制按钮，并新增右键复制入口，同时统一将复制成功提示展示在顶部。
2. 为用户消息和助手消息补充选中文本高亮样式，让用户在复制前就能明确看到选区范围。
3. 在 AIChatInput 中补充独立的上下键历史切换辅助逻辑，仅在首行首字符等合适位置接管 `ArrowUp`，并支持 `ArrowDown` 返回较新的历史消息或空输入。
4. 基于最新 main 分支结构落到 `UserMessage`、`AIChatInput`、`AIChatContent` 三个组件，避免把旧逻辑重新塞回已拆分的模块中。