### PR TITLE
✨ 支持终端字体预设

### DIFF
--- a/frontend/src/__tests__/terminalFonts.test.ts
+++ b/frontend/src/__tests__/terminalFonts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveTerminalFontFamily, terminalFontPresets, withTerminalFontFallback } from "../data/terminalFonts";
+
+describe("terminalFonts", () => {
+  it("keeps font presets as static choices without system detection metadata", () => {
+    expect(terminalFontPresets.some((preset) => "systemFontNames" in preset)).toBe(false);
+  });
+
+  it("keeps preset values as the primary font only", () => {
+    expect(terminalFontPresets.find((preset) => preset.id === "fira-code")?.fontFamily).toBe("'Fira Code'");
+  });
+
+  it("uses the default font stack when the custom value is blank", () => {
+    expect(resolveTerminalFontFamily("  ")).toBe("'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace");
+  });
+
+  it("keeps custom font family values unexpanded for storage", () => {
+    expect(resolveTerminalFontFamily("Iosevka Term, monospace")).toBe("Iosevka Term, monospace");
+  });
+
+  it("adds shared fallbacks at terminal runtime without duplicating the primary font", () => {
+    expect(withTerminalFontFallback("'Fira Code'")).toBe(
+      "'Fira Code', 'JetBrains Mono', 'Cascadia Code', Menlo, monospace"
+    );
+  });
+
+  it("strips trailing generic families before adding runtime fallbacks", () => {
+    expect(withTerminalFontFallback("Iosevka Term, monospace")).toBe(
+      "Iosevka Term, 'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace"
+    );
+  });
+
+  it("uses the default runtime fallback when the runtime font value is blank", () => {
+    expect(withTerminalFontFallback("  ")).toBe("'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace");
+  });
+
+  it("does not duplicate the default runtime fallback stack", () => {
+    expect(resolveTerminalFontFamily("Iosevka Term, monospace")).toBe("Iosevka Term, monospace");
+    expect(withTerminalFontFallback("'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace")).toBe(
+      "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace"
+    );
+  });
+});

--- a/frontend/src/__tests__/terminalThemeStore.test.ts
+++ b/frontend/src/__tests__/terminalThemeStore.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { useTerminalThemeStore, SCROLLBACK_DEFAULT } from "../stores/terminalThemeStore";
 import { builtinThemes, type TerminalTheme } from "../data/terminalThemes";
 
+type TerminalThemeStoreState = ReturnType<typeof useTerminalThemeStore.getState>;
+
 function makeCustomTheme(id: string, name: string): TerminalTheme {
   return {
     id,
@@ -35,6 +37,9 @@ describe("terminalThemeStore", () => {
       selectedThemeId: "default",
       customThemes: [],
       fontSize: 14,
+      fontPresetId: "default",
+      customFontFamily: "",
+      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
       scrollback: SCROLLBACK_DEFAULT,
     });
   });
@@ -60,6 +65,38 @@ describe("terminalThemeStore", () => {
     it("clamps to maximum 32", () => {
       useTerminalThemeStore.getState().setFontSize(100);
       expect(useTerminalThemeStore.getState().fontSize).toBe(32);
+    });
+  });
+
+  describe("font presets", () => {
+    const defaultFontFamily = "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace";
+
+    it("defaults to the existing terminal font stack", () => {
+      expect(useTerminalThemeStore.getState().fontFamily).toBe(defaultFontFamily);
+    });
+
+    it("selects a known preset and applies its terminal font family", () => {
+      const state: TerminalThemeStoreState = useTerminalThemeStore.getState();
+
+      state.setFontPresetId("fira-code");
+
+      expect(useTerminalThemeStore.getState().fontPresetId).toBe("fira-code");
+      expect(useTerminalThemeStore.getState().fontFamily).toBe("'Fira Code'");
+    });
+
+    it("uses the edited custom font family and falls back when blank", () => {
+      const state: TerminalThemeStoreState = useTerminalThemeStore.getState();
+
+      state.setCustomFontFamily("  Iosevka Term, monospace  ");
+
+      expect(useTerminalThemeStore.getState().fontPresetId).toBe("custom");
+      expect(useTerminalThemeStore.getState().customFontFamily).toBe("Iosevka Term, monospace");
+      expect(useTerminalThemeStore.getState().fontFamily).toBe("Iosevka Term, monospace");
+
+      useTerminalThemeStore.getState().setCustomFontFamily("   ");
+
+      expect(useTerminalThemeStore.getState().customFontFamily).toBe("");
+      expect(useTerminalThemeStore.getState().fontFamily).toBe(defaultFontFamily);
     });
   });
 

