### PR TITLE
🐛 修复终端 Ctrl+F 硬编码导致用户改绑无效

### DIFF
--- a/frontend/src/__tests__/shortcutUtils.test.ts
+++ b/frontend/src/__tests__/shortcutUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { matchShortcut, formatBinding, DEFAULT_SHORTCUTS, type ShortcutBinding } from "../stores/shortcutStore";
+import { matchShortcut, formatBinding, formatModKey, DEFAULT_SHORTCUTS, type ShortcutBinding } from "../stores/shortcutStore";
 
 // In happy-dom test env, isMac = false (non-Mac).
 
@@ -86,5 +86,26 @@ describe("formatBinding", () => {
   it("formats key without modifiers", () => {
     const binding: ShortcutBinding = { code: "F5", mod: false, shift: false, alt: false };
     expect(formatBinding(binding)).toBe("F5");
+  });
+});
+
+describe("formatModKey", () => {
+  // happy-dom env → isMac = false → Windows-style output
+
+  it("formats letter keys", () => {
+    expect(formatModKey("KeyC")).toBe("Ctrl+C");
+    expect(formatModKey("KeyR")).toBe("Ctrl+R");
+  });
+
+  it("formats Enter", () => {
+    expect(formatModKey("Enter")).toBe("Ctrl+Enter");
+  });
+
+  it("applies shift modifier", () => {
+    expect(formatModKey("KeyF", { shift: true })).toBe("Ctrl+Shift+F");
+  });
+
+  it("applies alt modifier", () => {
+    expect(formatModKey("KeyD", { alt: true })).toBe("Ctrl+Alt+D");
   });
 });

