### PR TITLE
✨ Show repository address in settings

### DIFF
--- a/frontend/src/__tests__/UpdateSection.test.tsx
+++ b/frontend/src/__tests__/UpdateSection.test.tsx
@@ -12,6 +12,8 @@ import {
 import { BrowserOpenURL, EventsOn } from "../../wailsjs/runtime/runtime";
 
 describe("UpdateSection", () => {
+  const repositoryURL = "https://github.com/opskat/opskat";
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(EventsOn).mockReturnValue(vi.fn());
@@ -22,11 +24,13 @@ describe("UpdateSection", () => {
     vi.mocked(GetAvailableMirrors).mockResolvedValue([]);
   });
 
-  it("opens the project repository from settings", async () => {
+  it("shows and opens the project repository from settings", async () => {
     render(<UpdateSection />);
 
-    await userEvent.click(screen.getByRole("button", { name: "appUpdate.openRepository" }));
+    expect(screen.getByText(repositoryURL)).toBeInTheDocument();
 
-    expect(BrowserOpenURL).toHaveBeenCalledWith("https://github.com/opskat/opskat");
+    await userEvent.click(screen.getByRole("button", { name: repositoryURL }));
+
+    expect(BrowserOpenURL).toHaveBeenCalledWith(repositoryURL);
   });
 });

--- a/frontend/src/__tests__/UpdateSection.test.tsx
+++ b/frontend/src/__tests__/UpdateSection.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UpdateSection } from "@/components/settings/UpdateSection";
+import {
+  GetAppVersion,
+  GetAvailableMirrors,
+  GetDebugMode,
+  GetDownloadMirror,
+  GetUpdateChannel,
+} from "../../wailsjs/go/app/App";
+import { BrowserOpenURL, EventsOn } from "../../wailsjs/runtime/runtime";
+
+describe("UpdateSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(EventsOn).mockReturnValue(vi.fn());
+    vi.mocked(GetAppVersion).mockResolvedValue("dev");
+    vi.mocked(GetUpdateChannel).mockResolvedValue("stable");
+    vi.mocked(GetDebugMode).mockResolvedValue(false);
+    vi.mocked(GetDownloadMirror).mockResolvedValue("");
+    vi.mocked(GetAvailableMirrors).mockResolvedValue([]);
+  });
+
+  it("opens the project repository from settings", async () => {
+    render(<UpdateSection />);
+
+    await userEvent.click(screen.getByRole("button", { name: "appUpdate.openRepository" }));
+
+    expect(BrowserOpenURL).toHaveBeenCalledWith("https://github.com/opskat/opskat");
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -11,6 +11,8 @@ vi.mock("../../wailsjs/runtime/runtime", () => ({
   EventsOn: vi.fn(),
   EventsOff: vi.fn(),
   EventsEmit: vi.fn(),
+  BrowserOpenURL: vi.fn(),
+  Quit: vi.fn(),
   WindowIsFullscreen: vi.fn().mockResolvedValue(false),
 }));
 

--- a/frontend/src/components/settings/UpdateSection.tsx
+++ b/frontend/src/components/settings/UpdateSection.tsx
@@ -37,12 +37,13 @@ import {
   SetDebugMode,
   OpenLogsDir,
 } from "../../../wailsjs/go/app/App";
-import { Bug, Download, FolderOpen, Loader2, ExternalLink, RefreshCw } from "lucide-react";
+import { Bug, Download, FolderOpen, Github, Loader2, ExternalLink, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { BrowserOpenURL, Quit } from "../../../wailsjs/runtime/runtime";
 import { EventsOn } from "../../../wailsjs/runtime/runtime";
 
 const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e));
+const REPOSITORY_URL = "https://github.com/opskat/opskat";
 
 export function UpdateSection() {
   const { t } = useTranslation();
@@ -119,6 +120,10 @@ export function UpdateSection() {
       // 取不到诊断信息时仍然打开模板，让用户手动填写
     }
     BrowserOpenURL(`https://github.com/opskat/opskat/issues/new?${params.toString()}`);
+  };
+
+  const handleOpenRepository = () => {
+    BrowserOpenURL(REPOSITORY_URL);
   };
 
   const handleChannelChange = async (value: string) => {
@@ -291,6 +296,10 @@ export function UpdateSection() {
           <Button onClick={handleReportBug} size="sm" variant="outline" title={t("appUpdate.reportBugDesc")}>
             <Bug className="h-3.5 w-3.5 mr-1.5" />
             {t("appUpdate.reportBug")}
+          </Button>
+          <Button onClick={handleOpenRepository} size="sm" variant="outline" title={t("appUpdate.openRepositoryDesc")}>
+            <Github className="h-3.5 w-3.5 mr-1.5" />
+            {t("appUpdate.openRepository")}
           </Button>
           <Button onClick={handleOpenLogsDir} size="sm" variant="outline">
             <FolderOpen className="h-3.5 w-3.5 mr-1.5" />

--- a/frontend/src/components/settings/UpdateSection.tsx
+++ b/frontend/src/components/settings/UpdateSection.tsx
@@ -37,7 +37,7 @@ import {
   SetDebugMode,
   OpenLogsDir,
 } from "../../../wailsjs/go/app/App";
-import { Bug, Download, FolderOpen, Github, Loader2, ExternalLink, RefreshCw } from "lucide-react";
+import { Bug, Download, FolderOpen, Loader2, ExternalLink, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { BrowserOpenURL, Quit } from "../../../wailsjs/runtime/runtime";
 import { EventsOn } from "../../../wailsjs/runtime/runtime";
@@ -224,6 +224,20 @@ export function UpdateSection() {
           <span className="font-mono text-xs">{currentVersion || "dev"}</span>
         </div>
 
+        <div className="flex justify-between items-center gap-3 text-sm">
+          <span className="text-muted-foreground">{t("appUpdate.openRepository")}</span>
+          <Button
+            onClick={handleOpenRepository}
+            size="sm"
+            variant="link"
+            className="h-auto min-w-0 p-0 text-right text-xs font-mono"
+            title={t("appUpdate.openRepositoryDesc")}
+          >
+            <span className="truncate">{REPOSITORY_URL}</span>
+            <ExternalLink className="ml-1 h-3 w-3 shrink-0" />
+          </Button>
+        </div>
+
         <div className="flex justify-between items-center text-sm">
           <span className="text-muted-foreground">{t("appUpdate.updateChannel")}</span>
           <Select value={channel} onValueChange={handleChannelChange}>
@@ -296,10 +310,6 @@ export function UpdateSection() {
           <Button onClick={handleReportBug} size="sm" variant="outline" title={t("appUpdate.reportBugDesc")}>
             <Bug className="h-3.5 w-3.5 mr-1.5" />
             {t("appUpdate.reportBug")}
-          </Button>
-          <Button onClick={handleOpenRepository} size="sm" variant="outline" title={t("appUpdate.openRepositoryDesc")}>
-            <Github className="h-3.5 w-3.5 mr-1.5" />
-            {t("appUpdate.openRepository")}
           </Button>
           <Button onClick={handleOpenLogsDir} size="sm" variant="outline">
             <FolderOpen className="h-3.5 w-3.5 mr-1.5" />

--- a/frontend/src/components/settings/UpdateSection.tsx
+++ b/frontend/src/components/settings/UpdateSection.tsx
@@ -39,8 +39,7 @@ import {
 } from "../../../wailsjs/go/app/App";
 import { Bug, Download, FolderOpen, Loader2, ExternalLink, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
-import { BrowserOpenURL, Quit } from "../../../wailsjs/runtime/runtime";
-import { EventsOn } from "../../../wailsjs/runtime/runtime";
+import { BrowserOpenURL, EventsOn, Quit } from "../../../wailsjs/runtime/runtime";
 
 const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e));
 const REPOSITORY_URL = "https://github.com/opskat/opskat";
@@ -119,11 +118,7 @@ export function UpdateSection() {
     } catch {
       // 取不到诊断信息时仍然打开模板，让用户手动填写
     }
-    BrowserOpenURL(`https://github.com/opskat/opskat/issues/new?${params.toString()}`);
-  };
-
-  const handleOpenRepository = () => {
-    BrowserOpenURL(REPOSITORY_URL);
+    BrowserOpenURL(`${REPOSITORY_URL}/issues/new?${params.toString()}`);
   };
 
   const handleChannelChange = async (value: string) => {
@@ -227,7 +222,7 @@ export function UpdateSection() {
         <div className="flex justify-between items-center gap-3 text-sm">
           <span className="text-muted-foreground">{t("appUpdate.openRepository")}</span>
           <Button
-            onClick={handleOpenRepository}
+            onClick={() => BrowserOpenURL(REPOSITORY_URL)}
             size="sm"
             variant="link"
             className="h-auto min-w-0 p-0 text-right text-xs font-mono"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -802,6 +802,8 @@
     "checksumSkipCancel": "Cancel",
     "reportBug": "Report Bug",
     "reportBugDesc": "Open GitHub issue template with version & system info pre-filled",
+    "openRepository": "GitHub Repository",
+    "openRepositoryDesc": "Open the OpsKat GitHub repository",
     "debugMode": "Debug Logging",
     "debugModeDesc": "Lower log level to debug for troubleshooting. Turn off when done.",
     "debugModeOn": "Debug logging enabled",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -802,7 +802,7 @@
     "checksumSkipCancel": "Cancel",
     "reportBug": "Report Bug",
     "reportBugDesc": "Open GitHub issue template with version & system info pre-filled",
-    "openRepository": "GitHub Repository",
+    "openRepository": "Repository",
     "openRepositoryDesc": "Open the OpsKat GitHub repository",
     "debugMode": "Debug Logging",
     "debugModeDesc": "Lower log level to debug for troubleshooting. Turn off when done.",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -802,7 +802,7 @@
     "checksumSkipCancel": "Cancel",
     "reportBug": "Report Bug",
     "reportBugDesc": "Open GitHub issue template with version & system info pre-filled",
-    "openRepository": "Repository",
+    "openRepository": "Repository address",
     "openRepositoryDesc": "Open the OpsKat GitHub repository",
     "debugMode": "Debug Logging",
     "debugModeDesc": "Lower log level to debug for troubleshooting. Turn off when done.",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -802,7 +802,7 @@
     "checksumSkipCancel": "Cancel",
     "reportBug": "Report Bug",
     "reportBugDesc": "Open GitHub issue template with version & system info pre-filled",
-    "openRepository": "Repository address",
+    "openRepository": "Repository",
     "openRepositoryDesc": "Open the OpsKat GitHub repository",
     "debugMode": "Debug Logging",
     "debugModeDesc": "Lower log level to debug for troubleshooting. Turn off when done.",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -802,6 +802,8 @@
     "checksumSkipCancel": "取消",
     "reportBug": "Bug 反馈",
     "reportBugDesc": "打开 GitHub 反馈模板，自动带上版本与系统信息",
+    "openRepository": "源码仓库",
+    "openRepositoryDesc": "打开 OpsKat GitHub 源码仓库",
     "debugMode": "Debug 日志",
     "debugModeDesc": "开启后日志级别降为 debug，便于问题排查；问题解决后建议关闭",
     "debugModeOn": "Debug 日志已开启",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -802,7 +802,7 @@
     "checksumSkipCancel": "取消",
     "reportBug": "Bug 反馈",
     "reportBugDesc": "打开 GitHub 反馈模板，自动带上版本与系统信息",
-    "openRepository": "源码仓库",
+    "openRepository": "仓库地址",
     "openRepositoryDesc": "打开 OpsKat GitHub 源码仓库",
     "debugMode": "Debug 日志",
     "debugModeDesc": "开启后日志级别降为 debug，便于问题排查；问题解决后建议关闭",


### PR DESCRIPTION
## 变更说明 / Summary

- Move the settings repository link into a dedicated repository address row under the current version.
- Show the actual GitHub URL as the clickable control instead of placing it in the debug/log action button group.
- Update the English and Chinese labels and regression test for the new behavior.

## 关联 Issue / Related Issue

Closes #43

## 截图 / Screenshots

Settings/About UI change. Screenshot not attached in this metadata cleanup.

## 自检 / Checklist

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## 验证 / Validation

- `pnpm --filter . test -- UpdateSection.test.tsx`
- `pnpm build`
