### PR TITLE
Add GitHub repository link to settings

### DIFF
--- a/frontend/src/__tests__/UpdateSection.test.tsx
+++ b/frontend/src/__tests__/UpdateSection.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UpdateSection } from "@/components/settings/UpdateSection";
+import {
+  GetAppVersion,
+  GetAvailableMirrors,
+  GetDebugMode,
+  GetDownloadMirror,
+  GetUpdateChannel,
+} from "../../wailsjs/go/app/App";
+import { BrowserOpenURL, EventsOn } from "../../wailsjs/runtime/runtime";
+
+describe("UpdateSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(EventsOn).mockReturnValue(vi.fn());
+    vi.mocked(GetAppVersion).mockResolvedValue("dev");
+    vi.mocked(GetUpdateChannel).mockResolvedValue("stable");
+    vi.mocked(GetDebugMode).mockResolvedValue(false);
+    vi.mocked(GetDownloadMirror).mockResolvedValue("");
+    vi.mocked(GetAvailableMirrors).mockResolvedValue([]);
+  });
+
+  it("opens the project repository from settings", async () => {
+    render(<UpdateSection />);
+
+    await userEvent.click(screen.getByRole("button", { name: "appUpdate.openRepository" }));
+
+    expect(BrowserOpenURL).toHaveBeenCalledWith("https://github.com/opskat/opskat");
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -11,6 +11,8 @@ vi.mock("../../wailsjs/runtime/runtime", () => ({
   EventsOn: vi.fn(),
   EventsOff: vi.fn(),
   EventsEmit: vi.fn(),
+  BrowserOpenURL: vi.fn(),
+  Quit: vi.fn(),
   WindowIsFullscreen: vi.fn().mockResolvedValue(false),
 }));
 

--- a/frontend/src/components/settings/UpdateSection.tsx
+++ b/frontend/src/components/settings/UpdateSection.tsx
@@ -37,12 +37,13 @@ import {
   SetDebugMode,
   OpenLogsDir,
 } from "../../../wailsjs/go/app/App";
-import { Bug, Download, FolderOpen, Loader2, ExternalLink, RefreshCw } from "lucide-react";
+import { Bug, Download, FolderOpen, Github, Loader2, ExternalLink, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { BrowserOpenURL, Quit } from "../../../wailsjs/runtime/runtime";
 import { EventsOn } from "../../../wailsjs/runtime/runtime";
 
 const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e));
+const REPOSITORY_URL = "https://github.com/opskat/opskat";
 
 export function UpdateSection() {
   const { t } = useTranslation();
@@ -119,6 +120,10 @@ export function UpdateSection() {
       // 取不到诊断信息时仍然打开模板，让用户手动填写
     }
     BrowserOpenURL(`https://github.com/opskat/opskat/issues/new?${params.toString()}`);
+  };
+
+  const handleOpenRepository = () => {
+    BrowserOpenURL(REPOSITORY_URL);
   };
 
   const handleChannelChange = async (value: string) => {
@@ -291,6 +296,10 @@ export function UpdateSection() {
           <Button onClick={handleReportBug} size="sm" variant="outline" title={t("appUpdate.reportBugDesc")}>
             <Bug className="h-3.5 w-3.5 mr-1.5" />
             {t("appUpdate.reportBug")}
+          </Button>
+          <Button onClick={handleOpenRepository} size="sm" variant="outline" title={t("appUpdate.openRepositoryDesc")}>
+            <Github className="h-3.5 w-3.5 mr-1.5" />
+            {t("appUpdate.openRepository")}
           </Button>
           <Button onClick={handleOpenLogsDir} size="sm" variant="outline">
             <FolderOpen className="h-3.5 w-3.5 mr-1.5" />

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -802,6 +802,8 @@
     "checksumSkipCancel": "Cancel",
     "reportBug": "Report Bug",
     "reportBugDesc": "Open GitHub issue template with version & system info pre-filled",
+    "openRepository": "GitHub Repository",
+    "openRepositoryDesc": "Open the OpsKat GitHub repository",
     "debugMode": "Debug Logging",
     "debugModeDesc": "Lower log level to debug for troubleshooting. Turn off when done.",
     "debugModeOn": "Debug logging enabled",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -802,6 +802,8 @@
     "checksumSkipCancel": "取消",
     "reportBug": "Bug 反馈",
     "reportBugDesc": "打开 GitHub 反馈模板，自动带上版本与系统信息",
+    "openRepository": "源码仓库",
+    "openRepositoryDesc": "打开 OpsKat GitHub 源码仓库",
     "debugMode": "Debug 日志",
     "debugModeDesc": "开启后日志级别降为 debug，便于问题排查；问题解决后建议关闭",
     "debugModeOn": "Debug 日志已开启",


### PR DESCRIPTION
## Summary

- add a GitHub repository action to Settings > About
- localize the new action label and tooltip in English and zh-CN
- cover the repository action with a focused UpdateSection test

Closes #43

## Validation

- `pnpm test -- UpdateSection.test.tsx` (50 files, 482 tests passed)
- `pnpm lint` (passed with existing warnings)
- `pnpm build`