--- a/frontend/src/__tests__/shortcutUtils.test.ts
+++ b/frontend/src/__tests__/shortcutUtils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { matchShortcut, formatBinding, formatModKey, DEFAULT_SHORTCUTS, type ShortcutBinding } from "../stores/shortcutStore";
+import {
+  matchShortcut,
+  formatBinding,
+  formatModKey,
+  DEFAULT_SHORTCUTS,
+  type ShortcutBinding,
+} from "../stores/shortcutStore";
 
 // In happy-dom test env, isMac = false (non-Mac).
 

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -44,6 +44,7 @@ import {
 import { AIChatInput, type AIChatInputDraft, type AIChatInputHandle } from "@/components/ai/AIChatInput";
 import { UserMessage } from "@/components/ai/UserMessage";
 import { useTabStore, type AITabMeta } from "@/stores/tabStore";
+import { formatModKey } from "@/stores/shortcutStore";
 import { ToolBlock } from "@/components/ai/ToolBlock";
 import { ThinkingBlock } from "@/components/ai/ThinkingBlock";
 import { AgentBlock } from "@/components/ai/AgentBlock";
@@ -388,7 +389,7 @@ export function AIChatContent({
                 <span className="text-xs text-muted-foreground/40 select-none">
                   {sendOnEnter
                     ? `Enter ${t("ai.sendShortcutHint")}`
-                    : `${/mac/i.test(navigator.userAgent) ? "⌘+Enter" : "Ctrl+Enter"} ${t("ai.sendShortcutHint")}`}
+                    : `${formatModKey("Enter")} ${t("ai.sendShortcutHint")}`}
                 </span>
                 {sending ? (
                   <Button

--- a/frontend/src/components/query/MongoDBPanel.tsx
+++ b/frontend/src/components/query/MongoDBPanel.tsx
@@ -7,7 +7,7 @@ import { useResizeHandle } from "@opskat/ui";
 import { toast } from "sonner";
 import { useQueryStore, type MongoInnerTab } from "@/stores/queryStore";
 import { useTabStore, type QueryTabMeta } from "@/stores/tabStore";
-import { isMac } from "@/stores/shortcutStore";
+import { isMac, formatModKey } from "@/stores/shortcutStore";
 import { MongoDBCollectionBrowser } from "./MongoDBCollectionBrowser";
 import { MongoDBResultView } from "./MongoDBResultView";
 import { ExecuteMongo } from "../../../wailsjs/go/app/App";
@@ -141,7 +141,7 @@ interface MongoCollectionContentProps {
   pendingLoad: boolean;
 }
 
-const MONGO_REFRESH_SHORTCUT_LABEL = isMac ? "⌘R" : "Ctrl+R";
+const MONGO_REFRESH_SHORTCUT_LABEL = formatModKey("KeyR");
 
 function MongoCollectionContent(props: MongoCollectionContentProps) {
   const { t } = useTranslation();
@@ -553,7 +553,7 @@ function MongoQueryContent({ tabId, assetId, innerTab }: MongoQueryContentProps)
     [currentCollections, t]
   );
 
-  const shortcutLabel = isMac ? "⌘⏎" : "Ctrl+Enter";
+  const shortcutLabel = formatModKey("Enter");
   const canExecute = !!database || /getSiblingDB\s*\(/.test(query);
 
   return (

--- a/frontend/src/components/query/TableDataTab.tsx
+++ b/frontend/src/components/query/TableDataTab.tsx
@@ -36,7 +36,7 @@ import {
 } from "@opskat/ui";
 import { useTabStore, type QueryTabMeta } from "@/stores/tabStore";
 import { useQueryStore } from "@/stores/queryStore";
-import { isMac } from "@/stores/shortcutStore";
+import { isMac, formatModKey } from "@/stores/shortcutStore";
 import { ExecuteSQL } from "../../../wailsjs/go/app/App";
 import { QueryResultTable, CellEdit, SortDir } from "./QueryResultTable";
 import { SqlPreviewDialog } from "./SqlPreviewDialog";
@@ -73,7 +73,7 @@ function quoteIdent(name: string, driver?: string): string {
   return `\`${name}\``;
 }
 
-const REFRESH_SHORTCUT_LABEL = isMac ? "⌘R" : "Ctrl+R";
+const REFRESH_SHORTCUT_LABEL = formatModKey("KeyR");
 
 // 字符串 props 稳定 —— memo 避免 DatabasePanel 的 innerTabs 结构变化传导
 export const TableDataTab = memo(function TableDataTab(props: TableDataTabProps) {

--- a/frontend/src/components/terminal/Terminal.tsx
+++ b/frontend/src/components/terminal/Terminal.tsx
@@ -5,7 +5,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import "@xterm/xterm/css/xterm.css";
 import { WriteSSH, ResizeSSH } from "../../../wailsjs/go/app/App";
 import { EventsOn, EventsOff } from "../../../wailsjs/runtime/runtime";
-import { useShortcutStore, matchShortcut, formatBinding } from "@/stores/shortcutStore";
+import { useShortcutStore, matchShortcut, formatBinding, formatModKey } from "@/stores/shortcutStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useTerminalThemeStore, toXtermTheme } from "@/stores/terminalThemeStore";
 import { builtinThemes, defaultLightTheme, defaultDarkTheme } from "@/data/terminalThemes";
@@ -115,10 +115,12 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       fitAddon.fit();
     });
 
-    // Let global shortcut handler handle shortcut keys instead of xterm
-    // Also intercept Ctrl+F for search, Cmd/Ctrl+C for copy with toast
+    // Let global shortcut handler handle shortcut keys instead of xterm.
+    // The panel.filter binding also opens in-terminal search when xterm is focused
+    // (matched via current user binding — rebinding the shortcut moves both together).
     term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-      if (e.key === "f" && (e.ctrlKey || e.metaKey) && e.type === "keydown") {
+      const action = matchShortcut(e, useShortcutStore.getState().shortcuts);
+      if (action === "panel.filter" && e.type === "keydown") {
         setShowSearch((v) => !v);
         return false;
       }
@@ -131,7 +133,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           return false;
         }
       }
-      return !matchShortcut(e, useShortcutStore.getState().shortcuts);
+      return !action;
     });
 
     termRef.current = term;
@@ -250,20 +252,20 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         <ContextMenuContent>
           <ContextMenuItem onClick={handleCopy} disabled={!hasSelection}>
             {t("ssh.contextMenu.copy")}
-            <ContextMenuShortcut>⌘C</ContextMenuShortcut>
+            <ContextMenuShortcut>{formatModKey("KeyC")}</ContextMenuShortcut>
           </ContextMenuItem>
           <ContextMenuItem onClick={handlePaste}>
             {t("ssh.contextMenu.paste")}
-            <ContextMenuShortcut>⌘V</ContextMenuShortcut>
+            <ContextMenuShortcut>{formatModKey("KeyV")}</ContextMenuShortcut>
           </ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem onClick={handleSelectAll}>
             {t("ssh.contextMenu.selectAll")}
-            <ContextMenuShortcut>⌘A</ContextMenuShortcut>
+            <ContextMenuShortcut>{formatModKey("KeyA")}</ContextMenuShortcut>
           </ContextMenuItem>
           <ContextMenuItem onClick={() => setShowSearch(true)}>
             {t("ssh.contextMenu.find")}
-            <ContextMenuShortcut>⌘F</ContextMenuShortcut>
+            <ContextMenuShortcut>{formatBinding(shortcuts["panel.filter"])}</ContextMenuShortcut>
           </ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem onClick={() => splitPane(tabId, "horizontal")} disabled={!paneConnected}>

--- a/frontend/src/stores/shortcutStore.ts
+++ b/frontend/src/stores/shortcutStore.ts
@@ -214,3 +214,11 @@ export function formatBinding(binding: ShortcutBinding): string {
   parts.push(codeToDisplay(binding.code));
   return isMac ? parts.join("") : parts.join("+");
 }
+
+// Platform-convention modifier shortcut (Cmd on Mac, Ctrl elsewhere) — for
+// system-level bindings NOT in the shortcut registry (browser/xterm copy-paste,
+// editor shortcuts, etc.). User-configurable shortcuts must use
+// formatBinding(shortcuts[action]) so the UI follows rebindings.
+export function formatModKey(code: string, options: { shift?: boolean; alt?: boolean } = {}): string {
+  return formatBinding({ code, mod: true, shift: options.shift ?? false, alt: options.alt ?? false });
+}


### PR DESCRIPTION
## 问题

- 快捷键 Ctrl+B / Ctrl+F 被占用，vim 里无法 Ctrl+F 向下翻页、Ctrl+B 向上翻页。
- 把 `panel.filter` 从 Ctrl+F 改成 Ctrl+Shift+F 后，Ctrl+F 仍然打开终端搜索，改了无效。

## 根因

1. `Terminal.tsx` 的 xterm 自定义按键处理硬编码了 `e.key === "f" && (ctrlKey || metaKey)` 来触发搜索，完全绕开 `shortcutStore`。用户重绑 `panel.filter` 对这里不生效。
2. 同文件右键菜单"查找"的快捷键标签写死 `⌘F`，不随重绑更新，且在非 Mac 上显示错误的 Mac 风格符号（`⌘C/⌘V/⌘A` 同样问题）。

## 改动

### 行为修复
- `Terminal.tsx` xterm 按键处理改为基于 `matchShortcut` 匹配 `panel.filter` action — 改绑后搜索快捷键和 vim Ctrl+F 同步跟随。

### 文案同步
- 右键菜单"查找"标签使用 `formatBinding(shortcuts["panel.filter"])` 跟随用户配置。
- 新增 `formatModKey(code, opts?)` helper 统一处理"系统级、不可配置但需平台自适应"的快捷键展示（Cmd on Mac / Ctrl elsewhere）。
- 替换 6 处手写的 `⌘X` / `isMac ? "…" : "…"` 字面量：
  - `Terminal.tsx` 复制/粘贴/全选 `⌘C/⌘V/⌘A`
  - `TableDataTab.tsx` `⌘R` 刷新标签
  - `MongoDBPanel.tsx` `⌘R` 刷新、`⌘⏎` 执行
  - `AIChatContent.tsx` `⌘+Enter` 发送提示（顺手用 `isMac` 替代 `/mac/i.test(navigator.userAgent)` 的重复解析）

### 防再犯
- 约定：用户可改快捷键走 `formatBinding(shortcuts[action])`；系统级快捷键走 `formatModKey(...)`；禁止手写 `⌘` / `Ctrl+` 字面量。
- grep `'"⌘'` / `'isMac ? "'` 在 `src/` 下再无匹配（除 `shortcutStore.ts` 内部实现）。

## 影响

- 非 Mac 终端右键菜单的复制/粘贴/全选从 `⌘C/V/A` 改为 `Ctrl+C/V/A`（修正视觉错配）。
- Mac MongoDB 执行按钮 tooltip 从 `⌘⏎` 改为 `⌘Enter`，与快捷键设置面板风格一致。
- AI 发送提示从 `⌘+Enter` 改为 `⌘Enter`（Mac 格式去加号，与 `formatBinding` 一致）。
- 默认快捷键绑定**未变动**。

## 测试

- [x] `pnpm test` 422 passed（原 418 + 4 个 `formatModKey` 新用例）
- [x] `pnpm exec tsc --noEmit` 通过
- [x] `pnpm exec eslint` 对修改的文件无新增 error/warning
- [ ] 手动验证：默认绑定下终端 Ctrl+F 打开搜索；改绑 `panel.filter` 到 Ctrl+Shift+F 后 Ctrl+F 透传到 vim，Ctrl+Shift+F 打开搜索；右键菜单标签跟随更新