### PR TITLE
♻️ 重构资产路径并优化前端打包体积

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,129 +4,101 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-OpsKat is an AI-first desktop application for managing remote infrastructure (SSH, databases, Redis). Built with **Wails v2** (Go 1.25 backend + React 19 frontend). The desktop app communicates via Wails IPC — there is no HTTP API.
-
-Module: `github.com/opskat/opskat`
+OpsKat is an AI-first desktop app for managing remote infrastructure (SSH, databases, Redis). **Wails v2** (Go 1.25 + React 19), IPC only — no HTTP API. Module: `github.com/opskat/opskat`.
 
 ## Common Commands
 
 ```bash
-# Development
-make dev              # Wails dev mode with hot reload
-make install          # Install frontend deps (pnpm)
-make run              # Run embedded production build (no hot reload)
-make clean            # Remove build/bin, frontend/dist, embedded opsctl, coverage, root-level binaries
-
-# Build
+# Dev / build
+make dev              # Wails hot-reload dev
 make build            # Production build
-make build-embed      # Production with embedded opsctl CLI
-make build-cli        # Standalone opsctl CLI binary
-make install-cli      # Install opsctl to GOPATH/bin
+make build-embed      # Production with embedded opsctl
+make build-cli        # Standalone opsctl CLI
+make clean
 
-# Testing
-make test                              # Go tests (internal, cmd/opsctl, cmd/devserver, pkg)
-make test-cover                        # Coverage HTML → opens in browser
-make test-fixtures && make test-e2e    # E2E (needs ../extensions sibling repo)
-go test ./internal/ai/ -run TestName   # Single test
-cd frontend && pnpm test               # Frontend tests (vitest)
+# Test
+make test                              # All Go tests
+go test ./internal/ai/ -run TestName   # Single Go test
+cd frontend && pnpm test               # Frontend (vitest)
+make test-fixtures && make test-e2e    # E2E (needs ../extensions sibling)
 
 # Lint
-make lint / make lint-fix              # golangci-lint (10m timeout, .golangci.yml)
+make lint / make lint-fix              # golangci-lint
 cd frontend && pnpm lint / pnpm lint:fix
 
-# Extensions DevServer (refuses to run when OPSKAT_ENV=production)
-make devserver EXT=<name>     # Builds extension in ../extensions, loads its WASM + manifest
-make build-devserver-ui       # Rebuild embedded devserver UI
-
-# Plugin
-make install-skill            # Register Claude Code opsctl plugin (symlinks plugin/ into ~/.claude)
+# Extensions
+make devserver EXT=<name>              # Standalone dev server for one extension (refuses if OPSKAT_ENV=production)
 ```
 
 ## Architecture
 
-### Backend (Go) — Layered
+### Backend (Go) — layered
 
 ```
-main.go (Wails entry)
-  └─ internal/app/        Wails binding layer (App struct — public methods exposed to frontend via IPC)
-       ├─ internal/service/    Business logic (15 *_svc packages)
-       ├─ internal/repository/ Data access (13 *_repo, interface + impl pattern)
-       └─ internal/model/      Domain entities
+main.go → internal/app/ (Wails bindings)
+            → internal/service/    (business logic, *_svc)
+            → internal/repository/ (data access, interface + impl)
+            → internal/model/      (entities)
 ```
+
+Bindings stay thin: parse → service → return. Business rules in `service/`, persistence in `repository/`. Logic inside `App` is unreachable from tests and `opsctl`.
 
 **Key subsystems:**
-- `internal/ai/` — AI agent: provider abstraction (Anthropic/OpenAI), tool registry, command policy, conversation runner, context compression, audit logging
-- `internal/sshpool/` — SSH connection pool with Unix socket proxy for opsctl
-- `internal/connpool/` — Database/Redis tunnel management
-- `internal/approval/` — Inter-process approval workflow (Unix socket between desktop app and opsctl)
-- `internal/bootstrap/` — App init: database, credentials, migrations, auth tokens
-- `internal/embedded/` — Embedded opsctl binary (build tag: `embed_opsctl`)
-- `pkg/extension/` — WASM extension runtime (wazero); `HostProvider` in `pkg/extension/host.go` defines capabilities exposed to WASM (I/O, KV, asset config, file dialogs, logging, events)
-- `cmd/opsctl/` — Standalone CLI for remote ops, designed for AI assistant integration
-- `cmd/devserver/` — Standalone HTTP dev server for a single extension
+- `internal/ai/` — provider abstraction (Anthropic/OpenAI), tool registry, command policy, conversation runner, audit
+- `internal/sshpool/`, `internal/connpool/` — SSH pool (Unix socket proxy for opsctl); DB/Redis tunnels
+- `internal/approval/` — Unix-socket approval flow between desktop app and opsctl
+- `internal/bootstrap/` — DB, credentials, migrations, auth tokens
+- `pkg/extension/` — WASM runtime (wazero); `HostProvider` in `host.go` defines WASM capabilities
+- `cmd/opsctl/`, `cmd/devserver/` — standalone CLI / single-extension dev server
 
-**Repos:** Each has interface + default singleton + `Register()`/getter. **Database:** GORM + SQLite, gormigrate migrations in `/migrations/`. **Credentials:** Argon2id KDF + AES-256-GCM, master key in OS keychain.
+**Data:** GORM + SQLite, gormigrate migrations in `/migrations/`. Soft deletes via `Status` field (`StatusActive=1`, `StatusDeleted=2`), **not** GORM soft delete. Credentials: Argon2id KDF + AES-256-GCM, master key in OS keychain.
 
-**Extensions:** WASM modules loaded at runtime; tools declared in `manifest.json`. AI invokes them via a **single `exec_tool`** (not individual tools per extension). Handler `internal/ai/tool_handler_ext.go` dispatches by `extension` + `tool` args, enforces extension policy type against asset policy groups, then calls `Plugin.CallTool`.
+**Extensions:** WASM modules with `manifest.json`-declared tools. AI invokes them via a **single `exec_tool`** (not one tool per extension). Dispatcher in `internal/ai/tool_handler_ext.go` enforces extension policy type against asset policy groups before `Plugin.CallTool`.
 
 ### Frontend (React + TypeScript)
 
-`frontend/` is a pnpm workspace. Root app consumes `@opskat/ui` (`packages/ui`); `packages/devserver-ui` is embedded by `cmd/devserver`. Vite 6, Tailwind 4, shadcn/ui (Radix), Zustand 5.
+`frontend/` is a pnpm workspace. Root app uses `@opskat/ui` (`packages/ui`); `packages/devserver-ui` is embedded by `cmd/devserver`. Vite 6, Tailwind 4, shadcn/ui (Radix), Zustand 5.
 
-- **No React Router** — custom tab-based navigation in `tabStore`. Tab types: `terminal | ai | query | page | info`.
-- **State:** one Zustand store per domain in `src/stores/`.
-- **Backend calls:** Wails-generated bindings from `frontend/wailsjs/go/app/App`; real-time via `EventsOn()`.
-- **i18n:** i18next, locales in `src/i18n/locales/{zh-CN,en}/common.json`; keys namespaced under `"common"`, use `t("key.subkey")`.
-- **Terminal:** xterm.js 6 with split-pane.
-- **Tests:** Vitest + happy-dom + RTL; Wails runtime mocked in `src/__tests__/setup.ts`.
-
-### CI (`.github/workflows/ci.yml`)
-
-Triggers on PR + push to `main` / `develop/*`. Jobs: Go lint (golangci-lint) + Go test, frontend lint + test + build.
+- **No React Router** — custom tabs in `tabStore`. Tab types: `terminal | ai | query | page | info`.
+- One Zustand store per domain in `src/stores/`.
+- Backend calls via Wails-generated bindings (`frontend/wailsjs/go/app/App`); events via `EventsOn()`.
+- i18n: i18next, locales in `src/i18n/locales/{zh-CN,en}/common.json`, all keys under `"common"` namespace → `t("key.subkey")`.
+- Terminal: xterm.js 6, split-pane.
+- Tests: Vitest + happy-dom + RTL; Wails runtime mocked in `src/__tests__/setup.ts`.
 
 ## Conventions
 
