### PR TITLE
🐛 修复 DeepSeek thinking 模式下多轮对话报 400 错误的问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - uses: pnpm/action-setup@v5
         with:
           version: 10
@@ -71,6 +74,10 @@ jobs:
           node-version: "22"
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Install Wails CLI
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.10.2
+      - name: Generate Wails bindings
+        run: wails generate module
       - name: Install dependencies
         run: cd frontend && pnpm install --frozen-lockfile
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
       - name: Install Wails CLI
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.10.2
+      - name: Create frontend dist placeholder
+        run: mkdir -p frontend/dist && touch frontend/dist/.gitkeep
       - name: Generate Wails bindings
         run: wails generate module
       - name: Install dependencies

--- a/frontend/src/__tests__/aiStore.test.ts
+++ b/frontend/src/__tests__/aiStore.test.ts
@@ -816,3 +816,138 @@ describe("single-host invariant", () => {
     expect(useAIStore.getState().sidebarConversationId).toBe(77);
   });
 });
+
+describe("DeepSeek-v4 多轮 tool 调用历史展开", () => {
+  const buildHistory = () => [
+    { role: "user" as const, content: "查 SSH 服务器", blocks: [], streaming: false },
+    {
+      role: "assistant" as const,
+      content: "找到 2 台",
+      streaming: false,
+      blocks: [
+        { type: "thinking" as const, content: "我先查一下" },
+        {
+          type: "tool" as const,
+          content: '[{"id":1}]',
+          toolName: "list_assets",
+          toolInput: '{"asset_type":"ssh"}',
+          toolCallId: "call_001",
+          status: "completed" as const,
+        },
+        { type: "thinking" as const, content: "再过滤一下" },
+        { type: "text" as const, content: "找到 2 台" },
+      ],
+    },
+    { role: "user" as const, content: "再看 redis", blocks: [], streaming: false },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useTabStore.setState({ tabs: [], activeTabId: null });
+    vi.mocked(EventsOn).mockReturnValue(() => {});
+    vi.mocked(SendAIMessage).mockResolvedValue(undefined as any);
+  });
+
+  it("DeepSeek-v4 模型：assistant blocks 展开为 assistant(tool_calls)+tool+assistant(text) 多条标准消息", async () => {
+    useAIStore.setState({
+      modelName: "deepseek-v4-pro",
+      sidebarConversationId: 100,
+      conversationMessages: { 100: buildHistory() },
+      conversationStreaming: { 100: { sending: false, pendingQueue: [] } },
+    });
+
+    await useAIStore.getState().sendFromSidebar(100, "再看 redis");
+
+    const args = vi.mocked(SendAIMessage).mock.calls.at(-1)!;
+    const apiMsgs = args[1] as any[];
+
+    // user / assistant(thinking+tool_calls) / tool / assistant(final text) / user / user
+    // 注意 sendFromSidebar 会再追加一条 user 消息
+    const roles = apiMsgs.map((m) => m.role);
+    expect(roles).toEqual(["user", "assistant", "tool", "assistant", "user", "user"]);
+
+    const toolCallAssistant = apiMsgs[1];
+    expect(toolCallAssistant.thinking).toBe("我先查一下");
+    expect(toolCallAssistant.reasoning_content).toBe("我先查一下");
+    expect(toolCallAssistant.tool_calls).toHaveLength(1);
+    expect(toolCallAssistant.tool_calls[0].id).toBe("call_001");
+    expect(toolCallAssistant.tool_calls[0].function.name).toBe("list_assets");
+
+    const toolMsg = apiMsgs[2];
+    expect(toolMsg.tool_call_id).toBe("call_001");
+    expect(toolMsg.content).toBe('[{"id":1}]');
+
+    const finalAssistant = apiMsgs[3];
+    expect(finalAssistant.thinking).toBe("再过滤一下");
+    expect(finalAssistant.reasoning_content).toBe("再过滤一下");
+    expect(finalAssistant.content).toBe("找到 2 台");
+    expect(finalAssistant.tool_calls).toBeUndefined();
+  });
+
+  it("非 DeepSeek-v4 模型：保持原有塌缩行为，不展开 tool_calls，不带 reasoning_content", async () => {
+    useAIStore.setState({
+      modelName: "deepseek-chat",
+      sidebarConversationId: 101,
+      conversationMessages: { 101: buildHistory() },
+      conversationStreaming: { 101: { sending: false, pendingQueue: [] } },
+    });
+
+    await useAIStore.getState().sendFromSidebar(101, "再看 redis");
+
+    const args = vi.mocked(SendAIMessage).mock.calls.at(-1)!;
+    const apiMsgs = args[1] as any[];
+
+    // 只有 user / assistant / user / user（assistant 是塌缩后单条，不展开）
+    const roles = apiMsgs.map((m) => m.role);
+    expect(roles).toEqual(["user", "assistant", "user", "user"]);
+
+    const assistantMsg = apiMsgs[1];
+    expect(assistantMsg.content).toBe("找到 2 台");
+    expect(assistantMsg.tool_calls).toBeUndefined();
+    expect(assistantMsg.reasoning_content).toBeUndefined();
+    expect(assistantMsg.thinking).toBeUndefined();
+  });
+
+  it("DeepSeek-v4 模型 + 老数据（tool block 缺 toolCallId）：兜底为塌缩消息，不抛错", async () => {
+    const legacyHistory = [
+      { role: "user" as const, content: "old turn", blocks: [], streaming: false },
+      {
+        role: "assistant" as const,
+        content: "done",
+        streaming: false,
+        blocks: [
+          { type: "thinking" as const, content: "thoughts" },
+          // 缺 toolCallId 的旧持久化数据
+          {
+            type: "tool" as const,
+            content: "result",
+            toolName: "list_assets",
+            toolInput: "{}",
+            status: "completed" as const,
+          },
+          { type: "text" as const, content: "done" },
+        ],
+      },
+      { role: "user" as const, content: "next", blocks: [], streaming: false },
+    ];
+
+    useAIStore.setState({
+      modelName: "deepseek-v4-pro",
+      sidebarConversationId: 102,
+      conversationMessages: { 102: legacyHistory },
+      conversationStreaming: { 102: { sending: false, pendingQueue: [] } },
+    });
+
+    await useAIStore.getState().sendFromSidebar(102, "next");
+
+    const args = vi.mocked(SendAIMessage).mock.calls.at(-1)!;
+    const apiMsgs = args[1] as any[];
+
+    // 老数据回退到塌缩：user / assistant(单条，含 reasoning_content) / user / user
+    expect(apiMsgs.map((m) => m.role)).toEqual(["user", "assistant", "user", "user"]);
+    expect(apiMsgs[1].content).toBe("done");
+    expect(apiMsgs[1].reasoning_content).toBe("thoughts");
+    expect(apiMsgs[1].tool_calls).toBeUndefined();
+  });
+});

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -33,6 +33,7 @@ export interface ContentBlock {
   content: string;
   toolName?: string;
   toolInput?: string;
+  toolCallId?: string; // 跨 turn 还原 tool_calls 历史；老数据无此字段，发送时退化为塌缩消息
   status?: "running" | "completed" | "error" | "pending_confirm" | "cancelled";
   confirmId?: string;
   // agent 块专用
@@ -81,6 +82,7 @@ interface StreamEventData {
   content?: string;
   tool_name?: string;
   tool_input?: string;
+  tool_call_id?: string;
   confirm_id?: string;
   error?: string;
   agent_role?: string;
@@ -610,6 +612,7 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
           content: "",
           toolName: event.tool_name || "Tool",
           toolInput: event.tool_input || "",
+          toolCallId: event.tool_call_id,
           status: "running" as const,
         };
 
@@ -650,28 +653,27 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
             break;
           }
         }
