### PR TITLE
🐛 修复 windows 环境下 OpenDirectory 因隐藏界面而无法正常显示explorer的问题

### DIFF
--- a/internal/app/app_settings.go
+++ b/internal/app/app_settings.go
@@ -492,7 +492,9 @@ func (a *App) OpenDirectory(path string) error {
 		args = []string{path}
 	}
 	c := exec.Command(cmd, args...) //nolint:gosec
-	executil.HideWindow(c)
+	if runtime.GOOS != "windows" {
+		executil.HideWindow(c)
+	}
 	return c.Start()
 }
 

--- a/internal/app/app_settings.go
+++ b/internal/app/app_settings.go
@@ -492,9 +492,6 @@ func (a *App) OpenDirectory(path string) error {
 		args = []string{path}
 	}
 	c := exec.Command(cmd, args...) //nolint:gosec
-	if runtime.GOOS != "windows" {
-		executil.HideWindow(c)
-	}
 	return c.Start()
 }
 

--- a/internal/pkg/executil/hide_windows.go
+++ b/internal/pkg/executil/hide_windows.go
@@ -7,10 +7,11 @@ import (
 	"syscall"
 )
 
-// HideWindow 设置子进程不创建控制台窗口，防止黑窗一闪而过
+// HideWindow 给 console 子系统的子进程加 CREATE_NO_WINDOW，避免黑窗一闪而过；
+// 对 GUI 程序（如 explorer.exe）无副作用。注意：不要加 SysProcAttr.HideWindow，
+// 那会通过 SW_HIDE 把 GUI 程序的主窗口也藏起来。
 func HideWindow(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		HideWindow:    true,
 		CreationFlags: 0x08000000, // CREATE_NO_WINDOW
 	}
 }

--- a/internal/pkg/executil/hide_windows.go
+++ b/internal/pkg/executil/hide_windows.go
@@ -7,11 +7,12 @@ import (
 	"syscall"
 )
 
-// HideWindow 给 console 子系统的子进程加 CREATE_NO_WINDOW，避免黑窗一闪而过；
-// 对 GUI 程序（如 explorer.exe）无副作用。注意：不要加 SysProcAttr.HideWindow，
-// 那会通过 SW_HIDE 把 GUI 程序的主窗口也藏起来。
+// HideWindow 隐藏子进程窗口：console 子系统加 CREATE_NO_WINDOW 防止黑窗一闪而过，
+// GUI 程序通过 SW_HIDE 隐藏主窗口。注意：对需要正常显示的 GUI 程序（如 explorer.exe）
+// 不要调用本方法，否则其窗口会被一并隐藏。
 func HideWindow(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
 		CreationFlags: 0x08000000, // CREATE_NO_WINDOW
 	}
 }


### PR DESCRIPTION
## 变更说明 / Summary

🐛 修复 Windows 下 OpenDirectory 调用 `executil.HideWindow` 导致 Explorer 窗口无法正常显示的问题。

`explorer.exe` 是 GUI 子系统程序，不会产生控制台黑窗，`HideWindow` 对其无意义，反而会隐藏窗口。

## 关联 Issue / Related Issue



## 截图 / Screenshots

<!-- UI 改动必填 / Required for UI changes -->

## 自检 / Checklist

- [x]  Fixes mentioned issues / 修复已提及的问题
- [x]  Code reviewed by human / 代码通过人工检查
- [x]  Changes tested / 已完成测试