-- **Commits:** gitmoji prefixes — ✨ feature, 🐛 fix, ♻️ refactor, 🎨 UI, ⚡️ perf, 🔒 security, 🔧 config, ✅ tests, 📄 docs, 🚀 release.
-- **Go mocks:** `go.uber.org/mock` in `mock_*/` subdirs; regenerate via `go generate ./...`.
-- **Go test assertions:** goconvey + testify.
-- **Frontend formatting:** Prettier (120 char width, 2-space indent).
-- **Soft deletes:** `Status` field (`StatusActive=1`, `StatusDeleted=2`), not GORM soft delete.
-- **Version info:** embedded via ldflags at build time.
+- **Commits:** gitmoji — ✨ feature, 🐛 fix, ♻️ refactor, 🎨 UI, ⚡️ perf, 🔒 security, 🔧 config, ✅ tests, 📄 docs, 🚀 release.
+- **Go mocks:** `go.uber.org/mock` in `mock_*/` subdirs; regen via `go generate ./...`.
+- **Go tests:** goconvey + testify.
+- **Frontend:** Prettier (120 col, 2-space).
 
-## Fix-now policy — don't park tech debt
+## Fix policy — root cause, in scope, no parking
 
-When you find a real, in-scope problem while working on something else (Makefile target drifted from its docstring, CLAUDE.md line lying about the code, dead reference, obvious one-line bug under your cursor) — fix it in the same change. Don't open a TODO, don't ship docs that lie about the code.
+- **Fix root causes, not symptoms.** Don't guard at the call site to mask a producer that emits bad values — fix the producer. Don't re-normalize a field at multiple consumers — normalize once at the boundary. If the design is wrong, refactor the affected piece; don't route around it. A comment explaining why a workaround is needed usually means the underlying code should change.
+- **Fix in-scope drift in the same change.** Stale docstring, lying CLAUDE.md line, dead reference, obvious one-line bug under your cursor → fix it now, don't TODO it.
+- **Stay in scope.** Multi-day refactors / hot subsystems / design-discussion territory → flag and ask. Genuine out-of-scope workaround → isolate it in one place with a clear comment and surface it; don't normalize patching as the default.
 
-Bar: "broken thing under my hands, fix is small and obvious". Multi-day refactors / hot-subsystem changes / things needing design discussion → call out and ask, don't silently expand scope.
+## Reuse first — grep before writing new code
 
-## Code smells — reuse first
+Parallel copies drift within weeks. Before writing any component / hook / util / Go helper, grep for the existing one.
 
-**Before writing any new component, hook, util, or Go helper: grep first.** Parallel copies drift within weeks (missing features, inconsistent UX, stale fixes).
+Recurring smells:
+- **Hand-rolled UI instead of the shared primitive.** `AssetSelect` / `AssetMultiSelect` / `GroupSelect`, `TreeSelect` / `TreeCheckList`, `ConfirmDialog`, `PasswordSourceField`, `IconPicker`, terminal panes, query result grid, tab system, shortcut store all exist — don't re-derive expand/collapse, tri-state checkboxes, search/pinyin, shortcuts, approval flows, or icon resolution.
+- **Hardcoded defaults instead of the entity's own field.** Resolve `Icon` / `Type` / `Color` / policy group via the canonical helper (`getIconComponent` + `getIconColor`, `getAssetType`); fall back only when empty.
+- **Inline filters / data loading.** Common filters (`Status === 1`, type filter, excludeIds, sort) belong in the shared hook (`useAssetStore`, `useAssetTree`, `useGroupTree`, `useShortcutStore`). New filter → hook option, not inline.
+- **Re-implementing cross-cutting concerns.** Logging, audit, AI tool registration, approval, credential encryption, connection pools, i18n all have canonical entry points — don't spin up a second one.
 
-Recurring smells in this repo:
+Heuristics: importing a primitive (`lucide-react`, tree, Radix, `ConfirmDialog`, xterm) **and** an entity store from a new file usually means you're re-implementing a picker/pane/dialog. About to copy >10 lines? Extract. Same fix in two near-identical blocks? The second block is the bug — delete it, call the first.
 
-- **Hand-rolled UI instead of the shared primitive.** Use `AssetSelect` / `AssetMultiSelect` / `GroupSelect`, `TreeSelect` / `TreeCheckList`, `ConfirmDialog`, `PasswordSourceField`, `IconPicker`, the terminal panes, query result grid, tab system, shortcut store. Don't re-derive expand/collapse, tri-state checkboxes, search/pinyin, keyboard shortcuts, approval flows, or icon resolution in a leaf component.
-- **Hardcoded defaults instead of the entity's own field.** When an entity carries a configured property (asset/group `Icon`, asset `Type`, `Color`, policy group), resolve via the canonical helper (`getIconComponent` + `getIconColor`, `getAssetType`); fall back only when empty.
-- **Duplicating filters / data loading at call sites.** Common filters (`Status === 1`, type filter, excludeIds, sort) and data access belong in the shared hook/store (`useAssetStore`, `useAssetTree`, `useGroupTree`, `useShortcutStore`). New filter? Add a hook option, don't inline.
-- **Fat Wails binding methods in `internal/app/*.go`.** Bindings should be thin: parse args → call service → return. Business rules in `internal/service/`; persistence in `internal/repository/`. Logic inside `App` becomes unreachable from tests and from `opsctl`.
-- **Re-implementing cross-cutting concerns.** Logging, audit, AI tool registration, approval, credential encryption, connection pools, i18n keys all have canonical entry points (`internal/ai/`, `internal/approval/`, `internal/sshpool/`, `internal/connpool/`, `src/i18n`). Don't spin up a second one.
-
-Heuristics:
-
-- A new file importing a primitive (`lucide-react`, tree component, Radix, `ConfirmDialog`, xterm) **and** an entity store usually means you're re-implementing a picker/pane/dialog — grep first.
-- About to copy–paste >10 lines? Extract instead.
-- A fix has to be applied to two near-identical blocks → the second block is the bug; delete it, call the first.
-
-## ⚠️ Generated / auto-managed files — do not edit by hand
+## ⚠️ Generated / auto-managed files
 
 | Path | Producer | Regenerate |
 |------|----------|------------|
-| `frontend/wailsjs/go/app/App.{d.ts,js}`, `models.ts` | Wails (from `internal/app/*.go` `App` methods + Go structs) | `make dev` / `wails build` |
+| `frontend/wailsjs/go/app/App.{d.ts,js}`, `models.ts` | Wails (from `internal/app/*.go` + Go structs) | `make dev` / `wails build` |
 | `frontend/wailsjs/runtime/runtime.{js,d.ts}` | Wails runtime shim | shipped with Wails CLI |
-| `internal/**/mock_*/` (e.g. `mock_asset_repo/asset.go`) | `mockgen` (`go.uber.org/mock`) | `go generate ./...` against the matching `//go:generate` directive |
+| `internal/**/mock_*/` | `mockgen` | `go generate ./...` |
 | `internal/embedded/opsctl_bin` | `make build-cli-embed` | `make build-embed` |
-| `frontend/packages/devserver-ui/dist/` | Vite build, embedded into `cmd/devserver` via `embed.go` | `make build-devserver-ui` |
+| `frontend/packages/devserver-ui/dist/` | Vite (embedded by `cmd/devserver`) | `make build-devserver-ui` |
 
-Build artifacts (gitignored, removed by `make clean`): `build/bin/`, `frontend/dist/`, `coverage.out`, `coverage.html`, `coverage_new.out`, `internal/embedded/opsctl_bin`, `frontend/package.json.md5`, top-level `opskat`/`opsctl`/`devserver` binaries.
-
-Lockfiles — never hand-edit; use the package manager: `go.sum` (`go mod tidy`), `frontend/pnpm-lock.yaml` (`pnpm add/remove/install`).
+Lockfiles (`go.sum`, `frontend/pnpm-lock.yaml`) — never hand-edit; use `go mod tidy` / `pnpm add|remove|install`.