+        // 匹配优先级：toolCallId 精确匹配 > toolName + running > 任意 running
+        const findToolMatch = (arr: ContentBlock[]): number => {
+          if (event.tool_call_id) {
+            for (let i = arr.length - 1; i >= 0; i--) {
+              if (arr[i].type === "tool" && arr[i].toolCallId === event.tool_call_id) return i;
+            }
+          }
+          for (let i = arr.length - 1; i >= 0; i--) {
+            const b = arr[i];
+            if (b.type === "tool" && b.status === "running" && b.toolName === event.tool_name) return i;
+          }
+          for (let i = arr.length - 1; i >= 0; i--) {
+            if (arr[i].type === "tool" && arr[i].status === "running") return i;
+          }
+          return -1;
+        };
+
         if (agentIdx !== -1 && newBlocks[agentIdx].childBlocks) {
           const agentBlock = { ...newBlocks[agentIdx] };
           const children = [...(agentBlock.childBlocks || [])];
-          let matchIdx = -1;
-          for (let i = children.length - 1; i >= 0; i--) {
-            if (
-              children[i].type === "tool" &&
-              children[i].status === "running" &&
-              children[i].toolName === event.tool_name
-            ) {
-              matchIdx = i;
-              break;
-            }
-          }
-          if (matchIdx === -1) {
-            for (let i = children.length - 1; i >= 0; i--) {
-              if (children[i].type === "tool" && children[i].status === "running") {
-                matchIdx = i;
-                break;
-              }
-            }
-          }
+          const matchIdx = findToolMatch(children);
           if (matchIdx !== -1) {
             children[matchIdx] = { ...children[matchIdx], content: event.content || "", status: "completed" };
             agentBlock.childBlocks = children;
@@ -681,23 +683,7 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
         }
 
         // 顶层工具块匹配
-        let matchIdx = -1;
-        for (let i = newBlocks.length - 1; i >= 0; i--) {
-          const b = newBlocks[i];
-          if (b.type === "tool" && b.status === "running" && b.toolName === event.tool_name) {
-            matchIdx = i;
-            break;
-          }
-        }
-        if (matchIdx === -1) {
-          for (let i = newBlocks.length - 1; i >= 0; i--) {
-            const b = newBlocks[i];
-            if (b.type === "tool" && b.status === "running") {
-              matchIdx = i;
-              break;
-            }
-          }
-        }
+        const matchIdx = findToolMatch(newBlocks);
         if (matchIdx !== -1) {
           newBlocks[matchIdx] = { ...newBlocks[matchIdx], content: event.content || "", status: "completed" };
         }
@@ -952,6 +938,91 @@ function resolveMentionedAssets(mentions: MentionRef[] | undefined): ai.Mentione
   return out;
 }
 
