### PR TITLE
🐛 修复 GitHub Releases 手动安装链接

### DIFF
--- a/frontend/src/__tests__/AISettingsSection.test.tsx
+++ b/frontend/src/__tests__/AISettingsSection.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AISettingsSection } from "@/components/settings/AISettingsSection";
+import {
+  DetectOpsctl,
+  DetectSkills,
+  GetAppVersion,
+  GetDataDir,
+  GetOpsctlInstallDir,
+  ListAIProviders,
+} from "../../wailsjs/go/app/App";
+import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
+
+describe("AISettingsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ListAIProviders).mockResolvedValue([]);
+    vi.mocked(DetectOpsctl).mockResolvedValue({
+      installed: false,
+      path: "",
+      version: "",
+      embedded: false,
+    });
+    vi.mocked(DetectSkills).mockResolvedValue([]);
+    vi.mocked(GetOpsctlInstallDir).mockResolvedValue("");
+    vi.mocked(GetDataDir).mockResolvedValue("");
+    vi.mocked(GetAppVersion).mockResolvedValue("dev");
+  });
+
+  it("opens the GitHub Releases page for manual opsctl CLI install", async () => {
+    render(<AISettingsSection />);
+
+    await userEvent.click(screen.getByRole("button", { name: /GitHub Releases/i }));
+
+    expect(BrowserOpenURL).toHaveBeenCalledWith("https://github.com/opskat/opskat/releases");
+  });
+});

--- a/frontend/src/components/settings/AISettingsSection.tsx
+++ b/frontend/src/components/settings/AISettingsSection.tsx
@@ -245,7 +245,7 @@ function IntegrationSection() {
                   variant="link"
                   size="sm"
                   className="h-auto p-0 text-xs"
-                  onClick={() => BrowserOpenURL("https://github.com/opskat/opskat/release")}
+                  onClick={() => BrowserOpenURL("https://github.com/opskat/opskat/releases")}
                 >
                   <ExternalLink className="h-3 w-3 mr-1" />
                   GitHub Releases


### PR DESCRIPTION
## 变更说明 / Summary

- 修复设置页 opsctl CLI 手动安装区域的 `GitHub Releases` 按钮 URL，将 `/release` 改为 `/releases`。
- 新增回归测试，覆盖手动安装按钮打开正确 Releases 页面。

## 关联 Issue / Related Issue

Closes #49

## 截图 / Screenshots

N/A（链接行为修复，无视觉变化）。

## 自检 / Checklist

- [x]  Fixes mentioned issues / 修复已提及的问题
- [x]  Code reviewed by human / 代码通过人工检查
- [x]  Changes tested / 已完成测试

验证：
- `npx -y pnpm@10 vitest run src/__tests__/AISettingsSection.test.tsx`
- `npx -y pnpm@10 test`
- `npx -y pnpm@10 lint`