--- a/cmd/opsctl/command/resolve.go
+++ b/cmd/opsctl/command/resolve.go
@@ -119,11 +119,8 @@ func resolveGroup(ctx context.Context, identifier string) (int64, string, error)
 		return 0, "", fmt.Errorf("failed to list groups: %w", err)
 	}
 
-	// Build path map for matching
-	pathMap, err := buildGroupPathMap(ctx)
-	if err != nil {
-		return 0, "", err
-	}
+	// Build path map from the already-fetched groups (avoid a second List).
+	pathMap := buildGroupPathMapFromGroups(groups)
 
 	var candidates []struct {
 		id   int64

--- a/cmd/opsctl/command/resolve.go
+++ b/cmd/opsctl/command/resolve.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/opskat/opskat/internal/model/entity/asset_entity"
+	"github.com/opskat/opskat/internal/model/entity/group_entity"
 	"github.com/opskat/opskat/internal/repository/asset_repo"
 	"github.com/opskat/opskat/internal/repository/group_repo"
 
@@ -163,39 +164,45 @@ func buildGroupPathMap(ctx context.Context) (map[int64]string, error) {
 		return nil, fmt.Errorf("failed to list groups: %w", err)
 	}
 
-	byID := make(map[int64]string)
-	idToParent := make(map[int64]int64)
-	idToName := make(map[int64]string)
+	return buildGroupPathMapFromGroups(groups), nil
+}
+
+func buildGroupPathMapFromGroups(groups []*group_entity.Group) map[int64]string {
+	byID := make(map[int64]*group_entity.Group, len(groups))
 	for _, g := range groups {
-		idToParent[g.ID] = g.ParentID
-		idToName[g.ID] = g.Name
+		byID[g.ID] = g
 	}
 
-	// Build paths by walking up parent chain
-	var buildPath func(id int64, depth int) string
-	buildPath = func(id int64, depth int) string {
-		if id == 0 || depth > 5 {
-			return ""
-		}
-		if cached, ok := byID[id]; ok {
-			return cached
-		}
-		name := idToName[id]
-		parent := idToParent[id]
-		parentPath := buildPath(parent, depth+1)
-		var path string
-		if parentPath != "" {
-			path = parentPath + "/" + name
-		} else {
-			path = name
-		}
-		byID[id] = path
-		return path
-	}
-
+	paths := make(map[int64]string, len(groups))
 	for _, g := range groups {
-		buildPath(g.ID, 0)
+		paths[g.ID] = buildGroupPathFromLookup(byID, g.ID)
+	}
+	return paths
+}
+
+func buildGroupPathFromLookup(groups map[int64]*group_entity.Group, groupID int64) string {
+	if groupID == 0 {
+		return ""
 	}
 
-	return byID, nil
+	var names []string
+	seen := make(map[int64]struct{})
+	for id := groupID; id > 0; {
+		if _, ok := seen[id]; ok {
+			break
+		}
+		seen[id] = struct{}{}
+
+		group, ok := groups[id]
+		if !ok {
+			break
+		}
+		names = append(names, group.Name)
+		id = group.ParentID
+	}
+
+	for i, j := 0, len(names)-1; i < j; i, j = i+1, j-1 {
+		names[i], names[j] = names[j], names[i]
+	}
+	return strings.Join(names, "/")
 }

--- a/cmd/opsctl/command/resolve_test.go
+++ b/cmd/opsctl/command/resolve_test.go
@@ -1,0 +1,74 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/opskat/opskat/internal/model/entity/group_entity"
+	"github.com/opskat/opskat/internal/repository/group_repo"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type resolveGroupRepoStub struct {
+	groups []*group_entity.Group
+}
+
+func (s *resolveGroupRepoStub) Find(_ context.Context, id int64) (*group_entity.Group, error) {
+	for _, group := range s.groups {
+		if group.ID == id {
+			return group, nil
+		}
+	}
+	return nil, errors.New("group not found")
+}
+
+func (s *resolveGroupRepoStub) List(_ context.Context) ([]*group_entity.Group, error) {
+	return s.groups, nil
+}
+
+func (s *resolveGroupRepoStub) Create(_ context.Context, _ *group_entity.Group) error { return nil }
+func (s *resolveGroupRepoStub) Update(_ context.Context, _ *group_entity.Group) error { return nil }
+func (s *resolveGroupRepoStub) Delete(_ context.Context, _ int64) error               { return nil }
+func (s *resolveGroupRepoStub) ReparentChildren(_ context.Context, _, _ int64) error  { return nil }
+func (s *resolveGroupRepoStub) UpdateSortOrder(_ context.Context, _ int64, _ int) error {
+	return nil
+}
+
+func TestBuildGroupPathMap(t *testing.T) {
+	Convey("buildGroupPathMap", t, func() {
+		origGroup := group_repo.Group()
+		defer group_repo.RegisterGroup(origGroup)
+
+		Convey("supports hierarchy deeper than five levels", func() {
+			group_repo.RegisterGroup(&resolveGroupRepoStub{groups: []*group_entity.Group{
+				{ID: 1, Name: "g1"},
+				{ID: 2, Name: "g2", ParentID: 1},
+				{ID: 3, Name: "g3", ParentID: 2},
+				{ID: 4, Name: "g4", ParentID: 3},
+				{ID: 5, Name: "g5", ParentID: 4},
+				{ID: 6, Name: "g6", ParentID: 5},
+				{ID: 7, Name: "g7", ParentID: 6},
+			}})
+
+			paths, err := buildGroupPathMap(context.Background())
+
+			So(err, ShouldBeNil)
+			So(paths[7], ShouldEqual, "g1/g2/g3/g4/g5/g6/g7")
+		})
+
+		Convey("breaks parent cycles from the current group perspective", func() {
+			group_repo.RegisterGroup(&resolveGroupRepoStub{groups: []*group_entity.Group{
+				{ID: 1, Name: "A", ParentID: 2},
+				{ID: 2, Name: "B", ParentID: 1},
+			}})
+
+			paths, err := buildGroupPathMap(context.Background())
+
+			So(err, ShouldBeNil)
+			So(paths[1], ShouldEqual, "B/A")
+			So(paths[2], ShouldEqual, "A/B")
+		})
+	})
+}

--- a/frontend/src/__tests__/assetSearch.test.ts
+++ b/frontend/src/__tests__/assetSearch.test.ts
@@ -23,6 +23,13 @@ describe("buildGroupPathMap", () => {
     const map = buildGroupPathMap(groups);
     expect(map.get(2)).toBe("孤儿");
   });