+// 把前端塌缩的 ChatMessage 还原成 OpenAI/Anthropic 标准的多条 LLM 消息：
+//   - 一次 user turn 对应一条 ChatMessage(assistant)，blocks 顺序为
+//     thinking_n -> tool_n(含 input/result) -> ... -> text(最终回复)
+//   - 展开后变成：assistant(thinking + tool_calls) + tool(result) + ... + assistant(text)
+//   - 前置约束：tool block 必须带 toolCallId 才能展开；缺失的（旧数据）直接忽略 tool 块，回退到塌缩
+//
+// 这样跨 turn 时 DeepSeek/OpenAI 能看到上一 turn 的中间 tool_calls 与结果，
+// 同时也满足 DeepSeek thinking 模式"带 tool_calls 的 assistant 必须回传 reasoning_content"的强制要求。
+function expandToAPIMessages(messages: ChatMessage[]): ai.Message[] {
+  const out: ai.Message[] = [];
+  for (const m of messages) {
+    if (m.role !== "assistant") {
+      out.push(new ai.Message({ role: m.role, content: m.content }));
+      continue;
+    }
+
+    // assistant 累加器：在遇到 tool block 时刷出当前 assistant + 跟一条 tool 消息
+    let thinking = "";
+    let text = "";
+    const pendingToolCalls: { id: string; type: string; function: { name: string; arguments: string } }[] = [];
+
+    const flushAssistant = () => {
+      if (!thinking && !text && pendingToolCalls.length === 0) return;
+      const payload: Record<string, unknown> = { role: "assistant", content: text };
+      if (thinking) {
+        payload.thinking = thinking;
+        payload.reasoning_content = thinking;
+      }
+      if (pendingToolCalls.length > 0) payload.tool_calls = pendingToolCalls.slice();
+      out.push(new ai.Message(payload));
+      thinking = "";
+      text = "";
+      pendingToolCalls.length = 0;
+    };
+
+    let canExpand = true; // 老数据若有 tool block 缺 toolCallId，全消息回退到塌缩
+    for (const b of m.blocks) {
+      if (b.type === "tool" && !b.toolCallId) {
+        canExpand = false;
+        break;
+      }
+    }
+
+    if (!canExpand) {
+      // 兼容旧数据：仅发最终 content + thinking 拼接（thinking 拼接也无害）
+      const allThinking = m.blocks
+        .filter((b) => b.type === "thinking")
+        .map((b) => b.content)
+        .join("");
+      const payload: Record<string, unknown> = { role: "assistant", content: m.content };
+      if (allThinking) {
+        payload.thinking = allThinking;
+        payload.reasoning_content = allThinking;
+      }
+      out.push(new ai.Message(payload));
+      continue;
+    }
+
+    for (const b of m.blocks) {
+      if (b.type === "thinking") {
+        thinking += b.content;
+      } else if (b.type === "text") {
+        text += b.content;
+      } else if (b.type === "tool" && b.toolCallId) {
+        pendingToolCalls.push({
+          id: b.toolCallId,
+          type: "function",
+          function: { name: b.toolName || "", arguments: b.toolInput || "{}" },
+        });
+        flushAssistant();
+        out.push(
+          new ai.Message({
+            role: "tool",
+            content: b.content,
+            tool_call_id: b.toolCallId,
+          })
+        );
+      }
+      // approval / agent 块不参与 LLM 历史还原，跳过
+    }
+    flushAssistant();
+  }
+  return out;
+}
+
 // 核心发送：完全基于 convId，共享给 sendToTab / sendFromSidebar / regenerate
 async function _sendForConversation(convId: number, content: string, mentions?: MentionRef[]) {
   const state = useAIStore.getState();
@@ -1015,27 +1086,14 @@ async function _sendForConversation(convId: number, content: string, mentions?: 
     handleStreamEvent(convId, event);
   });
 
-  // 只有 DeepSeek 模型的 reasoning_content 必须原样回传（否则 thinking 模式多轮 API 返回 400）。
-  // modelName 在 checkConfigured 后写入 store，能调到此处时一定已 configured，故直接读取。
-  const isDeepSeek = useAIStore.getState().modelName.startsWith("deepseek");
-
-  const apiMessages = newMessages.map((m) => {
-    // 从 blocks 中提取 thinking 内容（仅 DeepSeek + assistant 角色需要）
-    let reasoningContent: string | undefined;
-    if (isDeepSeek && m.role === "assistant") {
-      for (const b of m.blocks) {
-        if (b.type === "thinking") {
-          reasoningContent = b.content;
-          break;
-        }
-      }
-    }
-    return new ai.Message({
-      role: m.role,
-      content: m.content,
-      reasoningContent,
-    });
-  });
+  // 仅 DeepSeek-v4 thinking 模式强制要求"带 tool_calls 的 assistant 必须回传 reasoning_content"，
+  // 且需要历史中间 tool_calls 可见才能跨 turn 继续推理；其他 provider（Anthropic / OpenAI / Kimi 等）
+  // 保持原有塌缩行为，避免引入不必要的回归。
+  const modelName = useAIStore.getState().modelName;
+  const needExpand = modelName.startsWith("deepseek-v4");
+  const apiMessages = needExpand
+    ? expandToAPIMessages(newMessages)
+    : newMessages.map((m) => new ai.Message({ role: m.role, content: m.content }));
 
   // 收集当前 Tab 上下文
   const allTabs = useTabStore.getState().tabs;

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -848,10 +848,7 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
       const reason = event.error ? `: ${event.error}` : "";
       const updated = updateLastAssistant(msgs, (msg) => ({
         ...msg,
-        blocks: appendText(
-          msg.blocks,
-          `\n\n*${i18n.t("ai.retrying", "重试中")} (${event.content})${reason}*`
-        ),
+        blocks: appendText(msg.blocks, `\n\n*${i18n.t("ai.retrying", "重试中")} (${event.content})${reason}*`),
       }));
       if (updated) updateConversation(convId, { messages: updated });
       break;
@@ -1018,15 +1015,9 @@ async function _sendForConversation(convId: number, content: string, mentions?: 
     handleStreamEvent(convId, event);
   });
 