--- a/frontend/src/components/settings/AppearanceSection.tsx
+++ b/frontend/src/components/settings/AppearanceSection.tsx
@@ -8,6 +8,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
   Card,
@@ -20,6 +21,11 @@ import { useTheme, useResolvedTheme } from "@/components/theme-provider";
 import { Plus, Pencil, Trash2 } from "lucide-react";
 import { useTerminalThemeStore, SCROLLBACK_MIN, SCROLLBACK_MAX } from "@/stores/terminalThemeStore";
 import { builtinThemes, defaultLightTheme, defaultDarkTheme, TerminalTheme } from "@/data/terminalThemes";
+import {
+  CUSTOM_TERMINAL_FONT_PRESET_ID,
+  DEFAULT_TERMINAL_FONT_PRESET_ID,
+  terminalFontPresets,
+} from "@/data/terminalFonts";
 import { TerminalThemeEditor } from "@/components/settings/TerminalThemeEditor";
 
 export function AppearanceSection() {
@@ -96,6 +102,10 @@ export function TerminalSection() {
     setSelectedThemeId,
     fontSize,
     setFontSize,
+    fontPresetId,
+    customFontFamily,
+    setFontPresetId,
+    setCustomFontFamily,
     scrollback,
     setScrollback,
     customThemes,
@@ -106,6 +116,10 @@ export function TerminalSection() {
   const resolvedTheme = useResolvedTheme();
   const [themeEditorOpen, setThemeEditorOpen] = useState(false);
   const [editingTheme, setEditingTheme] = useState<TerminalTheme | undefined>(undefined);
+  const fontSelectValue =
+    fontPresetId === CUSTOM_TERMINAL_FONT_PRESET_ID || terminalFontPresets.some((preset) => preset.id === fontPresetId)
+      ? fontPresetId
+      : DEFAULT_TERMINAL_FONT_PRESET_ID;
 
   return (
     <>
@@ -114,6 +128,34 @@ export function TerminalSection() {
           <CardTitle className="text-base">{t("terminal.title")}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          {/* Font family */}
+          <div className="grid gap-2">
+            <Label>{t("terminal.fontFamily")}</Label>
+            <Select value={fontSelectValue} onValueChange={setFontPresetId}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="min-w-[18rem]">
+                {terminalFontPresets.map((preset) => (
+                  <SelectItem key={preset.id} value={preset.id}>
+                    <span className="min-w-0 flex-1 truncate" style={{ fontFamily: preset.fontFamily }}>
+                      {preset.id === DEFAULT_TERMINAL_FONT_PRESET_ID ? t("terminal.defaultFont") : preset.name}
+                    </span>
+                  </SelectItem>
+                ))}
+                <SelectSeparator />
+                <SelectItem value={CUSTOM_TERMINAL_FONT_PRESET_ID}>{t("terminal.customFont")}</SelectItem>
+              </SelectContent>
+            </Select>
+            {fontPresetId === CUSTOM_TERMINAL_FONT_PRESET_ID && (
+              <Input
+                value={customFontFamily}
+                onChange={(e) => setCustomFontFamily(e.target.value)}
+                placeholder={t("terminal.customFontPlaceholder")}
+              />
+            )}
+          </div>
+
           {/* Font size */}
           <div className="grid gap-2">
             <Label>{t("terminal.fontSize")}</Label>

--- a/frontend/src/components/terminal/Terminal.tsx
+++ b/frontend/src/components/terminal/Terminal.tsx
@@ -7,6 +7,7 @@ import { useShortcutStore, matchShortcut, formatBinding, formatModKey } from "@/
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useTerminalThemeStore, toXtermTheme } from "@/stores/terminalThemeStore";
 import { builtinThemes, defaultLightTheme, defaultDarkTheme } from "@/data/terminalThemes";
+import { withTerminalFontFallback } from "@/data/terminalFonts";
 import { useResolvedTheme } from "@/components/theme-provider";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -45,6 +46,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   const [hasSelection, setHasSelection] = useState(false);
   const shortcuts = useShortcutStore((s) => s.shortcuts);
   const fontSize = useTerminalThemeStore((s) => s.fontSize);
+  const fontFamily = useTerminalThemeStore((s) => s.fontFamily);
   const scrollback = useTerminalThemeStore((s) => s.scrollback);
   const selectedThemeId = useTerminalThemeStore((s) => s.selectedThemeId);
   const customThemes = useTerminalThemeStore((s) => s.customThemes);
@@ -86,7 +88,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
 
-    const inst = getOrCreateTerminal(sessionId, { fontSize, theme: xtermTheme, scrollback });
+    const inst = getOrCreateTerminal(sessionId, { fontSize, fontFamily, theme: xtermTheme, scrollback });
     termRef.current = inst.term;
     fitAddonRef.current = inst.fitAddon;
     searchAddonRef.current = inst.searchAddon;
@@ -164,9 +166,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     if (!termRef.current) return;
     termRef.current.options.theme = xtermTheme;
     termRef.current.options.fontSize = fontSize;
+    termRef.current.options.fontFamily = withTerminalFontFallback(fontFamily);
     termRef.current.options.scrollback = scrollback;
     fitAddonRef.current?.fit();
-  }, [xtermTheme, fontSize, scrollback]);
+  }, [xtermTheme, fontSize, fontFamily, scrollback]);
 
   useEffect(() => {
     activeRef.current = active;

--- a/frontend/src/components/terminal/terminalRegistry.ts
+++ b/frontend/src/components/terminal/terminalRegistry.ts
@@ -6,6 +6,7 @@ import { WriteSSH } from "../../../wailsjs/go/app/App";
 import { EventsOn, EventsOff } from "../../../wailsjs/runtime/runtime";
 import { bytesToBase64 } from "@/lib/terminalEncode";
 import { useTerminalStore } from "@/stores/terminalStore";
+import { withTerminalFontFallback } from "@/data/terminalFonts";
 
 export interface TerminalInstance {
   term: XTerminal;
@@ -24,7 +25,7 @@ const registry = new Map<string, InternalInstance>();
 
 export function getOrCreateTerminal(
   sessionId: string,
-  init: { fontSize: number; theme?: ITheme; scrollback: number }
+  init: { fontSize: number; fontFamily: string; theme?: ITheme; scrollback: number }
 ): TerminalInstance {
   const cached = registry.get(sessionId);
   if (cached) return cached;
@@ -36,7 +37,7 @@ export function getOrCreateTerminal(
   const term = new XTerminal({
     cursorBlink: true,
     fontSize: init.fontSize,
-    fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
+    fontFamily: withTerminalFontFallback(init.fontFamily),
     theme: init.theme,
     scrollback: init.scrollback,
   });

--- a/frontend/src/data/terminalFonts.ts
+++ b/frontend/src/data/terminalFonts.ts
@@ -1,0 +1,159 @@
+export interface TerminalFontPreset {
+  id: string;
+  name: string;
+  fontFamily: string;
+}
+
+export const DEFAULT_TERMINAL_FONT_PRESET_ID = "default";
+export const CUSTOM_TERMINAL_FONT_PRESET_ID = "custom";
+export const DEFAULT_TERMINAL_FONT_FALLBACKS = [
+  "'JetBrains Mono'",
+  "'Fira Code'",
+  "'Cascadia Code'",
+  "Menlo",
+  "monospace",
+];
+export const DEFAULT_TERMINAL_FONT_FAMILY = DEFAULT_TERMINAL_FONT_FALLBACKS.join(", ");
+const TRAILING_GENERIC_FONT_FAMILY_RE = /(?:,\s*(?:ui-monospace|monospace|serif|sans-serif)\s*)+$/i;
+
+export const terminalFontPresets: TerminalFontPreset[] = [
+  {
+    id: DEFAULT_TERMINAL_FONT_PRESET_ID,
+    name: "Default",
+    fontFamily: DEFAULT_TERMINAL_FONT_FAMILY,
+  },
+  {
+    id: "jetbrains-mono",
+    name: "JetBrains Mono",
+    fontFamily: "'JetBrains Mono'",
+  },
+  {
+    id: "fira-code",
+    name: "Fira Code",
+    fontFamily: "'Fira Code'",
+  },
+  {
+    id: "cascadia-code",
+    name: "Cascadia Code",
+    fontFamily: "'Cascadia Code'",
+  },
+  {
+    id: "sf-mono",
+    name: "SF Mono",
+    fontFamily: "'SF Mono'",
+  },
+  {
+    id: "menlo",
+    name: "Menlo",
+    fontFamily: "Menlo",
+  },
+  {
+    id: "monaco",
+    name: "Monaco",
+    fontFamily: "Monaco",
+  },
+  {
+    id: "consolas",
+    name: "Consolas",
+    fontFamily: "Consolas",
+  },
+  {
+    id: "source-code-pro",
+    name: "Source Code Pro",
+    fontFamily: "'Source Code Pro'",
+  },
+  {
+    id: "hack",
+    name: "Hack",
+    fontFamily: "Hack",
+  },
+  {
+    id: "ibm-plex-mono",
+    name: "IBM Plex Mono",
+    fontFamily: "'IBM Plex Mono'",
+  },
+  {
+    id: "roboto-mono",
+    name: "Roboto Mono",
+    fontFamily: "'Roboto Mono'",
+  },
+  {
+    id: "noto-sans-mono",
+    name: "Noto Sans Mono",
+    fontFamily: "'Noto Sans Mono'",
+  },
+  {
+    id: "ubuntu-mono",
+    name: "Ubuntu Mono",
+    fontFamily: "'Ubuntu Mono'",
+  },
+  {
+    id: "dejavu-sans-mono",
+    name: "DejaVu Sans Mono",
+    fontFamily: "'DejaVu Sans Mono'",
+  },
+];
+
+export function normalizeTerminalFontFamily(fontFamily: string): string {
+  return fontFamily.trim();
+}
+
+export function resolveTerminalFontFamily(fontFamily: string): string {
+  const normalized = normalizeTerminalFontFamily(fontFamily);
+  return normalized || DEFAULT_TERMINAL_FONT_FAMILY;
+}
+
+function splitFontFamilyList(fontFamily: string): string[] {
+  const families: string[] = [];
+  let current = "";
+  let quote: string | undefined;
+
+  for (const char of fontFamily) {
+    if ((char === "'" || char === '"') && !quote) {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (char === quote) {
+      quote = undefined;
+      current += char;
+      continue;
+    }
+    if (char === "," && !quote) {
+      const family = current.trim();
+      if (family) families.push(family);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+
+  const family = current.trim();
+  if (family) families.push(family);
+  return families;
+}
+
+function normalizeFontFamilyToken(fontFamily: string): string {
+  return fontFamily
+    .trim()
+    .replace(/^['"]|['"]$/g, "")
+    .toLowerCase();
+}
+
+export function withTerminalFontFallback(fontFamily: string): string {
+  const normalized = normalizeTerminalFontFamily(fontFamily);
+  if (!normalized || normalized === DEFAULT_TERMINAL_FONT_FAMILY) return DEFAULT_TERMINAL_FONT_FAMILY;
+
+  const primaryFontFamily = normalized.replace(TRAILING_GENERIC_FONT_FAMILY_RE, "").trim() || normalized;
+  const primaryFonts = splitFontFamilyList(primaryFontFamily);
+  const usedFontNames = new Set(primaryFonts.map(normalizeFontFamilyToken));
+  const fallbackFonts = DEFAULT_TERMINAL_FONT_FALLBACKS.filter(
+    (fallbackFont) => !usedFontNames.has(normalizeFontFamilyToken(fallbackFont))
+  );
+
+  return [...primaryFonts, ...fallbackFonts].join(", ");
+}
+
+export function findTerminalFontPreset(id: string): TerminalFontPreset | undefined {
+  return terminalFontPresets.find((preset) => preset.id === id);
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -774,6 +774,10 @@
   "terminal": {
     "title": "Terminal",
     "desc": "Terminal color scheme and font settings",
+    "fontFamily": "Font",
+    "defaultFont": "Default Font",
+    "customFont": "Custom",
+    "customFontPlaceholder": "Enter font-family, e.g. Iosevka Term, monospace",
     "fontSize": "Font Size",
     "scrollback": "Scrollback",
     "scrollbackUnit": "lines",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -774,6 +774,10 @@
   "terminal": {
     "title": "终端",
     "desc": "终端配色与字体设置",
+    "fontFamily": "字体",
+    "defaultFont": "默认字体",
+    "customFont": "自定义",
+    "customFontPlaceholder": "输入 font-family，例如 Iosevka Term, monospace",
     "fontSize": "字体大小",
     "scrollback": "回滚缓冲区",
     "scrollbackUnit": "行",

--- a/frontend/src/stores/terminalThemeStore.ts
+++ b/frontend/src/stores/terminalThemeStore.ts
@@ -1,6 +1,14 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { TerminalTheme, builtinThemes } from "@/data/terminalThemes";
+import {
+  CUSTOM_TERMINAL_FONT_PRESET_ID,
+  DEFAULT_TERMINAL_FONT_FAMILY,
+  DEFAULT_TERMINAL_FONT_PRESET_ID,
+  findTerminalFontPreset,
+  normalizeTerminalFontFamily,
+  resolveTerminalFontFamily,
+} from "@/data/terminalFonts";
 
 export const SCROLLBACK_MIN = 100;
 export const SCROLLBACK_MAX = 1000000;
@@ -10,10 +18,15 @@ interface TerminalThemeState {
   selectedThemeId: string;
   customThemes: TerminalTheme[];
   fontSize: number;
+  fontPresetId: string;
+  customFontFamily: string;
+  fontFamily: string;
   scrollback: number;
 
   setSelectedThemeId: (id: string) => void;
   setFontSize: (size: number) => void;
+  setFontPresetId: (id: string) => void;
+  setCustomFontFamily: (fontFamily: string) => void;
   setScrollback: (lines: number) => void;
   addCustomTheme: (theme: TerminalTheme) => void;
   updateCustomTheme: (theme: TerminalTheme) => void;
@@ -27,11 +40,43 @@ export const useTerminalThemeStore = create<TerminalThemeState>()(
       selectedThemeId: "default",
       customThemes: [],
       fontSize: 14,
+      fontPresetId: DEFAULT_TERMINAL_FONT_PRESET_ID,
+      customFontFamily: "",
+      fontFamily: DEFAULT_TERMINAL_FONT_FAMILY,
       scrollback: SCROLLBACK_DEFAULT,
 
       setSelectedThemeId: (id) => set({ selectedThemeId: id }),
 
       setFontSize: (size) => set({ fontSize: Math.max(8, Math.min(32, size)) }),
+
+      setFontPresetId: (id) => {
+        if (id === CUSTOM_TERMINAL_FONT_PRESET_ID) {
+          const customFontFamily = normalizeTerminalFontFamily(get().customFontFamily);
+          set({
+            fontPresetId: CUSTOM_TERMINAL_FONT_PRESET_ID,
+            customFontFamily,
+            fontFamily: resolveTerminalFontFamily(customFontFamily),
+          });
+          return;
+        }
+
+        const preset = findTerminalFontPreset(id) || findTerminalFontPreset(DEFAULT_TERMINAL_FONT_PRESET_ID);
+        if (!preset) return;
+
+        set({
+          fontPresetId: preset.id,
+          fontFamily: preset.fontFamily,
+        });
+      },
+
+      setCustomFontFamily: (fontFamily) => {
+        const customFontFamily = normalizeTerminalFontFamily(fontFamily);
+        set({
+          fontPresetId: CUSTOM_TERMINAL_FONT_PRESET_ID,
+          customFontFamily,
+          fontFamily: resolveTerminalFontFamily(customFontFamily),
+        });
+      },
 
       setScrollback: (lines) => {
         const n = Number.isFinite(lines) ? Math.floor(lines) : SCROLLBACK_DEFAULT;


### PR DESCRIPTION
## Summary
- Add terminal font presets and a custom font-family input above terminal font size settings.
- Persist the selected/custom font in the terminal theme store while applying default runtime fallbacks in xterm.
- Cover preset, custom, and fallback behavior with frontend tests.

Refs #65

## Test Plan
- [x] pnpm test -- src/__tests__/terminalFonts.test.ts src/__tests__/terminalThemeStore.test.ts
- [x] pnpm lint
- [x] pnpm build