+
+  it("parent 链成环时按当前组视角截断路径", () => {
+    const groups = [group(1, "A", 2), group(2, "B", 1)];
+    const map = buildGroupPathMap(groups);
+    expect(map.get(1)).toBe("B/A");
+    expect(map.get(2)).toBe("A/B");
+  });
 });
 
 describe("filterAssets", () => {

--- a/frontend/src/__tests__/assetStore.test.ts
+++ b/frontend/src/__tests__/assetStore.test.ts
@@ -207,6 +207,17 @@ describe("assetStore", () => {
       const path = useAssetStore.getState().getAssetPath({ Name: "S1", GroupID: 2 } as any);
       expect(path).toBe("Orphan / S1");
     });
+
+    it("stops when group parents form a cycle", () => {
+      useAssetStore.setState({
+        groups: [
+          { ID: 1, Name: "A", ParentID: 2 },
+          { ID: 2, Name: "B", ParentID: 1 },
+        ] as any,
+      });
+      const path = useAssetStore.getState().getAssetPath({ Name: "S1", GroupID: 1 } as any);
+      expect(path).toBe("B / A / S1");
+    });
   });
 
   describe("selection", () => {

--- a/frontend/src/__tests__/assetTree.test.ts
+++ b/frontend/src/__tests__/assetTree.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildAssetTree, collectLeafIds } from "@/lib/assetTree";
+import type { TreeNode } from "@opskat/ui";
+import type { asset_entity, group_entity } from "../../wailsjs/go/models";
+
+function asset(id: number, name: string, type: string, groupId = 0, status = 1): asset_entity.Asset {
+  return { ID: id, Name: name, Type: type, GroupID: groupId, Status: status } as asset_entity.Asset;
+}
+
+function group(id: number, name: string, parentId = 0): group_entity.Group {
+  return { ID: id, Name: name, ParentID: parentId } as group_entity.Group;
+}
+
+function selectableIds(nodes: TreeNode[]): number[] {
+  return nodes.flatMap((node) => collectLeafIds(node));
+}
+
+describe("buildAssetTree", () => {
+  it("applies common picker filters before building tree nodes", () => {
+    const groups = [group(10, "SSH"), group(20, "Database")];
+    const assets = [
+      asset(1, "ssh-a", "ssh", 10),
+      asset(2, "ssh-b", "ssh", 10),
+      asset(3, "inactive-ssh", "ssh", 10, 2),
+      asset(4, "mysql", "database", 20),
+      asset(5, "root-ssh", "ssh"),
+    ];
+
+    const tree = buildAssetTree(assets, groups, {
+      filterType: "ssh",
+      activeOnly: true,
+      excludeIds: [2],
+    });
+
+    expect(tree.map((node: TreeNode) => node.label)).toEqual(["SSH", "root-ssh"]);
+    expect(selectableIds(tree)).toEqual([1, 5]);
+  });
+});

--- a/frontend/src/__tests__/bundleBoundaries.test.ts
+++ b/frontend/src/__tests__/bundleBoundaries.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(pathFromSrc: string): string {
+  return readFileSync(join(process.cwd(), "src", pathFromSrc), "utf8");
+}
+
+function expectNoStaticImport(source: string, modulePath: string): void {
+  const escaped = modulePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  expect(source).not.toMatch(new RegExp(`^import\\s+(?:type\\s+)?[\\s\\S]*?from\\s+["']${escaped}["'];?`, "m"));
+  expect(source).not.toMatch(new RegExp(`^import\\s+["']${escaped}["'];?`, "m"));
+}
+
+describe("bundle boundaries", () => {
+  it("keeps Monaco setup out of the startup entry", () => {
+    const source = readSource("main.tsx");
+
+    expectNoStaticImport(source, "./lib/monaco-setup");
+  });
+
+  it("keeps terminal renderer code out of the terminal store startup path", () => {
+    const source = readSource("stores/terminalStore.ts");
+
+    expectNoStaticImport(source, "@/components/terminal/terminalRegistry");
+  });
+
+  it("loads heavy tab surfaces through dynamic chunks", () => {
+    const source = readSource("components/layout/MainPanel.tsx");
+
+    for (const modulePath of [
+      "@/components/asset/AssetDetail",
+      "@/components/asset/GroupDetail",
+      "@/components/terminal/SplitPane",
+      "@/components/terminal/SessionToolbar",
+      "@/components/terminal/TerminalToolbar",
+      "@/components/terminal/FileManagerPanel",
+      "@/components/settings/SettingsPage",
+      "@/components/settings/CredentialManager",
+      "@/components/audit/AuditLogPage",
+      "@/components/forward/PortForwardPage",
+      "@/components/snippet/SnippetsPage",
+      "@/components/ai/AIChatContent",
+      "@/components/query/DatabasePanel",
+      "@/components/query/RedisPanel",
+      "@/components/query/MongoDBPanel",
+    ]) {
+      expectNoStaticImport(source, modulePath);
+    }
+  });
+
+  it("keeps AI chat content out of the side panel shell", () => {
+    const source = readSource("components/ai/SideAssistantPanel.tsx");
+
+    expectNoStaticImport(source, "./AIChatContent");
+  });
+});

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -79,6 +79,23 @@ export function CodeEditor({
   const resolvedTheme = useResolvedTheme();
   const editorRef = useRef<MonacoNS.editor.IStandaloneCodeEditor | null>(null);
   const modelUriRef = useRef<string | null>(null);
+  const [monacoReady, setMonacoReady] = useState(false);
+  const [monacoLoadError, setMonacoLoadError] = useState<unknown>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    import("@/lib/monaco-setup")
+      .then(({ setupMonaco }) => {
+        setupMonaco();
+        if (!cancelled) setMonacoReady(true);
+      })
+      .catch((error) => {
+        if (!cancelled) setMonacoLoadError(error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // 用 ref 桥接最新的 dynamicCompletions，避免 prop 变化时 re-mount editor
   const dynamicRef = useRef<DynamicCompletionGetter | undefined>(dynamicCompletions);
@@ -137,6 +154,14 @@ export function CodeEditor({
     },
     [handleMount, isControlled, placeholder]
   );
+
+  if (monacoLoadError) {
+    throw monacoLoadError;
+  }
+
+  if (!monacoReady) {
+    return <div className={`relative h-full w-full ${className ?? ""}`} style={{ height }} />;
+  }
 
   return (
     <div className={`relative h-full w-full ${className ?? ""}`}>

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -81,9 +81,11 @@ export function CodeEditor({
   const modelUriRef = useRef<string | null>(null);
   const [monacoReady, setMonacoReady] = useState(false);
   const [monacoLoadError, setMonacoLoadError] = useState<unknown>(null);
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
+    setMonacoLoadError(null);
     import("@/lib/monaco-setup")
       .then(({ setupMonaco }) => {
         setupMonaco();
@@ -95,6 +97,10 @@ export function CodeEditor({
     return () => {
       cancelled = true;
     };
+  }, [loadAttempt]);
+
+  const handleRetryLoad = useCallback(() => {
+    setLoadAttempt((n) => n + 1);
   }, []);
 
   // 用 ref 桥接最新的 dynamicCompletions，避免 prop 变化时 re-mount editor
@@ -156,7 +162,23 @@ export function CodeEditor({
   );
 
   if (monacoLoadError) {
-    throw monacoLoadError;
+    const message = monacoLoadError instanceof Error ? monacoLoadError.message : String(monacoLoadError);
+    return (
+      <div
+        className={`relative h-full w-full flex flex-col items-center justify-center gap-2 p-4 text-xs text-muted-foreground ${className ?? ""}`}
+        style={{ height }}
+      >
+        <div className="text-destructive">编辑器加载失败</div>
+        <div className="font-mono text-[11px] opacity-70 max-w-full truncate">{message}</div>
+        <button
+          type="button"
+          onClick={handleRetryLoad}
+          className="px-2 py-1 text-xs rounded border border-border hover:bg-accent"
+        >
+          重试
+        </button>
+      </div>
+    );
   }
 
   if (!monacoReady) {

--- a/frontend/src/components/ai/SideAssistantPanel.tsx
+++ b/frontend/src/components/ai/SideAssistantPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { lazy, Suspense, useRef, useState, useEffect } from "react";
 import { cn, useResizeHandle } from "@opskat/ui";
 import { useAIStore, type MentionRef } from "@/stores/aiStore";
 import { useFullscreen } from "@/hooks/useFullscreen";
@@ -6,9 +6,10 @@ import { SideAssistantHeader } from "./SideAssistantHeader";
 import { SideAssistantContextBar } from "./SideAssistantContextBar";
 import { SideAssistantHistoryDropdown } from "./SideAssistantHistoryDropdown";
 import { SideAssistantTabBar } from "./SideAssistantTabBar";
-import { AIChatContent } from "./AIChatContent";
 import { Trans } from "react-i18next";
-import { History } from "lucide-react";
+import { History, Loader2 } from "lucide-react";
+
+const AIChatContent = lazy(() => import("./AIChatContent").then((m) => ({ default: m.AIChatContent })));
 
 interface SideAssistantPanelProps {
   collapsed: boolean;
@@ -198,13 +199,21 @@ export function SideAssistantPanel({ collapsed, onToggle }: SideAssistantPanelPr
               </div>
             ) : (
               <div className="flex-1 min-h-0 flex flex-col">
-                <AIChatContent
-                  sideTabId={activeSidebarTab.id}
-                  conversationId={activeConversationId}
-                  compact
-                  onSendOverride={handleSendOverride}
-                  onStopOverride={handleStopOverride}
-                />
+                <Suspense
+                  fallback={
+                    <div className="flex h-full items-center justify-center">
+                      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                    </div>
+                  }
+                >
+                  <AIChatContent
+                    sideTabId={activeSidebarTab.id}
+                    conversationId={activeConversationId}
+                    compact
+                    onSendOverride={handleSendOverride}
+                    onStopOverride={handleStopOverride}
+                  />
+                </Suspense>
               </div>
             )}
           </div>

--- a/frontend/src/components/layout/MainPanel.tsx
+++ b/frontend/src/components/layout/MainPanel.tsx
@@ -1,23 +1,9 @@
+import { lazy, Suspense, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import logoLight from "@/assets/images/logo.png";
 import logoDark from "@/assets/images/logo-dark.png";
 import { useFullscreen } from "@/hooks/useFullscreen";
-import { AssetDetail } from "@/components/asset/AssetDetail";
-import { GroupDetail } from "@/components/asset/GroupDetail";
-import { SplitPane } from "@/components/terminal/SplitPane";
-import { SessionToolbar } from "@/components/terminal/SessionToolbar";
-import { TerminalToolbar } from "@/components/terminal/TerminalToolbar";
-import { FileManagerPanel } from "@/components/terminal/FileManagerPanel";
-import { SettingsPage } from "@/components/settings/SettingsPage";
-import { CredentialManager } from "@/components/settings/CredentialManager";
-import { AuditLogPage } from "@/components/audit/AuditLogPage";
-import { PortForwardPage } from "@/components/forward/PortForwardPage";
-import { SnippetsPage } from "@/components/snippet/SnippetsPage";
-import { AIChatContent } from "@/components/ai/AIChatContent";
-import { DatabasePanel } from "@/components/query/DatabasePanel";
-import { RedisPanel } from "@/components/query/RedisPanel";
-import { MongoDBPanel } from "@/components/query/MongoDBPanel";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { useTabStore, type QueryTabMeta, type PageTabMeta, type InfoTabMeta } from "@/stores/tabStore";
@@ -29,12 +15,54 @@ import { TopTabBar } from "./TopTabBar";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { CommandPalette } from "@/components/command/CommandPalette";
 
+const AssetDetail = lazy(() => import("@/components/asset/AssetDetail").then((m) => ({ default: m.AssetDetail })));
+const GroupDetail = lazy(() => import("@/components/asset/GroupDetail").then((m) => ({ default: m.GroupDetail })));
+const SplitPane = lazy(() => import("@/components/terminal/SplitPane").then((m) => ({ default: m.SplitPane })));
+const SessionToolbar = lazy(() =>
+  import("@/components/terminal/SessionToolbar").then((m) => ({ default: m.SessionToolbar }))
+);
+const TerminalToolbar = lazy(() =>
+  import("@/components/terminal/TerminalToolbar").then((m) => ({ default: m.TerminalToolbar }))
+);
+const FileManagerPanel = lazy(() =>
+  import("@/components/terminal/FileManagerPanel").then((m) => ({ default: m.FileManagerPanel }))
+);
+const SettingsPage = lazy(() =>
+  import("@/components/settings/SettingsPage").then((m) => ({ default: m.SettingsPage }))
+);
+const CredentialManager = lazy(() =>
+  import("@/components/settings/CredentialManager").then((m) => ({ default: m.CredentialManager }))
+);
+const AuditLogPage = lazy(() => import("@/components/audit/AuditLogPage").then((m) => ({ default: m.AuditLogPage })));
+const PortForwardPage = lazy(() =>
+  import("@/components/forward/PortForwardPage").then((m) => ({ default: m.PortForwardPage }))
+);
+const SnippetsPage = lazy(() => import("@/components/snippet/SnippetsPage").then((m) => ({ default: m.SnippetsPage })));
+const AIChatContent = lazy(() => import("@/components/ai/AIChatContent").then((m) => ({ default: m.AIChatContent })));
+const DatabasePanel = lazy(() =>
+  import("@/components/query/DatabasePanel").then((m) => ({ default: m.DatabasePanel }))
+);
+const RedisPanel = lazy(() => import("@/components/query/RedisPanel").then((m) => ({ default: m.RedisPanel })));
+const MongoDBPanel = lazy(() => import("@/components/query/MongoDBPanel").then((m) => ({ default: m.MongoDBPanel })));
+
 interface MainPanelProps {
   onEditAsset: (asset: asset_entity.Asset) => void;
   onDeleteAsset: (id: number) => void;
   onConnectAsset: (asset: asset_entity.Asset) => void;
   commandOpen: boolean;
   setCommandOpen: (open: boolean) => void;
+}
+
+function PanelFallback() {
+  return (
+    <div className="flex h-full items-center justify-center bg-background">
+      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
+
+function LazySurface({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<PanelFallback />}>{children}</Suspense>;
 }
 
 export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset, commandOpen, setCommandOpen }: MainPanelProps) {
@@ -207,31 +235,33 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset, commandO
                 pointerEvents: isActive ? "auto" : "none",
               }}
             >
-              <SessionToolbar tabId={tab.id} />
-              <div className="flex-1 min-h-0 overflow-hidden flex">
-                <div className="flex-1 min-w-0 overflow-hidden">
-                  {data && (
-                    <SplitPane
-                      node={data.splitTree}
+              <LazySurface>
+                <SessionToolbar tabId={tab.id} />
+                <div className="flex-1 min-h-0 overflow-hidden flex">
+                  <div className="flex-1 min-w-0 overflow-hidden">
+                    {data && (
+                      <SplitPane
+                        node={data.splitTree}
+                        tabId={tab.id}
+                        isTabActive={isActive}
+                        activePaneId={data.activePaneId}
+                        showFocusRing={data.splitTree.type === "split"}
+                        path={[]}
+                      />
+                    )}
+                  </div>
+                  {data?.activePaneId && (
+                    <FileManagerPanel
                       tabId={tab.id}
-                      isTabActive={isActive}
-                      activePaneId={data.activePaneId}
-                      showFocusRing={data.splitTree.type === "split"}
-                      path={[]}
+                      sessionId={data.activePaneId}
+                      isOpen={!!fileManagerOpenTabs[tab.id]}
+                      width={fileManagerWidth}
+                      onWidthChange={setFileManagerWidth}
                     />
                   )}
                 </div>
-                {data?.activePaneId && (
-                  <FileManagerPanel
-                    tabId={tab.id}
-                    sessionId={data.activePaneId}
-                    isOpen={!!fileManagerOpenTabs[tab.id]}
-                    width={fileManagerWidth}
-                    onWidthChange={setFileManagerWidth}
-                  />
-                )}
-              </div>
-              <TerminalToolbar tabId={tab.id} />
+                <TerminalToolbar tabId={tab.id} />
+              </LazySurface>
             </div>
           );
         })}
@@ -248,13 +278,17 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset, commandO
                 pointerEvents: isActive ? "auto" : "none",
               }}
             >
-              <AIChatContent tabId={tab.id} />
+              <LazySurface>
+                <AIChatContent tabId={tab.id} />
+              </LazySurface>
             </div>
           );
         })}
 
         {activeTab && activeTab.type === "page" && (
-          <div className="absolute inset-0 bg-background">{renderActiveContent()}</div>
+          <div className="absolute inset-0 bg-background">
+            <LazySurface>{renderActiveContent()}</LazySurface>
+          </div>
         )}
         {/* Query tabs: display-based — sticky thead would leak as a composited
             layer if the parent only toggled visibility. State is in zustand,
@@ -268,20 +302,24 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset, commandO
               className="absolute inset-0 bg-background"
               style={{ display: isActive ? "block" : "none" }}
             >
-              {meta.assetType === "database" ? (
-                <DatabasePanel tabId={tab.id} />
-              ) : meta.assetType === "redis" ? (
-                <RedisPanel tabId={tab.id} />
-              ) : (
-                <MongoDBPanel tabId={tab.id} />
-              )}
+              <LazySurface>
+                {meta.assetType === "database" ? (
+                  <DatabasePanel tabId={tab.id} />
+                ) : meta.assetType === "redis" ? (
+                  <RedisPanel tabId={tab.id} />
+                ) : (
+                  <MongoDBPanel tabId={tab.id} />
+                )}
+              </LazySurface>
             </div>
           );
         })}
 
         {/* Page and info tabs: rendered only when active */}
         {activeTab && activeTab.type === "info" && (
-          <div className="absolute inset-0 bg-background">{renderActiveContent()}</div>
+          <div className="absolute inset-0 bg-background">
+            <LazySurface>{renderActiveContent()}</LazySurface>
+          </div>
         )}
 
         {/* Welcome screen when no active tab */}

--- a/frontend/src/components/query/MongoDBPanel.tsx
+++ b/frontend/src/components/query/MongoDBPanel.tsx
@@ -14,6 +14,7 @@ import { ExecuteMongo } from "../../../wailsjs/go/app/App";
 import { CodeEditor } from "@/components/CodeEditor";
 import { SnippetPopover } from "@/components/snippet/SnippetPopover";
 import { parseMongosh, type ParsedMongosh } from "@/lib/mongosh-parser";
+import type { DynamicCompletionGetter } from "@/lib/monaco-completions";
 
 interface MongoDBPanelProps {
   tabId: string;
@@ -526,13 +527,8 @@ function MongoQueryContent({ tabId, assetId, innerTab }: MongoQueryContentProps)
     return mongoState.collections[database] ?? [];
   }, [database, mongoState]);
 
-  const dynamicCompletions = useCallback(
-    (ctx: {
-      monaco: typeof MonacoNS;
-      range: MonacoNS.IRange;
-      model: MonacoNS.editor.ITextModel;
-      position: MonacoNS.Position;
-    }) => {
+  const dynamicCompletions = useCallback<DynamicCompletionGetter>(
+    (ctx) => {
       const line = ctx.model.getLineContent(ctx.position.lineNumber);
       const before = line.slice(0, ctx.position.column - 1);
       const items: MonacoNS.languages.CompletionItem[] = [];

--- a/frontend/src/components/snippet/SnippetAssetDrawer.tsx
+++ b/frontend/src/components/snippet/SnippetAssetDrawer.tsx
@@ -4,6 +4,7 @@ import { Play, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@opskat/ui";
 import { AssetMultiSelect } from "@/components/asset/AssetMultiSelect";
+import { filterAssetTreeAssets } from "@/lib/assetTree";
 import { useAssetStore } from "@/stores/assetStore";
 import { useSnippetStore } from "@/stores/snippetStore";
 import { snippet_entity } from "../../../wailsjs/go/models";
@@ -25,7 +26,7 @@ export function SnippetAssetDrawer({ snippet, onClose }: SnippetAssetDrawerProps
   const assetType = category?.assetType ?? "";
 
   const matchingAssetIds = useMemo(
-    () => new Set(allAssets.filter((a) => a.Type === assetType && a.Status === 1).map((a) => a.ID)),
+    () => new Set(filterAssetTreeAssets(allAssets, { filterType: assetType, activeOnly: true }).map((a) => a.ID)),
     [allAssets, assetType]
   );
 

--- a/frontend/src/lib/assetSearch.ts
+++ b/frontend/src/lib/assetSearch.ts
@@ -1,29 +1,8 @@
 import { pinyinMatch } from "./pinyin";
+import { buildGroupPathMap } from "./groupPath";
 import type { asset_entity, group_entity } from "../../wailsjs/go/models";
 
-/** 把 group 列表解析为 groupId → "父/子/孙" 路径映射。 */
-export function buildGroupPathMap(groups: group_entity.Group[]): Map<number, string> {
-  const byId = new Map<number, group_entity.Group>();
-  for (const g of groups) byId.set(g.ID, g);
-  const cache = new Map<number, string>();
-  // visiting 用于检测 parent 链成环（DB 异常或直接改写可能造成），避免爆栈
-  const visiting = new Set<number>();
-  const resolve = (id: number): string => {
-    if (cache.has(id)) return cache.get(id)!;
-    if (visiting.has(id)) return "";
-    const g = byId.get(id);
-    if (!g) return "";
-    visiting.add(id);
-    const parent = g.ParentID ? resolve(g.ParentID) : "";
-    visiting.delete(id);
-    const full = parent ? `${parent}/${g.Name}` : g.Name;
-    cache.set(id, full);
-    return full;
-  };
-  const map = new Map<number, string>();
-  for (const g of groups) map.set(g.ID, resolve(g.ID));
-  return map;
-}
+export { buildGroupPathMap } from "./groupPath";
 
 export interface FilteredAsset {
   asset: asset_entity.Asset;

--- a/frontend/src/lib/assetTree.ts
+++ b/frontend/src/lib/assetTree.ts
@@ -26,15 +26,38 @@ export const defaultGroupIcon: ReactNode = createElement(Folder, { className: IC
  * from its entity's `Icon` field (via getIconComponent/getIconColor) with a fallback
  * to Server / Folder when no icon is configured.
  */
-export function buildAssetTree(assets: asset_entity.Asset[], groups: group_entity.Group[]): TreeNode[] {
+export function buildAssetTree(
+  assets: asset_entity.Asset[],
+  groups: group_entity.Group[],
+  options: UseAssetTreeOptions = {}
+): TreeNode[] {
+  const visibleAssets = filterAssetTreeAssets(assets, options);
+  const groupsByParent = new Map<number, group_entity.Group[]>();
+  const assetsByGroup = new Map<number, asset_entity.Asset[]>();
+
+  for (const group of groups) {
+    const parentId = group.ParentID || 0;
+    const siblings = groupsByParent.get(parentId) ?? [];
+    siblings.push(group);
+    groupsByParent.set(parentId, siblings);
+  }
+
+  for (const asset of visibleAssets) {
+    const groupId = asset.GroupID || 0;
+    const siblings = assetsByGroup.get(groupId) ?? [];
+    siblings.push(asset);
+    assetsByGroup.set(groupId, siblings);
+  }
+
   const visit = (parentId: number): TreeNode[] =>
-    groups
-      .filter((g) => (g.ParentID || 0) === parentId)
+    (groupsByParent.get(parentId) ?? [])
       .map((g) => {
         const childGroups = visit(g.ID);
-        const childAssets: TreeNode[] = assets
-          .filter((a) => a.GroupID === g.ID)
-          .map((a) => ({ id: a.ID, label: a.Name, icon: renderEntityIcon(a.Icon, Server) }));
+        const childAssets: TreeNode[] = (assetsByGroup.get(g.ID) ?? []).map((a) => ({
+          id: a.ID,
+          label: a.Name,
+          icon: renderEntityIcon(a.Icon, Server),
+        }));
         return {
           id: -g.ID,
           label: g.Name,
@@ -46,8 +69,7 @@ export function buildAssetTree(assets: asset_entity.Asset[], groups: group_entit
       .filter((g) => g.children && g.children.length > 0);
 
   const nodes: TreeNode[] = visit(0);
-  const ungrouped = assets.filter((a) => !a.GroupID || a.GroupID === 0);
-  for (const a of ungrouped) {
+  for (const a of assetsByGroup.get(0) ?? []) {
     nodes.push({ id: a.ID, label: a.Name, icon: renderEntityIcon(a.Icon, Server) });
   }
   return nodes;
@@ -67,9 +89,23 @@ export interface UseAssetTreeOptions {
   /** Filter assets by type (e.g. "ssh"). */
   filterType?: string;
   /** Asset IDs to exclude (e.g. exclude self for jump host selection). */
-  excludeIds?: number[];
+  excludeIds?: Iterable<number>;
   /** Only include assets with Status === 1. */
   activeOnly?: boolean;
+}
+
+/** Shared asset filtering for tree/picker UIs. Keep status/type/exclude semantics in one place. */
+export function filterAssetTreeAssets(
+  assets: asset_entity.Asset[],
+  { filterType, excludeIds, activeOnly }: UseAssetTreeOptions = {}
+): asset_entity.Asset[] {
+  const exclude = excludeIds ? new Set(excludeIds) : undefined;
+  return assets.filter((asset) => {
+    if (activeOnly && asset.Status !== 1) return false;
+    if (filterType && asset.Type !== filterType) return false;
+    if (exclude?.has(asset.ID)) return false;
+    return true;
+  });
 }
 
 /**
@@ -80,15 +116,10 @@ export interface UseAssetTreeOptions {
 export function useAssetTree({ filterType, excludeIds, activeOnly }: UseAssetTreeOptions = {}): TreeNode[] {
   const { assets, groups } = useAssetStore();
 
-  const filtered = useMemo(() => {
-    let list = assets;
-    if (activeOnly) list = list.filter((a) => a.Status === 1);
-    if (filterType) list = list.filter((a) => a.Type === filterType);
-    if (excludeIds?.length) list = list.filter((a) => !excludeIds.includes(a.ID));
-    return list;
-  }, [assets, filterType, excludeIds, activeOnly]);
-
-  return useMemo(() => buildAssetTree(filtered, groups), [filtered, groups]);
+  return useMemo(
+    () => buildAssetTree(assets, groups, { filterType, excludeIds, activeOnly }),
+    [assets, groups, filterType, excludeIds, activeOnly]
+  );
 }
 
 export interface UseGroupTreeOptions {

--- a/frontend/src/lib/groupPath.ts
+++ b/frontend/src/lib/groupPath.ts
@@ -1,0 +1,68 @@
+import type { asset_entity, group_entity } from "../../wailsjs/go/models";
+
+interface GroupPathOptions {
+  separator?: string;
+}
+
+const DEFAULT_SEPARATOR = "/";
+
+function buildGroupLookup(groups: group_entity.Group[]): Map<number, group_entity.Group> {
+  const byId = new Map<number, group_entity.Group>();
+  for (const group of groups) byId.set(group.ID, group);
+  return byId;
+}
+
+function resolveGroupPathFromLookup(
+  byId: Map<number, group_entity.Group>,
+  groupId: number | undefined,
+  separator: string
+): string {
+  if (!groupId) return "";
+
+  const names: string[] = [];
+  const seen = new Set<number>();
+  let currentId = groupId;
+
+  while (currentId > 0) {
+    if (seen.has(currentId)) break;
+    seen.add(currentId);
+
+    const group = byId.get(currentId);
+    if (!group) break;
+
+    names.unshift(group.Name);
+    currentId = group.ParentID || 0;
+  }
+
+  return names.join(separator);
+}
+
+export function resolveGroupPath(
+  groups: group_entity.Group[],
+  groupId: number | undefined,
+  { separator = DEFAULT_SEPARATOR }: GroupPathOptions = {}
+): string {
+  return resolveGroupPathFromLookup(buildGroupLookup(groups), groupId, separator);
+}
+
+/** 把 group 列表解析为 groupId -> "父/子/孙" 路径映射。异常 parent 环会在当前视角截断，避免缓存污染。 */
+export function buildGroupPathMap(
+  groups: group_entity.Group[],
+  { separator = DEFAULT_SEPARATOR }: GroupPathOptions = {}
+): Map<number, string> {
+  const byId = buildGroupLookup(groups);
+  const map = new Map<number, string>();
+  for (const group of groups) {
+    map.set(group.ID, resolveGroupPathFromLookup(byId, group.ID, separator));
+  }
+  return map;
+}
+
+export function formatAssetPath(
+  asset: asset_entity.Asset,
+  groups: group_entity.Group[],
+  { separator = DEFAULT_SEPARATOR }: GroupPathOptions = {}
+): string {
+  const groupPath = resolveGroupPath(groups, asset.GroupID, { separator });
+  return groupPath ? `${groupPath}${separator}${asset.Name}` : asset.Name;
+}

--- a/frontend/src/lib/monaco-completions.ts
+++ b/frontend/src/lib/monaco-completions.ts
@@ -7,11 +7,13 @@
 //
 // 该模块只能被 import 一次（registerCompletions 内部做了幂等保护）。
 //
-import * as monaco from "monaco-editor";
 import type * as MonacoNS from "monaco-editor";
+import type * as MonacoRuntimeNS from "monaco-editor/esm/vs/editor/editor.api.js";
+
+type MonacoRuntime = typeof MonacoRuntimeNS;
 
 export type CompletionContext = {
-  monaco: typeof MonacoNS;
+  monaco: MonacoRuntime;
   range: MonacoNS.IRange;
   model: MonacoNS.editor.ITextModel;
   position: MonacoNS.Position;
@@ -195,7 +197,7 @@ const MONGO_OPERATORS: MongoOp[] = [
 
 let registered = false;
 
-export function registerCompletions(): void {
+export function registerCompletions(monaco: MonacoRuntime): void {
   if (registered) return;
   registered = true;
 
@@ -238,8 +240,8 @@ export function registerCompletions(): void {
     },
   });
 
-  // Mongo 查询通常用 javascript 模式（用户当前已选 js 高亮）。这里追加 $operators，
-  // monaco 会与 ts.worker 自带补全合并。
+  // Mongo 查询通常用 javascript 模式（用户当前已选 js 高亮）。这里追加 $operators。
+  // 当前只加载基础 javascript 语言包，不启用体积较大的 TypeScript worker。
   monaco.languages.registerCompletionItemProvider("javascript", {
     triggerCharacters: ["$", "."],
     provideCompletionItems(model, position) {
@@ -267,9 +269,8 @@ export function registerCompletions(): void {
     },
   });
 
-  // mongo 查询体作为 JS 解析时，顶层 {...} 会被当作 block + label，
-  // ts.worker 容易标红。关掉语义校验（保留语法校验）。
-  // 0.55 把 typescript 子模块标 deprecated 但运行时仍存在；用宽松类型访问。
+  // 如果未来重新启用 TypeScript language service，mongo 查询体作为 JS 解析时，
+  // 顶层 {...} 会被当作 block + label，容易误报。这里保留兼容逻辑。
   const tsLang = (
     monaco.languages as unknown as {
       typescript?: { javascriptDefaults?: { setDiagnosticsOptions?: (o: unknown) => void } };

--- a/frontend/src/lib/monaco-setup.ts
+++ b/frontend/src/lib/monaco-setup.ts
@@ -16,7 +16,6 @@ let configured = false;
 
 export function setupMonaco(): void {
   if (configured) return;
-  configured = true;
 
   // 用本地的 monaco，避免 @monaco-editor/react 默认走 CDN（在 Wails 环境会断网失败）
   self.MonacoEnvironment = {
@@ -60,4 +59,7 @@ export function setupMonaco(): void {
 
   // 注册 SQL / JS(MongoDB) 的关键字、函数、snippet、operator 补全
   registerCompletions(monaco);
+
+  // 仅在全部步骤成功后置位，失败时下一次挂载可重试。
+  configured = true;
 }

--- a/frontend/src/lib/monaco-setup.ts
+++ b/frontend/src/lib/monaco-setup.ts
@@ -1,53 +1,63 @@
 // Monaco editor + Vite worker 装配。
-// 必须在任何 monaco 实例创建之前 import 一次（main.tsx 内）。
+// 由 CodeEditor 首次挂载时懒加载，避免把 Monaco 放进应用启动包。
 
-import * as monaco from "monaco-editor";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
+import "monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution";
+import "monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution";
+import "monaco-editor/esm/vs/basic-languages/shell/shell.contribution";
+import "monaco-editor/esm/vs/basic-languages/sql/sql.contribution";
+import "monaco-editor/esm/vs/language/json/monaco.contribution";
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
-import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 import { loader } from "@monaco-editor/react";
 import { registerCompletions } from "./monaco-completions";
 
-// 用本地的 monaco，避免 @monaco-editor/react 默认走 CDN（在 Wails 环境会断网失败）
-self.MonacoEnvironment = {
-  getWorker(_workerId, label) {
-    if (label === "json") return new jsonWorker();
-    if (label === "javascript" || label === "typescript") return new tsWorker();
-    return new editorWorker();
-  },
-};
+let configured = false;
 
-// 自定义主题：把 editor 自身的背景设为透明，让外层容器 bg-background 决定底色，
-// 这样 monaco 颜色能跟项目的浅色/深色主题（包括 oklch 自定义色）保持一致。
-const TRANSPARENT = "#00000000";
-monaco.editor.defineTheme("opskat-light", {
-  base: "vs",
-  inherit: true,
-  rules: [],
-  colors: {
-    "editor.background": TRANSPARENT,
-    "editorGutter.background": TRANSPARENT,
-    "editor.lineHighlightBackground": "#00000010",
-    "editor.lineHighlightBorder": TRANSPARENT,
-    "editorLineNumber.foreground": "#9ca3af",
-    "editorLineNumber.activeForeground": "#374151",
-  },
-});
-monaco.editor.defineTheme("opskat-dark", {
-  base: "vs-dark",
-  inherit: true,
-  rules: [],
-  colors: {
-    "editor.background": TRANSPARENT,
-    "editorGutter.background": TRANSPARENT,
-    "editor.lineHighlightBackground": "#ffffff10",
-    "editor.lineHighlightBorder": TRANSPARENT,
-    "editorLineNumber.foreground": "#6b7280",
-    "editorLineNumber.activeForeground": "#d1d5db",
-  },
-});
+export function setupMonaco(): void {
+  if (configured) return;
+  configured = true;
 
-loader.config({ monaco });
+  // 用本地的 monaco，避免 @monaco-editor/react 默认走 CDN（在 Wails 环境会断网失败）
+  self.MonacoEnvironment = {
+    getWorker(_workerId, label) {
+      if (label === "json") return new jsonWorker();
+      return new editorWorker();
+    },
+  };
 
-// 注册 SQL / JS(MongoDB) 的关键字、函数、snippet、operator 补全
-registerCompletions();
+  // 自定义主题：把 editor 自身的背景设为透明，让外层容器 bg-background 决定底色，
+  // 这样 monaco 颜色能跟项目的浅色/深色主题（包括 oklch 自定义色）保持一致。
+  const TRANSPARENT = "#00000000";
+  monaco.editor.defineTheme("opskat-light", {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": TRANSPARENT,
+      "editorGutter.background": TRANSPARENT,
+      "editor.lineHighlightBackground": "#00000010",
+      "editor.lineHighlightBorder": TRANSPARENT,
+      "editorLineNumber.foreground": "#9ca3af",
+      "editorLineNumber.activeForeground": "#374151",
+    },
+  });
+  monaco.editor.defineTheme("opskat-dark", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": TRANSPARENT,
+      "editorGutter.background": TRANSPARENT,
+      "editor.lineHighlightBackground": "#ffffff10",
+      "editor.lineHighlightBorder": TRANSPARENT,
+      "editorLineNumber.foreground": "#6b7280",
+      "editorLineNumber.activeForeground": "#d1d5db",
+    },
+  });
+
+  loader.config({ monaco });
+
+  // 注册 SQL / JS(MongoDB) 的关键字、函数、snippet、operator 补全
+  registerCompletions(monaco);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import "./i18n";
-import "./lib/monaco-setup";
 import "./styles/globals.css";
 import App from "./App";
 

--- a/frontend/src/stores/assetStore.ts
+++ b/frontend/src/stores/assetStore.ts
@@ -13,6 +13,7 @@ import {
   DeleteGroup,
 } from "../../wailsjs/go/app/App";
 import { useRecentAssetStore } from "./recentAssetStore";
+import { formatAssetPath } from "@/lib/groupPath";
 
 interface AssetState {
   assets: asset_entity.Asset[];
@@ -89,15 +90,7 @@ export const useAssetStore = create<AssetState>()(
 
       getAssetPath: (asset) => {
         const { groups } = get();
-        const parts: string[] = [asset.Name];
-        let groupId = asset.GroupID;
-        while (groupId > 0) {
-          const group = groups.find((g) => g.ID === groupId);
-          if (!group) break;
-          parts.unshift(group.Name);
-          groupId = group.ParentID;
-        }
-        return parts.join(" / ");
+        return formatAssetPath(asset, groups, { separator: " / " });
       },
 
       createGroup: async (group) => {

--- a/frontend/src/stores/terminalStore.ts
+++ b/frontend/src/stores/terminalStore.ts
@@ -14,7 +14,12 @@ import { EventsOn, EventsOff } from "../../wailsjs/runtime/runtime";
 import { bytesToBase64 } from "../lib/terminalEncode";
 import { useTabStore, registerTabCloseHook, registerTabRestoreHook, type TerminalTabMeta } from "./tabStore";
 import { useAssetStore } from "./assetStore";
-import { disposeTerminal } from "@/components/terminal/terminalRegistry";
+
+function disposeTerminalInstance(sessionId: string): void {
+  import("@/components/terminal/terminalRegistry")
+    .then(({ disposeTerminal }) => disposeTerminal(sessionId))
+    .catch((error) => console.error("Failed to dispose terminal instance:", error));
+}
 
 // Split tree types
 export type SplitNode =
@@ -493,7 +498,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     ConnectSSHAsync(req)
       .then((connectionId) => {
         // Dispose the old persistent xterm; the slot is replaced by a "connecting" node.
-        disposeTerminal(sessionId);
+        disposeTerminalInstance(sessionId);
         set((s) => {
           const d = s.tabData[tabId];
           if (!d) return s;
@@ -814,7 +819,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     }));
 
     // Drop the persistent xterm now that it's no longer in the tree.
-    disposeTerminal(sessionId);
+    disposeTerminalInstance(sessionId);
   },
 
   setSplitRatio: (tabId, path, ratio) => {
@@ -852,7 +857,7 @@ registerTabCloseHook((tab) => {
       if (pane.connected) {
         DisconnectSSH(pane.sessionId);
       }
-      disposeTerminal(pane.sessionId);
+      disposeTerminalInstance(pane.sessionId);
     }
   }
 

--- a/frontend/src/stores/terminalStore.ts
+++ b/frontend/src/stores/terminalStore.ts
@@ -18,7 +18,7 @@ import { useAssetStore } from "./assetStore";
 function disposeTerminalInstance(sessionId: string): void {
   import("@/components/terminal/terminalRegistry")
     .then(({ disposeTerminal }) => disposeTerminal(sessionId))
-    .catch((error) => console.error("Failed to dispose terminal instance:", error));
+    .catch((error) => console.error(`Failed to dispose terminal instance ${sessionId}:`, error));
 }
 
 // Split tree types


### PR DESCRIPTION
## 概要
- 抽取前端分组路径公共 helper，并复用到资产搜索和资产路径格式化逻辑中。
- 将资产选择器过滤逻辑集中到 `filterAssetTreeAssets`，并复用于资产树构建和片段资产选择。
- 将 opsctl 分组路径深度限制替换为带循环检测的路径解析，支持更深层级的分组结构。
- 增加分组父级循环、深层分组路径、资产树过滤、资产路径格式化等回归测试。
- 优化前端启动包体积：Monaco、xterm、AI 聊天、查询面板、设置页、审计页、片段页、资产详情页等重模块改为按需懒加载。
- 收窄 Monaco 打包范围，只加载 editor API 和必要语言 contribution，移除默认构建输出中的大型 TypeScript worker。
- 增加 bundle 边界回归测试，防止后续把重型前端模块重新静态引入启动路径。
- 更新 `CLAUDE.md` 仓库协作说明，强调根因修复和优先复用已有实现。

## 打包体积影响
- `frontend/dist`：约 16 MB → 7.5 MB
- 启动入口 `index-*.js`：6,469.49 kB / gzip 1,754.00 kB → 1,256.79 kB / gzip 422.04 kB
- 移除输出中的 `ts.worker-*.js`：6,977.88 kB / gzip 约 1,483 kB
- Monaco 现在按需加载为 `monaco-setup-*.js`：3,700.24 kB / gzip 933.82 kB

## 测试计划
- [x] `make test`
- [x] `cd frontend && pnpm test`
- [x] `cd frontend && pnpm lint`（通过，保留既有 warning：0 errors，32 warnings）
- [x] `cd frontend && pnpm build`
- [x] `cd frontend && pnpm exec vitest run src/__tests__/bundleBoundaries.test.ts`
- [x] `git diff --check origin/main...HEAD`