-  // 只有 DeepSeek 模型的 thinking_content 必须回传（否则 API 返回 400）
-  // 直接获取当前模型，避免依赖 state.modelName 未初始化的情况
-  let isDeepSeek = false;
-  try {
-    const active = await GetActiveAIProvider();
-    isDeepSeek = (active?.model || "").startsWith("deepseek");
-  } catch {
-    // 获取失败时跳过 thinking 处理
-  }
+  // 只有 DeepSeek 模型的 reasoning_content 必须原样回传（否则 thinking 模式多轮 API 返回 400）。
+  // modelName 在 checkConfigured 后写入 store，能调到此处时一定已 configured，故直接读取。
+  const isDeepSeek = useAIStore.getState().modelName.startsWith("deepseek");
 
   const apiMessages = newMessages.map((m) => {
     // 从 blocks 中提取 thinking 内容（仅 DeepSeek + assistant 角色需要）

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -845,9 +845,13 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
     }
 
     case "retry": {
+      const reason = event.error ? `: ${event.error}` : "";
       const updated = updateLastAssistant(msgs, (msg) => ({
         ...msg,
-        blocks: appendText(msg.blocks, `\n\n*${i18n.t("ai.retrying", "重试中")} (${event.content})...*`),
+        blocks: appendText(
+          msg.blocks,
+          `\n\n*${i18n.t("ai.retrying", "重试中")} (${event.content})${reason}*`
+        ),
       }));
       if (updated) updateConversation(convId, { messages: updated });
       break;

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -1014,10 +1014,31 @@ async function _sendForConversation(convId: number, content: string, mentions?: 
     handleStreamEvent(convId, event);
   });
 
+  // 只有 DeepSeek 模型的 thinking_content 必须回传（否则 API 返回 400）
+  // 直接获取当前模型，避免依赖 state.modelName 未初始化的情况
+  let isDeepSeek = false;
+  try {
+    const active = await GetActiveAIProvider();
+    isDeepSeek = (active?.model || "").startsWith("deepseek");
+  } catch {
+    // 获取失败时跳过 thinking 处理
+  }
+
   const apiMessages = newMessages.map((m) => {
+    // 从 blocks 中提取 thinking 内容（仅 DeepSeek + assistant 角色需要）
+    let reasoningContent: string | undefined;
+    if (isDeepSeek && m.role === "assistant") {
+      for (const b of m.blocks) {
+        if (b.type === "thinking") {
+          reasoningContent = b.content;
+          break;
+        }
+      }
+    }
     return new ai.Message({
       role: m.role,
       content: m.content,
+      reasoningContent,
     });
   });
 

--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +15,12 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
+
+// needsReasoningContent 判断当前模型是否要求多轮 tool 调用 assistant 消息回传 reasoning_content。
+// 目前只有 DeepSeek-v4 thinking 模式有此强制要求；其他 provider 保持原状以减少回归面。
+func needsReasoningContent(model string) bool {
+	return strings.HasPrefix(strings.ToLower(model), "deepseek-v4")
+}
 
 // ToolExecutor 执行 tool 调用的接口
 type ToolExecutor interface {
@@ -128,13 +135,17 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 			return nil
 		}
 
-		// 将 assistant 的回复（含 thinking + tool_calls）加入消息
+		// 将 assistant 的回复（含 thinking + tool_calls）加入消息。
+		// reasoning_content 仅 DeepSeek-v4 thinking 模式强制要求回传（否则多轮 400），
+		// 其他 provider 保持原有行为，避免引入未知字段触发严格 OpenAI-compat 后端报错。
 		assistantMsg := Message{
-			Role:             RoleAssistant,
-			Content:          contentBuf,
-			Thinking:         thinkingBuf,
-			ReasoningContent: thinkingBuf,
-			ToolCalls:        toolCalls,
+			Role:      RoleAssistant,
+			Content:   contentBuf,
+			Thinking:  thinkingBuf,
+			ToolCalls: toolCalls,
+		}
+		if needsReasoningContent(a.provider.Model()) {
+			assistantMsg.ReasoningContent = thinkingBuf
 		}
 		messages = append(messages, assistantMsg)
 
@@ -149,11 +160,12 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 
 		for i, tc := range toolCalls {
 			g.Go(func() error {
-				// 通知前端工具开始执行
+				// 通知前端工具开始执行；ToolCallID 用于前端跨 turn 还原 tool_calls 历史
 				onEvent(StreamEvent{
-					Type:      "tool_start",
-					ToolName:  tc.Function.Name,
-					ToolInput: tc.Function.Arguments,
+					Type:       "tool_start",
+					ToolName:   tc.Function.Name,
+					ToolInput:  tc.Function.Arguments,
+					ToolCallID: tc.ID,
 				})
 
 				result, execErr := executor.Execute(gCtx, tc.Function.Name, tc.Function.Arguments)
@@ -168,9 +180,10 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 
 				// 通知前端工具执行完成
 				onEvent(StreamEvent{
-					Type:     "tool_result",
-					ToolName: tc.Function.Name,
-					Content:  result,
+					Type:       "tool_result",
+					ToolName:   tc.Function.Name,
+					Content:    result,
+					ToolCallID: tc.ID,
 				})
 
 				mu.Lock()

--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -130,10 +130,11 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 
 		// 将 assistant 的回复（含 thinking + tool_calls）加入消息
 		assistantMsg := Message{
-			Role:      RoleAssistant,
-			Content:   contentBuf,
-			Thinking:  thinkingBuf,
-			ToolCalls: toolCalls,
+			Role:             RoleAssistant,
+			Content:          contentBuf,
+			Thinking:         thinkingBuf,
+			ReasoningContent: thinkingBuf,
+			ToolCalls:        toolCalls,
 		}
 		messages = append(messages, assistantMsg)
 

--- a/internal/ai/agent_test.go
+++ b/internal/ai/agent_test.go
@@ -13,9 +13,17 @@ import (
 type mockProvider struct {
 	responses [][]StreamEvent // 每轮对话的响应事件序列
 	round     int
+	model     string // 可选：测试模型相关分支时设置
 }
 
 func (m *mockProvider) Name() string { return "mock" }
+
+func (m *mockProvider) Model() string {
+	if m.model != "" {
+		return m.model
+	}
+	return "mock-model"
+}
 
 func (m *mockProvider) Chat(_ context.Context, _ []Message, _ []Tool) (<-chan StreamEvent, error) {
 	ch := make(chan StreamEvent, 32)
@@ -180,6 +188,8 @@ type captureMockProvider struct {
 
 func (c *captureMockProvider) Name() string { return "capture_mock" }
 
+func (c *captureMockProvider) Model() string { return c.inner.Model() }
+
 func (c *captureMockProvider) Chat(ctx context.Context, msgs []Message, tools []Tool) (<-chan StreamEvent, error) {
 	// 第二轮调用时捕获完整 messages
 	if c.inner.round > 0 {
@@ -188,38 +198,74 @@ func (c *captureMockProvider) Chat(ctx context.Context, msgs []Message, tools []
 	return c.inner.Chat(ctx, msgs, tools)
 }
 
-func TestAgent_ToolCallMessageCarriesReasoningContent(t *testing.T) {
-	convey.Convey("Agent tool 调用后构造的 assistant 消息同时携带 thinking 与 reasoning_content（修复 DeepSeek thinking 多轮 400）", t, func() {
-		var capturedMessages []Message
+func TestAgent_ToolStartAndResultCarryToolCallID(t *testing.T) {
+	convey.Convey("tool_start 与 tool_result 事件都带上 ToolCallID（前端用以跨 turn 还原 tool_calls）", t, func() {
 		provider := &mockProvider{
 			responses: [][]StreamEvent{
-				// 第一轮：LLM 输出 thinking + tool_call（DeepSeek thinking 模式典型形态）
 				{
-					{Type: "thinking", Content: "先看一下"},
-					{Type: "thinking", Content: "有哪些资产"},
-					{Type: "thinking_done"},
 					{Type: "tool_call", ToolCalls: []ToolCall{
-						{ID: "call_1", Type: "function", Function: struct {
+						{ID: "call_xyz", Type: "function", Function: struct {
 							Name      string `json:"name"`
 							Arguments string `json:"arguments"`
 						}{Name: "list_assets", Arguments: `{}`}},
 					}},
 					{Type: "done"},
 				},
-				// 第二轮：LLM 返回最终回复
-				{
-					{Type: "content", Content: "完成"},
-					{Type: "done"},
-				},
+				{{Type: "content", Content: "ok"}, {Type: "done"}},
 			},
 		}
+		executor := &mockExecutor{results: map[string]string{"list_assets": `[]`}}
+		agent := NewAgent(provider, func() ToolExecutor { return executor }, nil, NewDefaultConfig())
+
+		var events []StreamEvent
+		err := agent.Chat(context.Background(), []Message{
+			{Role: RoleUser, Content: "list"},
+		}, func(e StreamEvent) { events = append(events, e) }, nil)
+		assert.NoError(t, err)
+
+		var startEvent, resultEvent *StreamEvent
+		for i := range events {
+			if events[i].Type == "tool_start" {
+				startEvent = &events[i]
+			} else if events[i].Type == "tool_result" {
+				resultEvent = &events[i]
+			}
+		}
+		assert.NotNil(t, startEvent)
+		assert.NotNil(t, resultEvent)
+		assert.Equal(t, "call_xyz", startEvent.ToolCallID)
+		assert.Equal(t, "call_xyz", resultEvent.ToolCallID)
+	})
+}
+
+func TestAgent_ToolCallMessageCarriesReasoningContent(t *testing.T) {
+	buildResponses := func() [][]StreamEvent {
+		return [][]StreamEvent{
+			{
+				{Type: "thinking", Content: "先看一下"},
+				{Type: "thinking", Content: "有哪些资产"},
+				{Type: "thinking_done"},
+				{Type: "tool_call", ToolCalls: []ToolCall{
+					{ID: "call_1", Type: "function", Function: struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					}{Name: "list_assets", Arguments: `{}`}},
+				}},
+				{Type: "done"},
+			},
+			{{Type: "content", Content: "完成"}, {Type: "done"}},
+		}
+	}
+
+	convey.Convey("DeepSeek-v4 模型：tool 调用轮 assistant 消息同时携带 Thinking 与 ReasoningContent", t, func() {
+		var capturedMessages []Message
+		provider := &mockProvider{responses: buildResponses(), model: "deepseek-v4-pro"}
 		captureProvider := &captureMockProvider{inner: provider, captured: &capturedMessages}
 		executor := &mockExecutor{results: map[string]string{"list_assets": `[]`}}
 		agent := NewAgent(captureProvider, func() ToolExecutor { return executor }, nil, NewDefaultConfig())
 
-		err := agent.Chat(context.Background(), []Message{
-			{Role: RoleUser, Content: "列出资产"},
-		}, func(e StreamEvent) {}, nil)
+		err := agent.Chat(context.Background(), []Message{{Role: RoleUser, Content: "列出资产"}},
+			func(e StreamEvent) {}, nil)
 		assert.NoError(t, err)
 
 		var assistantMsg *Message
@@ -229,10 +275,33 @@ func TestAgent_ToolCallMessageCarriesReasoningContent(t *testing.T) {
 				break
 			}
 		}
-		assert.NotNil(t, assistantMsg, "第二轮应包含上一轮 assistant 消息")
+		assert.NotNil(t, assistantMsg)
 		expected := "先看一下有哪些资产"
-		assert.Equal(t, expected, assistantMsg.Thinking, "Thinking 字段累积全部 thinking 片段")
-		assert.Equal(t, expected, assistantMsg.ReasoningContent, "ReasoningContent 必须与 Thinking 同步——DeepSeek 多轮要求原样回传")
+		assert.Equal(t, expected, assistantMsg.Thinking)
+		assert.Equal(t, expected, assistantMsg.ReasoningContent, "DeepSeek-v4 多轮要求原样回传 reasoning_content")
+	})
+
+	convey.Convey("非 DeepSeek-v4 模型：仅写 Thinking，不写 ReasoningContent，避免对 OpenAI/Anthropic 等 provider 引入未知字段", t, func() {
+		var capturedMessages []Message
+		provider := &mockProvider{responses: buildResponses(), model: "gpt-4o"}
+		captureProvider := &captureMockProvider{inner: provider, captured: &capturedMessages}
+		executor := &mockExecutor{results: map[string]string{"list_assets": `[]`}}
+		agent := NewAgent(captureProvider, func() ToolExecutor { return executor }, nil, NewDefaultConfig())
+
+		err := agent.Chat(context.Background(), []Message{{Role: RoleUser, Content: "列出资产"}},
+			func(e StreamEvent) {}, nil)
+		assert.NoError(t, err)
+
+		var assistantMsg *Message
+		for i := range capturedMessages {
+			if capturedMessages[i].Role == RoleAssistant {
+				assistantMsg = &capturedMessages[i]
+				break
+			}
+		}
+		assert.NotNil(t, assistantMsg)
+		assert.Equal(t, "先看一下有哪些资产", assistantMsg.Thinking)
+		assert.Empty(t, assistantMsg.ReasoningContent, "非 DeepSeek-v4 不应写 ReasoningContent")
 	})
 }
 

--- a/internal/ai/agent_test.go
+++ b/internal/ai/agent_test.go
@@ -188,6 +188,83 @@ func (c *captureMockProvider) Chat(ctx context.Context, msgs []Message, tools []
 	return c.inner.Chat(ctx, msgs, tools)
 }
 
+func TestAgent_ToolCallMessageCarriesReasoningContent(t *testing.T) {
+	convey.Convey("Agent tool 调用后构造的 assistant 消息同时携带 thinking 与 reasoning_content（修复 DeepSeek thinking 多轮 400）", t, func() {
+		var capturedMessages []Message
+		provider := &mockProvider{
+			responses: [][]StreamEvent{
+				// 第一轮：LLM 输出 thinking + tool_call（DeepSeek thinking 模式典型形态）
+				{
+					{Type: "thinking", Content: "先看一下"},
+					{Type: "thinking", Content: "有哪些资产"},
+					{Type: "thinking_done"},
+					{Type: "tool_call", ToolCalls: []ToolCall{
+						{ID: "call_1", Type: "function", Function: struct {
+							Name      string `json:"name"`
+							Arguments string `json:"arguments"`
+						}{Name: "list_assets", Arguments: `{}`}},
+					}},
+					{Type: "done"},
+				},
+				// 第二轮：LLM 返回最终回复
+				{
+					{Type: "content", Content: "完成"},
+					{Type: "done"},
+				},
+			},
+		}
+		captureProvider := &captureMockProvider{inner: provider, captured: &capturedMessages}
+		executor := &mockExecutor{results: map[string]string{"list_assets": `[]`}}
+		agent := NewAgent(captureProvider, func() ToolExecutor { return executor }, nil, NewDefaultConfig())
+
+		err := agent.Chat(context.Background(), []Message{
+			{Role: RoleUser, Content: "列出资产"},
+		}, func(e StreamEvent) {}, nil)
+		assert.NoError(t, err)
+
+		var assistantMsg *Message
+		for i := range capturedMessages {
+			if capturedMessages[i].Role == RoleAssistant {
+				assistantMsg = &capturedMessages[i]
+				break
+			}
+		}
+		assert.NotNil(t, assistantMsg, "第二轮应包含上一轮 assistant 消息")
+		expected := "先看一下有哪些资产"
+		assert.Equal(t, expected, assistantMsg.Thinking, "Thinking 字段累积全部 thinking 片段")
+		assert.Equal(t, expected, assistantMsg.ReasoningContent, "ReasoningContent 必须与 Thinking 同步——DeepSeek 多轮要求原样回传")
+	})
+}
+
+func TestMessage_ReasoningContentJSON(t *testing.T) {
+	convey.Convey("Message.ReasoningContent 序列化为 reasoning_content（DeepSeek/OpenAI 兼容字段）", t, func() {
+		msg := Message{
+			Role:             RoleAssistant,
+			Content:          "",
+			Thinking:         "thoughts",
+			ReasoningContent: "thoughts",
+		}
+		data, err := json.Marshal(msg)
+		assert.NoError(t, err)
+
+		var raw map[string]any
+		assert.NoError(t, json.Unmarshal(data, &raw))
+		assert.Equal(t, "thoughts", raw["thinking"])
+		assert.Equal(t, "thoughts", raw["reasoning_content"])
+	})
+
+	convey.Convey("ReasoningContent 为空时通过 omitempty 不出现在 JSON 中", t, func() {
+		msg := Message{Role: RoleAssistant, Content: "hello"}
+		data, err := json.Marshal(msg)
+		assert.NoError(t, err)
+
+		var raw map[string]any
+		assert.NoError(t, json.Unmarshal(data, &raw))
+		_, exists := raw["reasoning_content"]
+		assert.False(t, exists, "空字符串应被 omitempty 略掉")
+	})
+}
+
 func TestAgent_ToolCallLoop(t *testing.T) {
 	convey.Convey("Agent tool 调用循环", t, func() {
 		provider := &mockProvider{

--- a/internal/ai/agent_test.go
+++ b/internal/ai/agent_test.go
@@ -225,9 +225,10 @@ func TestAgent_ToolStartAndResultCarryToolCallID(t *testing.T) {
 
 		var startEvent, resultEvent *StreamEvent
 		for i := range events {
-			if events[i].Type == "tool_start" {
+			switch events[i].Type {
+			case "tool_start":
 				startEvent = &events[i]
-			} else if events[i].Type == "tool_result" {
+			case "tool_result":
 				resultEvent = &events[i]
 			}
 		}

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -39,6 +39,8 @@ func NewAnthropicProvider(name, apiBase, apiKey, model string, maxOutputTokens i
 
 func (p *AnthropicProvider) Name() string { return p.name }
 
+func (p *AnthropicProvider) Model() string { return p.model }
+
 // --- Anthropic API 请求/响应类型 ---
 
 type anthropicCacheControl struct {

--- a/internal/ai/conversation_runner.go
+++ b/internal/ai/conversation_runner.go
@@ -180,6 +180,7 @@ func (r *ConversationRunner) run(ctx context.Context, messages []Message, onEven
 		onEvent(StreamEvent{
 			Type:    "retry",
 			Content: strconv.Itoa(attempt) + "/" + strconv.Itoa(MaxRetries),
+			Error:   err.Error(),
 		})
 
 		// 等待退避时间，支持取消

--- a/internal/ai/conversation_runner.go
+++ b/internal/ai/conversation_runner.go
@@ -7,6 +7,9 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/cago-frame/cago/pkg/logger"
+	"go.uber.org/zap"
 )
 
 // RunnerState 表示 ConversationRunner 的当前状态
@@ -155,6 +158,7 @@ func (r *ConversationRunner) run(ctx context.Context, messages []Message, onEven
 
 		// 用户停止
 		if ctx.Err() != nil {
+			logger.Ctx(ctx).Info("AI generation stopped")
 			onEvent(StreamEvent{Type: "stopped"})
 			return
 		}
@@ -165,6 +169,7 @@ func (r *ConversationRunner) run(ctx context.Context, messages []Message, onEven
 		attempt := r.retry
 		if attempt > MaxRetries {
 			r.mu.Unlock()
+			logger.Ctx(ctx).Error("AI stream failed", zap.Int("attempts", attempt-1), zap.Error(err))
 			onEvent(StreamEvent{
 				Type:  "error",
 				Error: err.Error(),
@@ -175,6 +180,11 @@ func (r *ConversationRunner) run(ctx context.Context, messages []Message, onEven
 		r.mu.Unlock()
 
 		delay := calcRetryDelay(attempt, err)
+		logger.Ctx(ctx).Warn("AI retrying",
+			zap.Int("attempt", attempt),
+			zap.Int("max", MaxRetries),
+			zap.Duration("delay", delay),
+			zap.Error(err))
 
 		// 通知前端重试状态
 		onEvent(StreamEvent{
@@ -191,6 +201,7 @@ func (r *ConversationRunner) run(ctx context.Context, messages []Message, onEven
 			r.mu.Unlock()
 			continue
 		case <-ctx.Done():
+			logger.Ctx(ctx).Info("AI generation stopped during retry backoff")
 			onEvent(StreamEvent{Type: "stopped"})
 			return
 		}

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -37,6 +37,8 @@ func NewOpenAIProvider(name, apiBase, apiKey, model string, maxOutputTokens int)
 
 func (p *OpenAIProvider) Name() string { return p.name }
 
+func (p *OpenAIProvider) Model() string { return p.model }
+
 // openAIRequest OpenAI API 请求体
 type openAIRequest struct {
 	Model         string               `json:"model"`

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -61,11 +61,12 @@ type StreamEvent struct {
 	Content   string     `json:"content,omitempty"`    // type=content/tool_result/approval_result/agent_end 时的文本
 	ToolName  string     `json:"tool_name,omitempty"`  // type=tool_start/tool_result 时的工具名
 	ToolInput string     `json:"tool_input,omitempty"` // type=tool_start 时的输入摘要
-	ToolCalls []ToolCall `json:"tool_calls,omitempty"` // type=tool_call 时的工具调用 (OpenAI)
-	ConfirmID string     `json:"confirm_id,omitempty"` // type=approval_request/approval_result 时的确认请求 ID
-	Error     string     `json:"error,omitempty"`      // type=error 时的错误信息
-	AgentRole string     `json:"agent_role,omitempty"` // type=agent_start/approval_request 时的角色描述
-	AgentTask string     `json:"agent_task,omitempty"` // type=agent_start 时的任务描述
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // type=tool_call 时的工具调用 (OpenAI)
+	ToolCallID string     `json:"tool_call_id,omitempty"` // type=tool_start/tool_result 时的工具调用 ID，前端用于跨 turn 还原 tool_calls 历史
+	ConfirmID  string     `json:"confirm_id,omitempty"`   // type=approval_request/approval_result 时的确认请求 ID
+	Error      string     `json:"error,omitempty"`        // type=error 时的错误信息
+	AgentRole  string     `json:"agent_role,omitempty"`   // type=agent_start/approval_request 时的角色描述
+	AgentTask  string     `json:"agent_task,omitempty"`   // type=agent_start 时的任务描述
 	// approval_request 专用字段
 	Kind        string         `json:"kind,omitempty"`        // "single" | "batch" | "grant"
 	Items       []ApprovalItem `json:"items,omitempty"`       // 审批项列表
@@ -102,4 +103,6 @@ type Provider interface {
 	Chat(ctx context.Context, messages []Message, tools []Tool) (<-chan StreamEvent, error)
 	// Name 返回 provider 名称
 	Name() string
+	// Model 返回当前使用的模型 ID（用于 agent 层根据模型类型决定是否需要回传 reasoning_content 等）
+	Model() string
 }

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -14,11 +14,12 @@ const (
 
 // Message 对话消息
 type Message struct {
-	Role       Role       `json:"role"`
-	Content    string     `json:"content"`
-	Thinking   string     `json:"thinking,omitempty"`
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string     `json:"tool_call_id,omitempty"` // role=tool 时标识调用
+	Role             Role       `json:"role"`
+	Content          string     `json:"content"`
+	Thinking         string     `json:"thinking,omitempty"`          // Anthropic 格式
+	ReasoningContent string     `json:"reasoning_content,omitempty"` // DeepSeek/OpenAI 格式
+	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID       string     `json:"tool_call_id,omitempty"` // role=tool 时标识调用
 }
 
 // ToolCall AI 发起的工具调用

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -57,10 +57,10 @@ type Usage struct {
 
 // StreamEvent 流式响应事件
 type StreamEvent struct {
-	Type      string     `json:"type"`                 // "content" | "tool_start" | "tool_result" | "tool_call" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage"
-	Content   string     `json:"content,omitempty"`    // type=content/tool_result/approval_result/agent_end 时的文本
-	ToolName  string     `json:"tool_name,omitempty"`  // type=tool_start/tool_result 时的工具名
-	ToolInput string     `json:"tool_input,omitempty"` // type=tool_start 时的输入摘要
+	Type       string     `json:"type"`                   // "content" | "tool_start" | "tool_result" | "tool_call" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage"
+	Content    string     `json:"content,omitempty"`      // type=content/tool_result/approval_result/agent_end 时的文本
+	ToolName   string     `json:"tool_name,omitempty"`    // type=tool_start/tool_result 时的工具名
+	ToolInput  string     `json:"tool_input,omitempty"`   // type=tool_start 时的输入摘要
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // type=tool_call 时的工具调用 (OpenAI)
 	ToolCallID string     `json:"tool_call_id,omitempty"` // type=tool_start/tool_result 时的工具调用 ID，前端用于跨 turn 还原 tool_calls 历史
 	ConfirmID  string     `json:"confirm_id,omitempty"`   // type=approval_request/approval_result 时的确认请求 ID

--- a/internal/app/app_ai.go
+++ b/internal/app/app_ai.go
@@ -332,6 +332,15 @@ func (a *App) SendAIMessage(convID int64, messages []ai.Message, aiCtx ai.AICont
 	onEvent := func(event ai.StreamEvent) {
 		wailsRuntime.EventsEmit(a.ctx, eventName, event)
 
+		switch event.Type {
+		case "error":
+			logger.Default().Error("AI stream error", zap.Int64("conv_id", convID), zap.String("error", event.Error))
+		case "stopped":
+			logger.Default().Info("AI generation stopped", zap.Int64("conv_id", convID))
+		case "retry":
+			logger.Default().Warn("AI retrying", zap.Int64("conv_id", convID), zap.String("attempt", event.Content), zap.String("error", event.Error))
+		}
+
 		// done/stopped 时更新会话时间
 		if event.Type == "done" || event.Type == "stopped" {
 			if conv, err := conversation_svc.Conversation().Get(a.ctx, convID); err == nil {

--- a/internal/app/app_ai.go
+++ b/internal/app/app_ai.go
@@ -313,6 +313,7 @@ func (a *App) SendAIMessage(convID int64, messages []ai.Message, aiCtx ai.AICont
 	chatCtx := ai.WithAuditSource(a.ctx, "ai")
 	chatCtx = ai.WithConversationID(chatCtx, convID)
 	chatCtx = ai.WithSessionID(chatCtx, fmt.Sprintf("conv_%d", convID))
+	chatCtx = logger.WithContextField(chatCtx, zap.Int64("conv_id", convID))
 	if a.sshPool != nil {
 		chatCtx = ai.WithSSHPool(chatCtx, a.sshPool)
 	}
@@ -331,15 +332,6 @@ func (a *App) SendAIMessage(convID int64, messages []ai.Message, aiCtx ai.AICont
 
 	onEvent := func(event ai.StreamEvent) {
 		wailsRuntime.EventsEmit(a.ctx, eventName, event)
-
-		switch event.Type {
-		case "error":
-			logger.Default().Error("AI stream error", zap.Int64("conv_id", convID), zap.String("error", event.Error))
-		case "stopped":
-			logger.Default().Info("AI generation stopped", zap.Int64("conv_id", convID))
-		case "retry":
-			logger.Default().Warn("AI retrying", zap.Int64("conv_id", convID), zap.String("attempt", event.Content), zap.String("error", event.Error))
-		}
 
 		// done/stopped 时更新会话时间
 		if event.Type == "done" || event.Type == "stopped" {

--- a/internal/model/entity/conversation_entity/conversation.go
+++ b/internal/model/entity/conversation_entity/conversation.go
@@ -84,11 +84,12 @@ func (Message) TableName() string {
 
 // ContentBlock 前端内容块（用于持久化显示状态）
 type ContentBlock struct {
-	Type      string `json:"type"` // "text" | "tool"
-	Content   string `json:"content"`
-	ToolName  string `json:"toolName,omitempty"`
-	ToolInput string `json:"toolInput,omitempty"`
-	Status    string `json:"status,omitempty"` // "running" | "completed" | "error"
+	Type       string `json:"type"` // "text" | "tool"
+	Content    string `json:"content"`
+	ToolName   string `json:"toolName,omitempty"`
+	ToolInput  string `json:"toolInput,omitempty"`
+	ToolCallID string `json:"toolCallId,omitempty"` // 跨 turn 还原 tool_calls 历史；老数据无此字段，前端兜底为塌缩消息
+	Status     string `json:"status,omitempty"`     // "running" | "completed" | "error"
 }
 
 // GetBlocks 获取前端显示块


### PR DESCRIPTION
 ## 变更说明 / Summary

  🐛 修复 DeepSeek thinking 模式下多轮对话报 400 错误的问题

  问题：DeepSeek 模型启用 thinking 模式后，第二轮及后续 API 调用返回 400 错误：The reasoning_content in the thinking mode must be passed back to the API.

  根因：DeepSeek API 要求 assistant 消息中的 reasoning_content 字段必须原样回传，但代码中：
  1. Message 结构体只有 thinking 字段（Anthropic 格式），没有 reasoning_content（DeepSeek/OpenAI 格式）
  2. agent.go 构建多轮对话的 assistant 消息时未携带推理内容
  3. 前端发送消息时也未从 blocks 中提取 thinking 内容回传

  修复：
  - provider.go：Message 新增 ReasoningContent 字段（json:"reasoning_content,omitempty"）
  - agent.go：agent 循环构建 assistant 消息时，ReasoningContent 与 Thinking 同时赋值为 thinkingBuf
  - aiStore.ts：发送消息时，若当前模型为 DeepSeek，从 assistant 消息的 thinking blocks 中提取内容设为 reasoningContent

## 截图 / Screenshots
<img width="2361" height="1347" alt="image" src="https://github.com/user-attachments/assets/87e4d1c5-2662-4930-bbf9-b60404893a67" />




## 自检 / Checklist

测试了 kimi api 与 deepseek api 正常

- [x]  Fixes mentioned issues / 修复已提及的问题
- [x]  Code reviewed by human / 代码通过人工检查
- [x]  Changes tested / 已完成测试


