### PR TITLE
修复 SSH 登录提示被隐藏

### DIFF
--- a/docs/superpowers/plans/2026-04-30-ssh-lazy-sync-injection.md
+++ b/docs/superpowers/plans/2026-04-30-ssh-lazy-sync-injection.md
@@ -1,0 +1,888 @@
+# SSH Lazy Sync Injection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the server-native `Last login` / motd / banner output on SSH terminal connect by removing the unconditional shell wrapper. Move directory-sync hook setup from session start to on-demand injection triggered by the user's first sync action (F→T / T→F / always-follow toggle).
+
+**Architecture:** `createSession` always opens via `session.Shell()` (SSH `shell` request, sshd emits banner natively). `Session` records the detected shell type but starts with `Supported=false`. New `Session.EnableSync()` writes a single-line hook installer to stdin (function definitions + `PROMPT_COMMAND`/`precmd`/`PS1` hook + `init:pid` marker), then waits for the marker and the first prompt nonce within a timeout to confirm bootstrap. `App.ChangeSSHDirectory` auto-enables sync if not yet supported. Frontend F→T flow lazy-enables on first click; T→F flow relies on backend auto-enable.
+
+**Tech Stack:** Go 1.25, `golang.org/x/crypto/ssh`, Wails v2 IPC, React 19, Zustand, goconvey/testify, Vitest.
+
+---
+
+## File Structure
+
+- Modify `internal/service/ssh_svc/dirsync_shell.go`: split `buildInteractiveShellCommand` into `buildEnableSyncCommand` (single-line stdin command, not a wrapping shell) + `buildDisableSyncCommand`.
+- Modify `internal/service/ssh_svc/ssh.go`:
+  - `Session` struct gains `shellPath` / `shellType` fields persisted at session creation.
+  - `createSession` removes the `Start(wrapperCmd)` branch — always calls `session.Shell()`. Drops eager `syncToken` / `promptNonce` generation.
+  - Adds `(*Manager).enableSyncForSession` shim (or move logic onto Session).
+- Modify `internal/service/ssh_svc/dirsync.go`: add `(*Session).EnableSync(ctx) error` and `(*Session).DisableSync()` methods. `EnableSync` is idempotent and serialized via `syncMu`.
+- Modify `internal/app/app_ssh.go`:
+  - `ChangeSSHDirectory` auto-calls `EnableSync` when `!Supported`.
+  - Add `EnableSSHSync(sessionID) error` Wails binding for explicit F→T.
+- Modify `internal/service/ssh_svc/ssh_test.go` and add `dirsync_shell_test.go`: cover new builders and bootstrap flow.
+- Regenerate `frontend/wailsjs/go/app/App.{d.ts,js}` via `make dev` once binding is added.
+- Modify `frontend/src/components/terminal/file-manager/useTerminalDirectorySync.ts`: F→T (`syncPanelFromTerminal`) lazy-calls `EnableSSHSync` when state is `unsupported`/missing.
+- Optionally modify `frontend/src/components/terminal/TerminalToolbar.tsx` (or wherever the sync indicator lives) to surface "正在启用目录同步…" / "请退出当前程序后重试" toasts.
+
+## Tasks
+
+### Task 1: Split shell command builders
+
+**Files:**
+- Modify: `internal/service/ssh_svc/dirsync_shell.go`
+- Test: `internal/service/ssh_svc/dirsync_shell_test.go` (new)
+
+The new `buildEnableSyncCommand` returns a one-line stdin payload. It is **not** a wrapping `exec` — it runs inside the user's already-running interactive shell, so it must be a single logical command terminated by `\r` (so the shell executes it immediately). It defines functions, sets the prompt hook, emits the `init:pid` marker, all separated by `;`. Heredocs are unsuitable inside a single line; we inline function bodies via `;` (multi-statement function body in bash/zsh syntax: `f() { stmt1; stmt2; }`).
+
+- [ ] **Step 1: Add failing test for `buildEnableSyncCommand` bash variant**
+
+```go
+// internal/service/ssh_svc/dirsync_shell_test.go
+package ssh_svc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildEnableSyncCommandBash(t *testing.T) {
+	cmd := buildEnableSyncCommand(shellTypeBash, "TOK", "NONCE")
+	if !strings.Contains(cmd, "opskat_prompt_proof") {
+		t.Fatalf("missing function name: %s", cmd)
+	}
+	if !strings.Contains(cmd, "OPSKAT_PROMPT_NONCE=NONCE") {
+		t.Fatalf("missing nonce assignment: %s", cmd)
+	}
+	if !strings.Contains(cmd, `PROMPT_COMMAND="opskat_prompt_proof`) {
+		t.Fatalf("missing PROMPT_COMMAND wiring: %s", cmd)
+	}
+	if !strings.Contains(cmd, `1337;opskat:TOK:init:pid:`) {
+		t.Fatalf("missing init marker: %s", cmd)
+	}
+	if strings.ContainsAny(cmd, "\n") {
+		t.Fatalf("command must be single-line, got newline: %q", cmd)
+	}
+	if !strings.HasSuffix(cmd, "\r") {
+		t.Fatalf("command must end with carriage return: %q", cmd)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `go test ./internal/service/ssh_svc -run TestBuildEnableSyncCommandBash -count=1`
+Expected: FAIL with `undefined: buildEnableSyncCommand`.
+
+- [ ] **Step 3: Replace `buildInteractiveShellCommand` with the split builders**
+
+Edit `internal/service/ssh_svc/dirsync_shell.go`. Remove `buildInteractiveShellCommand`. Add:
+
+```go
+// buildEnableSyncCommand returns a single-line shell statement to be written
+// to the running interactive shell's stdin. It installs the prompt-proof
+// hook, sets the initial nonce, and emits the init:pid marker.
+// shellType MUST be one of shellTypeBash/shellTypeZsh/shellTypeKsh/shellTypeMksh.
+func buildEnableSyncCommand(shellType, syncToken, promptNonce string) string {
+	switch shellType {
+	case shellTypeBash:
+		return fmt.Sprintf(
+			`opskat_next_prompt_nonce(){ local n r;n=$(date +%%s%%N 2>/dev/null||date +%%s 2>/dev/null||printf 0);r=${RANDOM:-0};printf '%%s-%%s-%%s' "$$" "$r" "$n";};`+
+				`opskat_prompt_proof(){ local p c x;c=${OPSKAT_PROMPT_NONCE:-};[ -n "$c" ]||return;x=$(opskat_next_prompt_nonce);p=$(builtin pwd -P 2>/dev/null||builtin pwd 2>/dev/null||printf '');printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$c" "$x" "$p";OPSKAT_PROMPT_NONCE=$x;};`+
+				`OPSKAT_PROMPT_NONCE=%s;`+
+				`PROMPT_COMMAND="opskat_prompt_proof${PROMPT_COMMAND:+;$PROMPT_COMMAND}";`+
+				`printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"`+"\r",
+			syncToken, shellQuote(promptNonce), syncToken)
+	case shellTypeZsh:
+		return fmt.Sprintf(
+			`opskat_next_prompt_nonce(){ local n r;n=$(date +%%s%%N 2>/dev/null||date +%%s 2>/dev/null||printf 0);r=${RANDOM:-0};printf '%%s-%%s-%%s' "$$" "$r" "$n";};`+
+				`opskat_prompt_proof(){ local p c x;c=${OPSKAT_PROMPT_NONCE:-};[[ -n "$c" ]]||return;x=$(opskat_next_prompt_nonce);p=$(pwd -P 2>/dev/null||pwd 2>/dev/null||printf '');printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$c" "$x" "$p";OPSKAT_PROMPT_NONCE=$x;};`+
+				`OPSKAT_PROMPT_NONCE=%s;`+
+				`autoload -Uz add-zsh-hook;add-zsh-hook precmd opskat_prompt_proof;`+
+				`printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"`+"\r",
+			syncToken, shellQuote(promptNonce), syncToken)
+	case shellTypeKsh, shellTypeMksh:
+		return fmt.Sprintf(
+			`opskat_next_prompt_nonce(){ OPSKAT_NOW=$(date +%%s%%N 2>/dev/null||date +%%s 2>/dev/null||printf 0);OPSKAT_RAND=${RANDOM:-0};printf '%%s-%%s-%%s' "$$" "$OPSKAT_RAND" "$OPSKAT_NOW";};`+
+				`opskat_prompt_proof(){ OPSKAT_CURRENT=${OPSKAT_PROMPT_NONCE:-};[ -n "$OPSKAT_CURRENT" ]||return;OPSKAT_NEXT=$(opskat_next_prompt_nonce);OPSKAT_PWD=$(pwd -P 2>/dev/null||pwd 2>/dev/null||printf '');printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$OPSKAT_CURRENT" "$OPSKAT_NEXT" "$OPSKAT_PWD";OPSKAT_PROMPT_NONCE=$OPSKAT_NEXT;};`+
+				`OPSKAT_PROMPT_NONCE=%s;`+
+				`OPSKAT_ORIG_PS1=${OPSKAT_ORIG_PS1:-$PS1};PS1='$(opskat_prompt_proof)'"$OPSKAT_ORIG_PS1";`+
+				`printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"`+"\r",
+			syncToken, shellQuote(promptNonce), syncToken)
+	default:
+		return ""
+	}
+}
+
+// buildDisableSyncCommand returns a one-line statement that removes the hook
+// and unsets helper functions. Safe to send even if EnableSync was never run.
+func buildDisableSyncCommand(shellType string) string {
+	switch shellType {
+	case shellTypeBash:
+		return `PROMPT_COMMAND=${PROMPT_COMMAND#opskat_prompt_proof};PROMPT_COMMAND=${PROMPT_COMMAND#;};unset -f opskat_prompt_proof opskat_next_prompt_nonce 2>/dev/null;unset OPSKAT_PROMPT_NONCE` + "\r"
+	case shellTypeZsh:
+		return `add-zsh-hook -d precmd opskat_prompt_proof 2>/dev/null;unset -f opskat_prompt_proof opskat_next_prompt_nonce 2>/dev/null;unset OPSKAT_PROMPT_NONCE` + "\r"
+	case shellTypeKsh, shellTypeMksh:
+		return `[ -n "$OPSKAT_ORIG_PS1" ] && PS1=$OPSKAT_ORIG_PS1;unset -f opskat_prompt_proof opskat_next_prompt_nonce 2>/dev/null;unset OPSKAT_PROMPT_NONCE OPSKAT_ORIG_PS1` + "\r"
+	default:
+		return ""
+	}
+}
+```
+
+Update or delete the deprecated test in `ssh_test.go` that references `buildInteractiveShellCommand` (search first, then either rename to point at `buildEnableSyncCommand` or remove if it was checking the wrapping form specifically). Use grep:
+
+```bash
+grep -n "buildInteractiveShellCommand" internal/service/ssh_svc/*.go
+```
+
+Replace usages or delete the test. Update `ssh_test.go:356` and any neighboring asserts to the new builder semantics (no wrapping `exec`, single line, ends in `\r`).
+
+- [ ] **Step 4: Add zsh + ksh variant tests in the same test file**
+
+```go
+func TestBuildEnableSyncCommandZsh(t *testing.T) {
+	cmd := buildEnableSyncCommand(shellTypeZsh, "TOK", "NONCE")
+	if !strings.Contains(cmd, "add-zsh-hook precmd opskat_prompt_proof") {
+		t.Fatalf("missing add-zsh-hook: %s", cmd)
+	}
+	if !strings.Contains(cmd, "1337;opskat:TOK:init:pid:") {
+		t.Fatalf("missing init marker: %s", cmd)
+	}
+	if !strings.HasSuffix(cmd, "\r") {
+		t.Fatalf("must end with \\r: %q", cmd)
+	}
+}
+
+func TestBuildEnableSyncCommandKsh(t *testing.T) {
+	cmd := buildEnableSyncCommand(shellTypeKsh, "TOK", "NONCE")
+	if !strings.Contains(cmd, `PS1='$(opskat_prompt_proof)'`) {
+		t.Fatalf("missing PS1 wiring: %s", cmd)
+	}
+	if !strings.HasSuffix(cmd, "\r") {
+		t.Fatalf("must end with \\r: %q", cmd)
+	}
+}
+
+func TestBuildEnableSyncCommandUnsupported(t *testing.T) {
+	if got := buildEnableSyncCommand(shellTypeUnsupported, "T", "N"); got != "" {
+		t.Fatalf("unsupported shell must return empty, got: %q", got)
+	}
+}
+
+func TestBuildDisableSyncCommand(t *testing.T) {
+	for _, sh := range []string{shellTypeBash, shellTypeZsh, shellTypeKsh, shellTypeMksh} {
+		got := buildDisableSyncCommand(sh)
+		if got == "" || !strings.HasSuffix(got, "\r") {
+			t.Fatalf("disable cmd for %s should end in \\r, got %q", sh, got)
+		}
+	}
+	if buildDisableSyncCommand(shellTypeUnsupported) != "" {
+		t.Fatal("unsupported should return empty")
+	}
+}
+```
+
+- [ ] **Step 5: Run all tests in package, fix any compile errors from the removal**
+
+Run: `go test ./internal/service/ssh_svc -count=1`
+Expected: all new tests PASS. Pre-existing tests that referenced `buildInteractiveShellCommand` either updated or deleted.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/service/ssh_svc/dirsync_shell.go internal/service/ssh_svc/dirsync_shell_test.go internal/service/ssh_svc/ssh_test.go
+git commit -m "♻️ 拆分 SSH 目录同步钩子为按需启用/关闭命令"
+```
+
+---
+
+### Task 2: Persist shell info on Session and remove wrapper from createSession
+
+**Files:**
+- Modify: `internal/service/ssh_svc/ssh.go` (Session struct, createSession)
+- Test: `internal/service/ssh_svc/ssh_test.go`
+
+- [ ] **Step 1: Add failing test asserting createSession does not eagerly mark Supported**
+
+Append to `ssh_test.go`:
+
+```go
+func TestSessionStartsWithSupportedFalse(t *testing.T) {
+	// Construct a Session via initSyncState directly (no real SSH needed).
+	sess := &Session{ID: "test"}
+	sess.initSyncState("/bin/bash", shellTypeBash, false)
+
+	state := sess.GetSyncState()
+	if state.Supported {
+		t.Fatal("Supported must be false until EnableSync is invoked")
+	}
+	if state.ShellType != shellTypeBash {
+		t.Fatalf("ShellType not retained: %q", state.ShellType)
+	}
+	if state.Status != directorySyncUnsupported {
+		t.Fatalf("Status should be unsupported initially, got %q", state.Status)
+	}
+}
+```
+
+- [ ] **Step 2: Run test, observe current state**
+
+Run: `go test ./internal/service/ssh_svc -run TestSessionStartsWithSupportedFalse -count=1`
+Expected: PASS already (initSyncState with `supported=false` already sets `Status=unsupported`). This is a regression guard.
+
+- [ ] **Step 3: Add `shellPath` / `shellType` fields to Session struct**
+
+Edit `internal/service/ssh_svc/ssh.go`. Locate the `Session` struct (around line 62). Add two fields:
+
+```go
+type Session struct {
+	ID       string
+	AssetID  int64
+	shared   *sharedClient
+	session  *ssh.Session
+	stdin    io.WriteCloser
+	stdout   io.Reader
+	mu       sync.Mutex
+	closed   bool
+	onData   func(data []byte)
+	onClosed func(sessionID string)
+	onSync   func(sessionID string, state DirectorySyncState)
+
+	shellPath string // detected user shell, e.g. /bin/bash — set in createSession
+	shellType string // shellTypeBash / shellTypeZsh / shellTypeKsh / shellTypeMksh / shellTypeUnsupported
+
+	syncMu             sync.Mutex
+	syncState          DirectorySyncState
+	// ... existing fields below ...
+```
+
+- [ ] **Step 4: Rewrite createSession to always use Shell() and never inject at start**
+
+Replace the block in `createSession` from the `shellPath, shellType := detectRemoteShell(...)` line through the `if supported { ... } else if err := session.Shell(); ...` branch (currently around lines 353–377) with:
+
+```go
+shellPath, shellType := detectRemoteShell(shared.client)
+sess := &Session{
+	ID:        sessionID,
+	AssetID:   assetID,
+	shared:    shared,
+	session:   session,
+	stdin:     stdin,
+	stdout:    stdout,
+	shellPath: shellPath,
+	shellType: shellType,
+	onData:    func(data []byte) { onData(sessionID, data) },
+	onClosed:  onClosed,
+}
+if onSync != nil {
+	sess.onSync = func(_ string, state DirectorySyncState) { onSync(sessionID, state) }
+}
+
+// Always use the SSH "shell" request so sshd emits Last login / motd / banner
+// natively. Directory-sync hooks are injected on demand via EnableSync().
+if err := session.Shell(); err != nil {
+	if closeErr := session.Close(); closeErr != nil {
+		logger.Default().Warn("close session after shell start failure", zap.Error(closeErr))
+	}
+	return "", fmt.Errorf("启动shell失败: %w", err)
+}
+
+sess.initSyncState(shellPath, shellType, false)
+
+m.sessions.Store(sessionID, sess)
+go m.readOutput(sess)
+
+return sessionID, nil
+```
+
+Also delete the now-unused early `syncToken` / `promptNonce` generation block (currently lines 322–335 in `ssh.go`). The Session no longer has `syncToken` / `promptNonce` populated at creation — those are generated on EnableSync. The struct fields stay (they're used during the sync lifecycle).
+
+- [ ] **Step 5: Run package tests + build**
+
+```bash
+go build ./...
+go test ./internal/service/ssh_svc -count=1
+```
+
+Expected: PASS. Compile failures from missing fields → fix locally.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/service/ssh_svc/ssh.go internal/service/ssh_svc/ssh_test.go
+git commit -m "♻️ SSH 会话默认走 Shell 请求，保留服务端原生登录提示"
+```
+
+---
+
+### Task 3: Implement Session.EnableSync / DisableSync
+
+**Files:**
+- Modify: `internal/service/ssh_svc/dirsync.go`
+- Test: `internal/service/ssh_svc/ssh_test.go`
+
+`EnableSync` is idempotent: if already supported it returns nil. Otherwise it generates fresh tokens, writes the enable command via `writeInternal`, and waits up to a bootstrap timeout for `handleSyncPayload` to flip `shellPID`. The wait is implemented as a channel signaled by `handleSyncPayload` when `init:pid` arrives.
+
+The bootstrap window: 3 seconds is generous. If it expires, we surface an error so the frontend can toast "请退出当前程序后重试".
+
+- [ ] **Step 1: Failing test for EnableSync timeout path**
+
+Append to `ssh_test.go`:
+
+```go
+func TestEnableSyncTimesOutWhenNoMarker(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	sess := &Session{
+		ID:        "test-timeout",
+		stdin:     pw,
+		shellPath: "/bin/bash",
+		shellType: shellTypeBash,
+	}
+	sess.initSyncState(sess.shellPath, sess.shellType, false)
+
+	// Drain whatever the enable command writes so the pipe doesn't block.
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+
+	prev := syncEnableTimeout
+	syncEnableTimeout = 100 * time.Millisecond
+	defer func() { syncEnableTimeout = prev }()
+
+	err := sess.EnableSync()
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if state := sess.GetSyncState(); state.Supported {
+		t.Fatalf("Supported must remain false on timeout, got %#v", state)
+	}
+}
+
+func TestEnableSyncUnsupportedShellReturnsError(t *testing.T) {
+	sess := &Session{ID: "u", shellType: shellTypeUnsupported}
+	sess.initSyncState("/bin/sh", shellTypeUnsupported, false)
+	if err := sess.EnableSync(); err == nil {
+		t.Fatal("expected error for unsupported shell")
+	}
+}
+
+func TestEnableSyncIdempotent(t *testing.T) {
+	sess := &Session{ID: "i", shellType: shellTypeBash, shellPath: "/bin/bash"}
+	sess.initSyncState(sess.shellPath, sess.shellType, true) // pretend already enabled
+	sess.syncMu.Lock()
+	sess.syncState.Supported = true
+	sess.syncState.Status = directorySyncReady
+	sess.shellPID = 12345
+	sess.syncMu.Unlock()
+
+	if err := sess.EnableSync(); err != nil {
+		t.Fatalf("idempotent enable should return nil, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, observe undefined symbols**
+
+Run: `go test ./internal/service/ssh_svc -run TestEnableSync -count=1`
+Expected: FAIL with `sess.EnableSync undefined` and `syncEnableTimeout undefined`.
+
+- [ ] **Step 3: Add EnableSync, DisableSync, and bootstrap signaling**
+
+Edit `internal/service/ssh_svc/dirsync.go`. Add near the top of the file (after the existing `var (...)` block):
+
+```go
+var syncEnableTimeout = 3 * time.Second
+```
+
+Add two fields to `Session` (in `ssh.go`, the struct definition from Task 2):
+
+```go
+syncBootstrapCh chan struct{} // closed when EnableSync receives init:pid; nil when not bootstrapping
+```
+
+Add the methods at the end of `dirsync.go`:
+
+```go
+// EnableSync injects the directory-sync hooks into the running interactive
+// shell and waits for the init:pid marker. Idempotent: returns nil immediately
+// if already supported with a known shell PID.
+func (s *Session) EnableSync() error {
+	s.syncMu.Lock()
+	if s.syncState.Supported && s.shellPID > 0 {
+		s.syncMu.Unlock()
+		return nil
+	}
+	if s.shellType == shellTypeUnsupported || s.shellType == "" {
+		s.syncMu.Unlock()
+		return dirsync.Error(dirSyncErrUnsupported)
+	}
+	if s.syncBootstrapCh != nil {
+		// Another EnableSync is in flight; wait on the same channel.
+		ch := s.syncBootstrapCh
+		s.syncMu.Unlock()
+		return waitForBootstrap(ch)
+	}
+
+	token, err := generateSyncToken()
+	if err != nil {
+		s.syncMu.Unlock()
+		return dirsync.Error(dirSyncErrNonceFailed)
+	}
+	promptNonce, err := generateSyncToken()
+	if err != nil {
+		s.syncMu.Unlock()
+		return dirsync.Error(dirSyncErrNonceFailed)
+	}
+	s.syncToken = token
+	s.promptNonce = promptNonce
+	s.shellPID = 0
+	s.syncState.Supported = true
+	s.syncState.Status = directorySyncInitializing
+	s.syncState.LastError = ""
+	s.syncDirty = true
+	bootstrapCh := make(chan struct{})
+	s.syncBootstrapCh = bootstrapCh
+	state := s.syncState
+	cmd := buildEnableSyncCommand(s.shellType, token, promptNonce)
+	s.syncMu.Unlock()
+
+	go s.emitSyncState(state)
+
+	if cmd == "" {
+		s.clearBootstrap(bootstrapCh)
+		return dirsync.Error(dirSyncErrUnsupported)
+	}
+	if err := s.writeInternal([]byte(cmd)); err != nil {
+		s.clearBootstrap(bootstrapCh)
+		s.syncMu.Lock()
+		s.syncState.Supported = false
+		s.syncState.Status = directorySyncUnsupported
+		s.syncState.LastError = err.Error()
+		st := s.syncState
+		s.syncMu.Unlock()
+		s.emitSyncState(st)
+		return err
+	}
+
+	if err := waitForBootstrap(bootstrapCh); err != nil {
+		s.syncMu.Lock()
+		// Only roll back if we still own the bootstrap (no one already promoted state).
+		if s.syncBootstrapCh == bootstrapCh {
+			s.syncBootstrapCh = nil
+			s.syncState.Supported = false
+			s.syncState.Status = directorySyncUnsupported
+			s.syncState.LastError = err.Error()
+			s.shellPID = 0
+		}
+		st := s.syncState
+		s.syncMu.Unlock()
+		s.emitSyncState(st)
+		return err
+	}
+	return nil
+}
+
+// DisableSync removes hooks from the running shell and flips state back to
+// unsupported. Best-effort: if the stdin write fails, state is still cleared.
+func (s *Session) DisableSync() {
+	s.syncMu.Lock()
+	if !s.syncState.Supported {
+		s.syncMu.Unlock()
+		return
+	}
+	cmd := buildDisableSyncCommand(s.shellType)
+	s.syncMu.Unlock()
+
+	if cmd != "" {
+		if err := s.writeInternal([]byte(cmd)); err != nil {
+			logger.Default().Warn("write disable-sync command", zap.String("sessionID", s.ID), zap.Error(err))
+		}
+	}
+	s.disableDirectorySync(dirSyncErrUnsupported)
+}
+
+func (s *Session) clearBootstrap(ch chan struct{}) {
+	s.syncMu.Lock()
+	if s.syncBootstrapCh == ch {
+		s.syncBootstrapCh = nil
+	}
+	s.syncMu.Unlock()
+}
+
+func waitForBootstrap(ch chan struct{}) error {
+	select {
+	case <-ch:
+		return nil
+	case <-time.After(syncEnableTimeout):
+		return dirsync.Error(dirSyncErrTimeout)
+	}
+}
+```
+
+Modify `handleSyncPayload` in `dirsync.go`. In the `init:pid` branch, after `s.shellPID = pid`, signal the bootstrap channel:
+
+```go
+case strings.HasPrefix(body, "init:pid:"):
+	pidText := strings.TrimPrefix(body, "init:pid:")
+	pid, err := strconv.Atoi(strings.TrimSpace(pidText))
+	if err != nil || pid <= 0 {
+		return false
+	}
+	s.syncMu.Lock()
+	if s.shellPID != 0 {
+		s.syncMu.Unlock()
+		return false
+	}
+	s.shellPID = pid
+	s.syncDirty = true
+	bootstrap := s.syncBootstrapCh
+	s.syncBootstrapCh = nil
+	s.syncMu.Unlock()
+	if bootstrap != nil {
+		close(bootstrap)
+	}
+	s.ensureSyncProbe()
+	return true
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/service/ssh_svc -count=1`
+Expected: All Task-3 tests PASS. Existing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/ssh_svc/dirsync.go internal/service/ssh_svc/ssh.go internal/service/ssh_svc/ssh_test.go
+git commit -m "✨ Session.EnableSync / DisableSync 实现按需注入目录同步钩子"
+```
+
+---
+
+### Task 4: Auto-enable in ChangeSSHDirectory + add EnableSSHSync binding
+
+**Files:**
+- Modify: `internal/app/app_ssh.go`
+- Test: `internal/app/app_ssh_test.go` (create if absent — otherwise extend)
+
+- [ ] **Step 1: Failing test ensuring ChangeSSHDirectory auto-enables**
+
+Search first:
+
+```bash
+ls internal/app/app_ssh_test.go 2>/dev/null || echo "missing"
+```
+
+If missing, create it. Otherwise extend. Test:
+
+```go
+// internal/app/app_ssh_test.go (extend or create)
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/opskat/opskat/internal/pkg/dirsync"
+)
+
+func TestChangeSSHDirectoryFailsCleanlyWhenSessionMissing(t *testing.T) {
+	a := &App{sshManager: nil}
+	err := a.ChangeSSHDirectory("nonexistent", "/tmp")
+	if !errors.Is(err, dirsync.Error(dirsync.CodeSessionNotFound)) {
+		t.Fatalf("expected SessionNotFound, got %v", err)
+	}
+}
+```
+
+Note: full integration test of auto-enable requires a real SSH server. The E2E suite (`make test-e2e`) covers that. Here we only assert the binding exists and surfaces the right error code on missing session.
+
+- [ ] **Step 2: Run test, observe failure or pass**
+
+Run: `go test ./internal/app -run TestChangeSSHDirectory -count=1`
+Expected: PASS once the binding signature matches. (May already pass — this is a guard.)
+
+- [ ] **Step 3: Modify ChangeSSHDirectory to auto-enable**
+
+Edit `internal/app/app_ssh.go`. Replace the `ChangeSSHDirectory` body (currently around lines 408–435):
+
+```go
+// ChangeSSHDirectory 请求当前终端切换到指定目录。
+// 若目录同步尚未启用，会自动注入钩子（一次性，会话内后续切换不再注入）。
+func (a *App) ChangeSSHDirectory(sessionID, targetPath string) error {
+	sess, ok := a.sshManager.GetSession(sessionID)
+	if !ok {
+		return dirsync.Error(dirsync.CodeSessionNotFound)
+	}
+
+	state := sess.GetSyncState()
+	if !state.Supported {
+		if err := sess.EnableSync(); err != nil {
+			return err
+		}
+		state = sess.GetSyncState()
+	}
+	if !state.CwdKnown {
+		// EnableSync resolved init:pid; first prompt may not have arrived yet.
+		// Probe loop will fill cwd shortly. Surface a typed retry error so the
+		// frontend can debounce + retry.
+		return dirsync.Error(dirsync.CodeCwdUnknown)
+	}
+
+	resolvedPath := targetPath
+	if !strings.HasPrefix(resolvedPath, "/") {
+		resolvedPath = path.Join(state.Cwd, resolvedPath)
+	}
+	resolvedPath = path.Clean(resolvedPath)
+
+	expectedPath, err := a.sftpService.ResolveDirectory(sessionID, resolvedPath)
+	if err != nil {
+		return err
+	}
+	return sess.ChangeDirectoryTo(resolvedPath, expectedPath)
+}
+
+// EnableSSHSync 显式启用目录同步（用于面板"跟随终端"按钮的首次点击）。
+func (a *App) EnableSSHSync(sessionID string) error {
+	sess, ok := a.sshManager.GetSession(sessionID)
+	if !ok {
+		return dirsync.Error(dirsync.CodeSessionNotFound)
+	}
+	return sess.EnableSync()
+}
+```
+
+- [ ] **Step 4: Build + test + regenerate Wails bindings**
+
+```bash
+go build ./...
+go test ./internal/app -count=1
+```
+
+Then regenerate the frontend Wails bindings. The project's standard regenerate path is via `make dev` — but for plan execution we want a non-interactive form. Use:
+
+```bash
+make dev
+```
+
+…and Ctrl-C once the dev server prints "wails: bindings generated" (or equivalent). Confirm `frontend/wailsjs/go/app/App.d.ts` now contains `EnableSSHSync`.
+
+If `make dev` is too heavy for CI, run `wails generate module` directly (consult `Makefile` for the canonical command — search for `bindings`):
+
+```bash
+grep -n "binding\|generate" Makefile
+```
+
+Use whatever the project's documented regenerate command is.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/app_ssh.go internal/app/app_ssh_test.go frontend/wailsjs/go/app/App.d.ts frontend/wailsjs/go/app/App.js
+git commit -m "✨ ChangeSSHDirectory 自动启用目录同步并暴露 EnableSSHSync 绑定"
+```
+
+---
+
+### Task 5: Frontend lazy-enable in F→T flow
+
+**Files:**
+- Modify: `frontend/src/components/terminal/file-manager/useTerminalDirectorySync.ts`
+- Test: extend an existing relevant frontend test, or add `frontend/src/__tests__/useTerminalDirectorySync.test.tsx` (mock Wails bindings as in `frontend/src/__tests__/setup.ts`)
+
+- [ ] **Step 1: Failing test — F→T calls EnableSSHSync when sessionSync is missing**
+
+Locate setup mocks:
+
+```bash
+grep -rn "EnableSSHSync\|ChangeSSHDirectory" frontend/src/__tests__/ 2>/dev/null
+grep -n "vi.mock" frontend/src/__tests__/setup.ts
+```
+
+Create `frontend/src/__tests__/useTerminalDirectorySync.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTerminalDirectorySync } from "@/components/terminal/file-manager/useTerminalDirectorySync";
+
+// Mock Wails bindings used by the hook.
+const enableSpy = vi.fn().mockResolvedValue(undefined);
+const changeSpy = vi.fn().mockResolvedValue(undefined);
+vi.mock("../../wailsjs/go/app/App", () => ({
+  EnableSSHSync: (...args: unknown[]) => enableSpy(...args),
+  ChangeSSHDirectory: (...args: unknown[]) => changeSpy(...args),
+}));
+
+// Minimal store shim — mirror the real store's keys touched by the hook.
+vi.mock("@/stores/terminalStore", () => {
+  const state = {
+    tabData: { tab1: { directoryFollowMode: "off", panes: { sess1: { connected: true } } } },
+    sessionSync: {} as Record<string, unknown>,
+    setDirectoryFollowMode: vi.fn(),
+  };
+  return {
+    useTerminalStore: (selector: (s: typeof state) => unknown) => selector(state),
+  };
+});
+
+describe("useTerminalDirectorySync lazy enable", () => {
+  beforeEach(() => {
+    enableSpy.mockClear();
+    changeSpy.mockClear();
+  });
+
+  it("calls EnableSSHSync before reading cwd when state is missing", async () => {
+    const loadDir = vi.fn().mockResolvedValue(true);
+    const currentPathRef = { current: "/" };
+    const { result } = renderHook(() =>
+      useTerminalDirectorySync({ currentPathRef, loadDir, sessionId: "sess1", tabId: "tab1" })
+    );
+    await act(async () => {
+      await result.current.syncPanelFromTerminal();
+    });
+    expect(enableSpy).toHaveBeenCalledWith("sess1");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend && pnpm test -- useTerminalDirectorySync`
+Expected: FAIL — current hook does not call `EnableSSHSync`.
+
+- [ ] **Step 3: Modify the hook to lazy-enable**
+
+Edit `frontend/src/components/terminal/file-manager/useTerminalDirectorySync.ts`. Add the import:
+
+```ts
+import { ChangeSSHDirectory, EnableSSHSync } from "../../../../wailsjs/go/app/App";
+```
+
+Replace `syncPanelFromTerminal`:
+
+```ts
+const syncPanelFromTerminal = useCallback(async () => {
+  let sync = sessionSync;
+  if (!sync || !sync.supported) {
+    try {
+      await EnableSSHSync(sessionId);
+    } catch (e) {
+      showSyncError(e);
+      return false;
+    }
+    sync = useTerminalStore.getState().sessionSync[sessionId];
+  }
+  if (!sync) {
+    showSyncCode(DIRSYNC_ERROR_CODES.CWD_UNKNOWN);
+    return false;
+  }
+  if (!sync.supported) {
+    showSyncCode(DIRSYNC_ERROR_CODES.UNSUPPORTED);
+    return false;
+  }
+  if (!sync.cwdKnown || !sync.cwd) {
+    showSyncCode(DIRSYNC_ERROR_CODES.CWD_UNKNOWN);
+    return false;
+  }
+  return loadDir(sync.cwd);
+}, [loadDir, sessionId, sessionSync, showSyncCode, showSyncError]);
+```
+
+Also add `useTerminalStore` direct access import at top:
+
+```ts
+import { useTerminalStore } from "@/stores/terminalStore";
+```
+
+(already imported — confirm it exposes `getState`. If selector-only, swap to `useTerminalStore.getState`.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd frontend && pnpm test -- useTerminalDirectorySync
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/terminal/file-manager/useTerminalDirectorySync.ts frontend/src/__tests__/useTerminalDirectorySync.test.tsx
+git commit -m "✨ 终端面板 F→T 首次点击时懒启用目录同步"
+```
+
+---
+
+### Task 6: Manual smoke test
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and launch dev**
+
+```bash
+make dev
+```
+
+- [ ] **Step 2: Connect to a Linux SSH host configured with `PrintLastLog yes` (default)**
+
+In a fresh tab, open a terminal session to any Linux server. Confirm visually:
+
+- "Last login: ..." line appears immediately after the auth banner.
+- `/etc/motd` (if present) is displayed.
+- Custom banners/issue.net (if configured) display.
+
+- [ ] **Step 3: First F→T click triggers enable**
+
+Click the "panel follows terminal" toggle. Expected:
+
+- A short visible flash of the injection command (this is the known UX cost — accepted for v1).
+- After ~100ms, panel loads the current cwd.
+- Subsequent F→T clicks have no command flash (already supported).
+
+- [ ] **Step 4: T→F via clicking a folder in the file manager**
+
+Navigate the panel into a subdirectory with auto-follow off, then enable always-follow. Expected: terminal `cd`s to the panel path. If sync was not previously enabled, expect a one-time injection flash followed by the cd.
+
+- [ ] **Step 5: Edge case — user is in `vim` when clicking F→T**
+
+In an active SSH session, run `vim`. While vim is foregrounded, click F→T. Expected:
+
+- The injection bytes are interpreted by vim (cosmetic damage to vim's UI).
+- After 3s, frontend toast: "请退出当前程序后重试" (mapped from `dirSyncErrTimeout`).
+- Session remains open and usable; sync state remains unsupported.
+- Pressing Esc + `:q!` recovers vim. Clicking F→T again works.
+
+- [ ] **Step 6: Disable + reconnect**
+
+Reconnect the session (via the toolbar's reconnect). Expected: full Last login + motd shown again, sync resets to unsupported. Re-enable works.
+
+- [ ] **Step 7: Lint + final commit**
+
+```bash
+make lint
+cd frontend && pnpm lint
+```
+
+If anything is flagged, fix and commit:
+
+```bash
+git add -p
+git commit -m "🎨 lint pass for SSH lazy sync injection"
+```
+
+---
+
+## Out of Scope (call out, do not implement)
+
+- Hiding the injection command echo via cursor-up + clear-line. Could be a v2 polish PR.
+- Showing a synthesized banner if `PrintLastLog no` on the server — keep behavior aligned with native sshd (i.e., don't show what the server chose to suppress).
+- Caching the shell-type detection across reconnects — a single `sh -lc 'printf %s $SHELL'` is cheap.
+- Restoring the previous wrapper as a fallback for "always-on sync from connect" — design choice is to defer hook installation.
+
+## Risks
+
+- **Bracketed paste mode**: some servers' `~/.inputrc` enables bracketed paste in readline. The Ctrl-U + command + `\r` injection is plain text, not paste-bracketed, so it should execute as a typed command. If observed broken on a specific shell config, prepend `\033[?2004l` and append `\033[?2004h` to the enable command.
+- **Localized error toasts**: `dirSyncErrTimeout` may not currently map to a user-friendly message. Confirm `frontend/src/lib/dirSyncErrors.ts` includes a mapping; add if missing during Task 5.
+- **Probe loop relies on `shellPID`**: with lazy enable, probe doesn't start until init marker arrives. If user never enables sync, probe never runs — desired. If user disables sync, probe stops on next tick (existing logic checks `Supported`).

--- a/frontend/src/__tests__/useTerminalDirectorySync.test.tsx
+++ b/frontend/src/__tests__/useTerminalDirectorySync.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import { ChangeSSHDirectory, EnableSSHSync } from "../../wailsjs/go/app/App";
+import { ChangeSSHDirectory, EnableSSHSync, GetSSHSyncState } from "../../wailsjs/go/app/App";
 import { useTerminalDirectorySync } from "@/components/terminal/file-manager/useTerminalDirectorySync";
 import { useTerminalStore, type TerminalDirectorySyncState, type TerminalTabData } from "@/stores/terminalStore";
 
@@ -24,40 +24,36 @@ function primeStore(sessionSync: Record<string, TerminalDirectorySyncState>) {
   } as never);
 }
 
+function readySyncState(cwd = "/srv/app"): TerminalDirectorySyncState {
+  return {
+    sessionId,
+    supported: true,
+    cwd,
+    cwdKnown: true,
+    shell: "/bin/bash",
+    shellType: "bash",
+    promptReady: true,
+    promptClean: true,
+    busy: false,
+    status: "ready",
+  };
+}
+
 describe("useTerminalDirectorySync — lazy enable", () => {
   beforeEach(() => {
     vi.mocked(EnableSSHSync).mockReset().mockResolvedValue(undefined);
     vi.mocked(ChangeSSHDirectory).mockReset().mockResolvedValue(undefined);
+    vi.mocked(GetSSHSyncState)
+      .mockReset()
+      .mockResolvedValue(readySyncState() as never);
   });
 
   afterEach(() => {
     primeStore({});
   });
 
-  it("calls EnableSSHSync when sessionSync is missing, then reads cwd from store", async () => {
+  it("calls EnableSSHSync when sessionSync is missing, then fetches latest cwd", async () => {
     primeStore({});
-
-    // Simulate the backend pushing sync state after EnableSync resolves.
-    vi.mocked(EnableSSHSync).mockImplementationOnce(async () => {
-      useTerminalStore.setState((state) => ({
-        sessionSync: {
-          ...state.sessionSync,
-          [sessionId]: {
-            sessionId,
-            supported: true,
-            cwd: "/srv/app",
-            cwdKnown: true,
-            shell: "/bin/bash",
-            shellType: "bash",
-            promptReady: true,
-            promptClean: true,
-            busy: false,
-            status: "ready",
-          },
-        },
-      }));
-      return undefined;
-    });
 
     const loadDir = vi.fn().mockResolvedValue(true);
     const currentPathRef = { current: "/" };
@@ -69,23 +65,14 @@ describe("useTerminalDirectorySync — lazy enable", () => {
     });
 
     expect(EnableSSHSync).toHaveBeenCalledWith(sessionId);
+    expect(GetSSHSyncState).toHaveBeenCalledWith(sessionId);
     expect(loadDir).toHaveBeenCalledWith("/srv/app");
+    expect(useTerminalStore.getState().sessionSync[sessionId]).toEqual(readySyncState());
   });
 
   it("does NOT call EnableSSHSync when sessionSync is already supported", async () => {
     primeStore({
-      [sessionId]: {
-        sessionId,
-        supported: true,
-        cwd: "/srv/app",
-        cwdKnown: true,
-        shell: "/bin/bash",
-        shellType: "bash",
-        promptReady: true,
-        promptClean: true,
-        busy: false,
-        status: "ready",
-      },
+      [sessionId]: readySyncState(),
     });
 
     const loadDir = vi.fn().mockResolvedValue(true);
@@ -98,6 +85,7 @@ describe("useTerminalDirectorySync — lazy enable", () => {
     });
 
     expect(EnableSSHSync).not.toHaveBeenCalled();
+    expect(GetSSHSyncState).not.toHaveBeenCalled();
     expect(loadDir).toHaveBeenCalledWith("/srv/app");
   });
 });

--- a/frontend/src/__tests__/useTerminalDirectorySync.test.tsx
+++ b/frontend/src/__tests__/useTerminalDirectorySync.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { ChangeSSHDirectory, EnableSSHSync } from "../../wailsjs/go/app/App";
+import { useTerminalDirectorySync } from "@/components/terminal/file-manager/useTerminalDirectorySync";
+import { useTerminalStore, type TerminalDirectorySyncState, type TerminalTabData } from "@/stores/terminalStore";
+
+const sessionId = "ssh-1";
+const tabId = "tab-1";
+
+function buildTabData(): TerminalTabData {
+  return {
+    splitTree: { type: "terminal", sessionId },
+    activePaneId: sessionId,
+    panes: { [sessionId]: { sessionId, connected: true, connectedAt: 0 } },
+    directoryFollowMode: "off",
+  };
+}
+
+function primeStore(sessionSync: Record<string, TerminalDirectorySyncState>) {
+  // Reset store to a known shape so each test is isolated.
+  useTerminalStore.setState({
+    tabData: { [tabId]: buildTabData() },
+    sessionSync,
+  } as never);
+}
+
+describe("useTerminalDirectorySync — lazy enable", () => {
+  beforeEach(() => {
+    vi.mocked(EnableSSHSync).mockReset().mockResolvedValue(undefined);
+    vi.mocked(ChangeSSHDirectory).mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    primeStore({});
+  });
+
+  it("calls EnableSSHSync when sessionSync is missing, then reads cwd from store", async () => {
+    primeStore({});
+
+    // Simulate the backend pushing sync state after EnableSync resolves.
+    vi.mocked(EnableSSHSync).mockImplementationOnce(async () => {
+      useTerminalStore.setState((state) => ({
+        sessionSync: {
+          ...state.sessionSync,
+          [sessionId]: {
+            sessionId,
+            supported: true,
+            cwd: "/srv/app",
+            cwdKnown: true,
+            shell: "/bin/bash",
+            shellType: "bash",
+            promptReady: true,
+            promptClean: true,
+            busy: false,
+            status: "ready",
+          },
+        },
+      }));
+      return undefined;
+    });
+
+    const loadDir = vi.fn().mockResolvedValue(true);
+    const currentPathRef = { current: "/" };
+
+    const { result } = renderHook(() => useTerminalDirectorySync({ currentPathRef, loadDir, sessionId, tabId }));
+
+    await act(async () => {
+      await result.current.syncPanelFromTerminal();
+    });
+
+    expect(EnableSSHSync).toHaveBeenCalledWith(sessionId);
+    expect(loadDir).toHaveBeenCalledWith("/srv/app");
+  });
+
+  it("does NOT call EnableSSHSync when sessionSync is already supported", async () => {
+    primeStore({
+      [sessionId]: {
+        sessionId,
+        supported: true,
+        cwd: "/srv/app",
+        cwdKnown: true,
+        shell: "/bin/bash",
+        shellType: "bash",
+        promptReady: true,
+        promptClean: true,
+        busy: false,
+        status: "ready",
+      },
+    });
+
+    const loadDir = vi.fn().mockResolvedValue(true);
+    const currentPathRef = { current: "/" };
+
+    const { result } = renderHook(() => useTerminalDirectorySync({ currentPathRef, loadDir, sessionId, tabId }));
+
+    await act(async () => {
+      await result.current.syncPanelFromTerminal();
+    });
+
+    expect(EnableSSHSync).not.toHaveBeenCalled();
+    expect(loadDir).toHaveBeenCalledWith("/srv/app");
+  });
+});

--- a/frontend/src/components/terminal/file-manager/useTerminalDirectorySync.ts
+++ b/frontend/src/components/terminal/file-manager/useTerminalDirectorySync.ts
@@ -1,7 +1,7 @@
 import { useCallback, type MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { ChangeSSHDirectory } from "../../../../wailsjs/go/app/App";
+import { ChangeSSHDirectory, EnableSSHSync } from "../../../../wailsjs/go/app/App";
 import { DIRSYNC_ERROR_CODES, type DirSyncErrorCode, formatDirSyncError } from "@/lib/dirSyncErrors";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { normalizeRemotePath } from "./utils";
@@ -40,20 +40,30 @@ export function useTerminalDirectorySync({
   );
 
   const syncPanelFromTerminal = useCallback(async () => {
-    if (!sessionSync) {
+    let sync = sessionSync;
+    if (!sync || !sync.supported) {
+      try {
+        await EnableSSHSync(sessionId);
+      } catch (e) {
+        showSyncError(e);
+        return false;
+      }
+      sync = useTerminalStore.getState().sessionSync[sessionId];
+    }
+    if (!sync) {
       showSyncCode(DIRSYNC_ERROR_CODES.CWD_UNKNOWN);
       return false;
     }
-    if (!sessionSync.supported) {
+    if (!sync.supported) {
       showSyncCode(DIRSYNC_ERROR_CODES.UNSUPPORTED);
       return false;
     }
-    if (!sessionSync.cwdKnown || !sessionSync.cwd) {
+    if (!sync.cwdKnown || !sync.cwd) {
       showSyncCode(DIRSYNC_ERROR_CODES.CWD_UNKNOWN);
       return false;
     }
-    return loadDir(sessionSync.cwd);
-  }, [loadDir, sessionSync, showSyncCode]);
+    return loadDir(sync.cwd);
+  }, [loadDir, sessionId, sessionSync, showSyncCode, showSyncError]);
 
   const syncTerminalToPath = useCallback(
     async (targetPath: string) => {

--- a/frontend/src/components/terminal/file-manager/useTerminalDirectorySync.ts
+++ b/frontend/src/components/terminal/file-manager/useTerminalDirectorySync.ts
@@ -1,9 +1,9 @@
 import { useCallback, type MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { ChangeSSHDirectory, EnableSSHSync } from "../../../../wailsjs/go/app/App";
+import { ChangeSSHDirectory, EnableSSHSync, GetSSHSyncState } from "../../../../wailsjs/go/app/App";
 import { DIRSYNC_ERROR_CODES, type DirSyncErrorCode, formatDirSyncError } from "@/lib/dirSyncErrors";
-import { useTerminalStore } from "@/stores/terminalStore";
+import { useTerminalStore, type TerminalDirectorySyncState } from "@/stores/terminalStore";
 import { normalizeRemotePath } from "./utils";
 
 interface UseTerminalDirectorySyncOptions {
@@ -44,11 +44,13 @@ export function useTerminalDirectorySync({
     if (!sync || !sync.supported) {
       try {
         await EnableSSHSync(sessionId);
+        const latest = (await GetSSHSyncState(sessionId)) as TerminalDirectorySyncState;
+        useTerminalStore.getState().setSessionSyncState(sessionId, latest);
+        sync = latest;
       } catch (e) {
         showSyncError(e);
         return false;
       }
-      sync = useTerminalStore.getState().sessionSync[sessionId];
     }
     if (!sync) {
       showSyncCode(DIRSYNC_ERROR_CODES.CWD_UNKNOWN);

--- a/internal/app/app_ssh.go
+++ b/internal/app/app_ssh.go
@@ -406,6 +406,7 @@ func (a *App) GetSSHSyncState(sessionID string) (ssh_svc.DirectorySyncState, err
 }
 
 // ChangeSSHDirectory 请求当前终端切换到指定目录。
+// 若目录同步尚未启用，会自动注入钩子（一次性，会话内后续切换不再注入）。
 func (a *App) ChangeSSHDirectory(sessionID, targetPath string) error {
 	sess, ok := a.sshManager.GetSession(sessionID)
 	if !ok {
@@ -413,10 +414,15 @@ func (a *App) ChangeSSHDirectory(sessionID, targetPath string) error {
 	}
 
 	state := sess.GetSyncState()
-	switch {
-	case !state.Supported:
-		return dirsync.Error(dirsync.CodeUnsupported)
-	case !state.CwdKnown:
+	if !state.Supported {
+		if err := sess.EnableSync(); err != nil {
+			return err
+		}
+		state = sess.GetSyncState()
+	}
+	if !state.CwdKnown {
+		// EnableSync resolved init:pid; the first prompt nonce may not have
+		// arrived yet. Surface a typed retry error so the frontend can debounce.
 		return dirsync.Error(dirsync.CodeCwdUnknown)
 	}
 
@@ -432,6 +438,17 @@ func (a *App) ChangeSSHDirectory(sessionID, targetPath string) error {
 	}
 
 	return sess.ChangeDirectoryTo(resolvedPath, expectedPath)
+}
+
+// EnableSSHSync 显式启用目录同步（用于面板"跟随终端"按钮的首次点击）。
+// 注入钩子需要终端处于 shell 提示符状态；若用户处于 vim/less/tmux 等前台
+// 程序中，会在 ~3s 后超时返回 DIRSYNC_TIMEOUT，前端应提示用户先退出该程序。
+func (a *App) EnableSSHSync(sessionID string) error {
+	sess, ok := a.sshManager.GetSession(sessionID)
+	if !ok {
+		return dirsync.Error(dirsync.CodeSessionNotFound)
+	}
+	return sess.EnableSync()
 }
 
 // SplitSSH 在已有会话的连接上创建新会话（分割窗格复用连接）

--- a/internal/app/app_ssh_test.go
+++ b/internal/app/app_ssh_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/opskat/opskat/internal/pkg/dirsync"
+	"github.com/opskat/opskat/internal/service/ssh_svc"
+)
+
+func TestChangeSSHDirectoryReturnsSessionNotFoundForUnknownID(t *testing.T) {
+	a := &App{sshManager: ssh_svc.NewManager()}
+	err := a.ChangeSSHDirectory("nonexistent", "/tmp")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != dirsync.CodeSessionNotFound {
+		t.Fatalf("expected SessionNotFound code, got %q", err.Error())
+	}
+}
+
+func TestEnableSSHSyncReturnsSessionNotFoundForUnknownID(t *testing.T) {
+	a := &App{sshManager: ssh_svc.NewManager()}
+	err := a.EnableSSHSync("nonexistent")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != dirsync.CodeSessionNotFound {
+		t.Fatalf("expected SessionNotFound code, got %q", err.Error())
+	}
+}

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -62,6 +62,11 @@ var (
 	syncProbeMaxUnusableResults = 12
 )
 
+// syncEnableTimeout bounds how long EnableSync waits for the shell to echo
+// the init:pid marker after we write the hook-installer to stdin. Variable so
+// tests can shorten it.
+var syncEnableTimeout = 3 * time.Second
+
 func (s *Session) GetSyncState() DirectorySyncState {
 	s.syncMu.Lock()
 	defer s.syncMu.Unlock()
@@ -569,7 +574,12 @@ func (s *Session) handleSyncPayload(payload string) bool {
 		}
 		s.shellPID = pid
 		s.syncDirty = true
+		bootstrap := s.syncBootstrapCh
+		s.syncBootstrapCh = nil
 		s.syncMu.Unlock()
+		if bootstrap != nil {
+			close(bootstrap)
+		}
 		s.ensureSyncProbe()
 		return true
 	case strings.HasPrefix(body, "prompt:"):
@@ -619,4 +629,124 @@ func (s *Session) handleSyncPayload(payload string) bool {
 		return true
 	}
 	return false
+}
+
+// EnableSync injects the directory-sync hooks into the running interactive
+// shell and waits for the init:pid marker. Idempotent: returns nil immediately
+// if the session is already supported with a known shell PID.
+//
+// On timeout (no marker within syncEnableTimeout), state is rolled back to
+// Supported=false and a CodeTimeout error is returned. Callers should map
+// that to a "please exit foreground program and retry" hint in the UI.
+func (s *Session) EnableSync() error {
+	s.syncMu.Lock()
+	if s.syncState.Supported && s.shellPID > 0 {
+		s.syncMu.Unlock()
+		return nil
+	}
+	if s.shellType == shellTypeUnsupported || s.shellType == "" {
+		s.syncMu.Unlock()
+		return dirsync.Error(dirSyncErrUnsupported)
+	}
+	if s.syncBootstrapCh != nil {
+		// Another EnableSync is in flight; wait on the same channel.
+		ch := s.syncBootstrapCh
+		s.syncMu.Unlock()
+		return waitForSyncBootstrap(ch)
+	}
+
+	token, err := generateSyncToken()
+	if err != nil {
+		s.syncMu.Unlock()
+		return dirsync.Error(dirSyncErrNonceFailed)
+	}
+	promptNonce, err := generateSyncToken()
+	if err != nil {
+		s.syncMu.Unlock()
+		return dirsync.Error(dirSyncErrNonceFailed)
+	}
+	s.syncToken = token
+	s.promptNonce = promptNonce
+	s.shellPID = 0
+	s.syncState.Supported = true
+	s.syncState.Status = directorySyncInitializing
+	s.syncState.LastError = ""
+	s.syncDirty = true
+	bootstrapCh := make(chan struct{})
+	s.syncBootstrapCh = bootstrapCh
+	state := s.syncState
+	cmd := buildEnableSyncCommand(s.shellType, token, promptNonce)
+	s.syncMu.Unlock()
+
+	go s.emitSyncState(state)
+
+	if cmd == "" {
+		s.clearBootstrap(bootstrapCh)
+		return dirsync.Error(dirSyncErrUnsupported)
+	}
+	if err := s.writeInternal([]byte(cmd)); err != nil {
+		s.clearBootstrap(bootstrapCh)
+		s.syncMu.Lock()
+		s.syncState.Supported = false
+		s.syncState.Status = directorySyncUnsupported
+		s.syncState.LastError = err.Error()
+		st := s.syncState
+		s.syncMu.Unlock()
+		s.emitSyncState(st)
+		return err
+	}
+
+	if err := waitForSyncBootstrap(bootstrapCh); err != nil {
+		s.syncMu.Lock()
+		// Only roll back if we still own this bootstrap; init:pid handler may
+		// have raced and already promoted the state to ready.
+		if s.syncBootstrapCh == bootstrapCh {
+			s.syncBootstrapCh = nil
+			s.syncState.Supported = false
+			s.syncState.Status = directorySyncUnsupported
+			s.syncState.LastError = err.Error()
+			s.shellPID = 0
+		}
+		st := s.syncState
+		s.syncMu.Unlock()
+		s.emitSyncState(st)
+		return err
+	}
+	return nil
+}
+
+// DisableSync removes hooks from the running shell and flips state back to
+// unsupported. Best-effort: if the stdin write fails, state is still cleared.
+func (s *Session) DisableSync() {
+	s.syncMu.Lock()
+	if !s.syncState.Supported {
+		s.syncMu.Unlock()
+		return
+	}
+	cmd := buildDisableSyncCommand(s.shellType)
+	s.syncMu.Unlock()
+
+	if cmd != "" {
+		if err := s.writeInternal([]byte(cmd)); err != nil {
+			logger.Default().Warn("write disable-sync command", zap.String("sessionID", s.ID), zap.Error(err))
+		}
+	}
+	s.disableDirectorySync(dirSyncErrUnsupported)
+}
+
+func (s *Session) clearBootstrap(ch chan struct{}) {
+	s.syncMu.Lock()
+	if s.syncBootstrapCh == ch {
+		s.syncBootstrapCh = nil
+	}
+	s.syncMu.Unlock()
+}
+
+func waitForSyncBootstrap(ch chan struct{}) error {
+	select {
+	case <-ch:
+		return nil
+	case <-time.After(syncEnableTimeout):
+		return dirsync.Error(dirSyncErrTimeout)
+	}
 }

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -699,7 +699,7 @@ func (s *Session) EnableSync() error {
 		st := s.syncState
 		s.syncMu.Unlock()
 		s.emitSyncState(st)
-		return err
+		return dirsync.Error(dirsync.CodeSessionClosed)
 	}
 
 	if err := waitForSyncBootstrap(bootstrapCh); err != nil {

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -128,7 +128,10 @@ func (s *Session) initSyncState(shellPath, shellType string, supported bool) {
 	if supported {
 		state.Status = directorySyncInitializing
 	}
-	state.Busy = !state.PromptReady || !state.PromptClean
+	// Busy means "currently mid-sync, can't accept another op". For an
+	// unsupported session, sync was never started — the toggle button must
+	// not be gated on busy or the user can't enable in the first place.
+	state.Busy = supported && (!state.PromptReady || !state.PromptClean)
 
 	s.syncMu.Lock()
 	s.syncState = state

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -177,6 +177,10 @@ func (s *Session) markUserInput(data []byte) {
 
 func (s *Session) notePrompt(cwd string) {
 	s.syncMu.Lock()
+	if !s.syncState.Supported {
+		s.syncMu.Unlock()
+		return
+	}
 	s.syncState.Cwd = strings.TrimRight(cwd, "\r\n")
 	s.syncState.CwdKnown = s.syncState.Cwd != ""
 	s.syncState.PromptReady = true
@@ -197,6 +201,10 @@ func (s *Session) noteObservedCwd(cwd string) {
 	}
 
 	s.syncMu.Lock()
+	if !s.syncState.Supported {
+		s.syncMu.Unlock()
+		return
+	}
 	s.syncState.Cwd = cleaned
 	s.syncState.CwdKnown = true
 	s.syncDirty = false
@@ -238,7 +246,7 @@ func (s *Session) prepareDirectoryChange(targetPath, expectedPath string, result
 	s.syncDirty = true
 	state := s.syncState
 
-	go s.emitSyncState(state)
+	s.emitSyncState(state)
 	return buildDirectoryChangeCommand(targetPath), nil
 }
 
@@ -313,6 +321,9 @@ func (s *Session) disableDirectorySync(reason string) {
 	bootstrapCh := s.syncBootstrapCh
 	s.syncBootstrapCh = nil
 	s.shellPID = 0
+	s.syncToken = ""
+	s.promptNonce = ""
+	s.promptPendingNonce = ""
 	state := s.syncState
 	s.syncMu.Unlock()
 
@@ -571,7 +582,10 @@ func trailingPrefixLength(data, prefix []byte) int {
 
 func (s *Session) handleSyncPayload(payload string) bool {
 	token, body, ok := strings.Cut(payload, ":")
-	if !ok || token == "" || token != s.syncToken {
+	s.syncMu.Lock()
+	syncToken := s.syncToken
+	s.syncMu.Unlock()
+	if !ok || token == "" || token != syncToken {
 		return false
 	}
 
@@ -583,7 +597,7 @@ func (s *Session) handleSyncPayload(payload string) bool {
 			return false
 		}
 		s.syncMu.Lock()
-		if s.shellPID != 0 {
+		if s.syncBootstrapCh == nil || !s.syncState.Supported || s.shellPID != 0 {
 			s.syncMu.Unlock()
 			return false
 		}
@@ -611,9 +625,10 @@ func (s *Session) handleSyncPayload(payload string) bool {
 		promptNonce := s.promptNonce
 		promptPendingNonce := s.promptPendingNonce
 		shellPID := s.shellPID
+		supported := s.syncState.Supported
 		s.syncMu.Unlock()
 		validCurrent := currentNonce == promptNonce || (promptPendingNonce != "" && currentNonce == promptPendingNonce)
-		if promptNonce == "" || !validCurrent || shellPID <= 0 {
+		if !supported || promptNonce == "" || !validCurrent || shellPID <= 0 {
 			return false
 		}
 		probe, err := s.probeShellState(shellPID)
@@ -654,6 +669,9 @@ func (s *Session) handleSyncPayload(payload string) bool {
 // Supported=false and a CodeTimeout error is returned. Callers should map
 // that to a "please exit foreground program and retry" hint in the UI.
 func (s *Session) EnableSync() error {
+	s.syncEnableMu.Lock()
+	defer s.syncEnableMu.Unlock()
+
 	s.syncMu.Lock()
 	if s.syncState.Supported && s.shellPID > 0 {
 		s.syncMu.Unlock()
@@ -662,12 +680,6 @@ func (s *Session) EnableSync() error {
 	if s.shellType == shellTypeUnsupported {
 		s.syncMu.Unlock()
 		return dirsync.Error(dirSyncErrUnsupported)
-	}
-	if s.syncBootstrapCh != nil {
-		// Another EnableSync is in flight; wait on the same channel.
-		ch := s.syncBootstrapCh
-		s.syncMu.Unlock()
-		return waitForSyncBootstrap(ch)
 	}
 
 	// Lazy shell detection: deferred from createSession to avoid the probe
@@ -698,8 +710,14 @@ func (s *Session) EnableSync() error {
 	}
 	s.syncToken = token
 	s.promptNonce = promptNonce
+	s.promptPendingNonce = ""
 	s.shellPID = 0
 	s.syncState.Supported = true
+	s.syncState.Cwd = ""
+	s.syncState.CwdKnown = false
+	s.syncState.PromptReady = false
+	s.syncState.PromptClean = true
+	s.syncState.Busy = true
 	s.syncState.Status = directorySyncInitializing
 	s.syncState.LastError = ""
 	s.syncDirty = true
@@ -709,21 +727,14 @@ func (s *Session) EnableSync() error {
 	cmd := buildEnableSyncCommand(s.shellType, token, promptNonce)
 	s.syncMu.Unlock()
 
-	go s.emitSyncState(state)
+	s.emitSyncState(state)
 
-	// cmd == "" is unreachable: shellTypeUnsupported was rejected at line 660
+	// cmd == "" is unreachable: shellTypeUnsupported was rejected above
 	// and buildEnableSyncCommand only returns "" for that case. No defensive
 	// branch needed; if invariants change, the write below will fail visibly.
 
 	if err := s.writeInternal([]byte(cmd)); err != nil {
-		s.clearBootstrap(bootstrapCh)
-		s.syncMu.Lock()
-		s.syncState.Supported = false
-		s.syncState.Status = directorySyncUnsupported
-		s.syncState.LastError = err.Error()
-		s.syncDirty = false
-		st := s.syncState
-		s.syncMu.Unlock()
+		st := s.rollbackSyncBootstrap(bootstrapCh, err.Error())
 		s.emitSyncState(st)
 		return dirsync.Error(dirsync.CodeSessionClosed)
 	}
@@ -733,17 +744,19 @@ func (s *Session) EnableSync() error {
 		// Only roll back if we still own this bootstrap; init:pid handler may
 		// have raced and already promoted the state to ready.
 		if s.syncBootstrapCh == bootstrapCh {
-			s.syncBootstrapCh = nil
-			s.syncState.Supported = false
-			s.syncState.Status = directorySyncUnsupported
-			s.syncState.LastError = err.Error()
-			s.shellPID = 0
-			s.syncDirty = false
+			s.rollbackSyncBootstrapLocked(err.Error())
+			st := s.syncState
+			s.syncMu.Unlock()
+			s.emitSyncState(st)
+			return err
 		}
+		ok := s.syncState.Supported && s.shellPID > 0
 		st := s.syncState
 		s.syncMu.Unlock()
 		s.emitSyncState(st)
-		return err
+		if !ok {
+			return err
+		}
 	}
 
 	// Bootstrap channel closed. Could be init:pid (success) or DisableSync
@@ -798,12 +811,31 @@ func (s *Session) DisableSync() {
 	s.disableDirectorySync(dirSyncErrUnsupported)
 }
 
-func (s *Session) clearBootstrap(ch chan struct{}) {
+func (s *Session) rollbackSyncBootstrap(ch chan struct{}, lastError string) DirectorySyncState {
 	s.syncMu.Lock()
 	if s.syncBootstrapCh == ch {
-		s.syncBootstrapCh = nil
+		s.rollbackSyncBootstrapLocked(lastError)
 	}
+	state := s.syncState
 	s.syncMu.Unlock()
+	return state
+}
+
+func (s *Session) rollbackSyncBootstrapLocked(lastError string) {
+	s.syncBootstrapCh = nil
+	s.shellPID = 0
+	s.syncToken = ""
+	s.promptNonce = ""
+	s.promptPendingNonce = ""
+	s.syncDirty = false
+	s.syncState.Supported = false
+	s.syncState.Cwd = ""
+	s.syncState.CwdKnown = false
+	s.syncState.PromptReady = false
+	s.syncState.PromptClean = true
+	s.syncState.Busy = false
+	s.syncState.Status = directorySyncUnsupported
+	s.syncState.LastError = lastError
 }
 
 func waitForSyncBootstrap(ch chan struct{}) error {

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -67,6 +67,12 @@ var (
 // tests can shorten it.
 var syncEnableTimeout = 3 * time.Second
 
+// syncFirstCwdGrace bounds the additional wait, after init:pid arrives, for
+// the first prompt nonce / probe to populate cwd. Without this, the first
+// F→T click after lazy enable can race the not-yet-arrived prompt nonce and
+// surface a spurious CWD_UNKNOWN toast.
+var syncFirstCwdGrace = 500 * time.Millisecond
+
 func (s *Session) GetSyncState() DirectorySyncState {
 	s.syncMu.Lock()
 	defer s.syncMu.Unlock()
@@ -726,6 +732,20 @@ func (s *Session) EnableSync() error {
 	s.syncMu.Unlock()
 	if !ok {
 		return dirsync.Error(dirSyncErrUnsupported)
+	}
+
+	// init:pid confirms the shell ran our injection, but cwd is filled by the
+	// next prompt nonce or the probe loop. Poll briefly so the first F→T click
+	// after lazy enable doesn't race a not-yet-arrived prompt.
+	deadline := time.Now().Add(syncFirstCwdGrace)
+	for time.Now().Before(deadline) {
+		s.syncMu.Lock()
+		known := s.syncState.CwdKnown
+		s.syncMu.Unlock()
+		if known {
+			return nil
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 	return nil
 }

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -656,7 +656,7 @@ func (s *Session) EnableSync() error {
 		s.syncMu.Unlock()
 		return nil
 	}
-	if s.shellType == shellTypeUnsupported || s.shellType == "" {
+	if s.shellType == shellTypeUnsupported {
 		s.syncMu.Unlock()
 		return dirsync.Error(dirSyncErrUnsupported)
 	}
@@ -665,6 +665,22 @@ func (s *Session) EnableSync() error {
 		ch := s.syncBootstrapCh
 		s.syncMu.Unlock()
 		return waitForSyncBootstrap(ch)
+	}
+
+	// Lazy shell detection: deferred from createSession to avoid the probe
+	// channel consuming PAM motd output before the main session shows it.
+	if s.shellType == "" {
+		s.syncMu.Unlock()
+		shellPath, shellType := detectRemoteShell(s.shared.client)
+		s.syncMu.Lock()
+		s.shellPath = shellPath
+		s.shellType = shellType
+		s.syncState.Shell = shellPath
+		s.syncState.ShellType = shellType
+		if shellType == shellTypeUnsupported {
+			s.syncMu.Unlock()
+			return dirsync.Error(dirSyncErrUnsupported)
+		}
 	}
 
 	token, err := generateSyncToken()

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -692,16 +692,17 @@ func (s *Session) EnableSync() error {
 
 	go s.emitSyncState(state)
 
-	if cmd == "" {
-		s.clearBootstrap(bootstrapCh)
-		return dirsync.Error(dirSyncErrUnsupported)
-	}
+	// cmd == "" is unreachable: shellTypeUnsupported was rejected at line 660
+	// and buildEnableSyncCommand only returns "" for that case. No defensive
+	// branch needed; if invariants change, the write below will fail visibly.
+
 	if err := s.writeInternal([]byte(cmd)); err != nil {
 		s.clearBootstrap(bootstrapCh)
 		s.syncMu.Lock()
 		s.syncState.Supported = false
 		s.syncState.Status = directorySyncUnsupported
 		s.syncState.LastError = err.Error()
+		s.syncDirty = false
 		st := s.syncState
 		s.syncMu.Unlock()
 		s.emitSyncState(st)
@@ -718,6 +719,7 @@ func (s *Session) EnableSync() error {
 			s.syncState.Status = directorySyncUnsupported
 			s.syncState.LastError = err.Error()
 			s.shellPID = 0
+			s.syncDirty = false
 		}
 		st := s.syncState
 		s.syncMu.Unlock()
@@ -736,7 +738,10 @@ func (s *Session) EnableSync() error {
 
 	// init:pid confirms the shell ran our injection, but cwd is filled by the
 	// next prompt nonce or the probe loop. Poll briefly so the first F→T click
-	// after lazy enable doesn't race a not-yet-arrived prompt.
+	// after lazy enable doesn't race a not-yet-arrived prompt. We don't surface
+	// an error if the grace expires — the shell is alive (init:pid arrived);
+	// the frontend will see cwd populate via the ssh:sync event whenever it
+	// finally lands.
 	deadline := time.Now().Add(syncFirstCwdGrace)
 	for time.Now().Before(deadline) {
 		s.syncMu.Lock()
@@ -752,6 +757,11 @@ func (s *Session) EnableSync() error {
 
 // DisableSync removes hooks from the running shell and flips state back to
 // unsupported. Best-effort: if the stdin write fails, state is still cleared.
+//
+// No frontend caller wires this up yet — kept for symmetry with EnableSync
+// and as the entry point when an explicit "disable directory sync" toggle
+// ships. If the toggle never lands, this and buildDisableSyncCommand can be
+// dropped.
 func (s *Session) DisableSync() {
 	s.syncMu.Lock()
 	if !s.syncState.Supported {

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -301,6 +301,9 @@ func (s *Session) disableDirectorySync(reason string) {
 	s.syncState.Busy = false
 	s.syncState.Status = directorySyncUnsupported
 	s.syncState.LastError = reason
+	bootstrapCh := s.syncBootstrapCh
+	s.syncBootstrapCh = nil
+	s.shellPID = 0
 	state := s.syncState
 	s.syncMu.Unlock()
 
@@ -308,6 +311,9 @@ func (s *Session) disableDirectorySync(reason string) {
 	if ch != nil {
 		ch <- err
 		close(ch)
+	}
+	if bootstrapCh != nil {
+		close(bootstrapCh)
 	}
 	s.emitSyncState(state)
 }
@@ -711,6 +717,15 @@ func (s *Session) EnableSync() error {
 		s.syncMu.Unlock()
 		s.emitSyncState(st)
 		return err
+	}
+
+	// Bootstrap channel closed. Could be init:pid (success) or DisableSync
+	// racing in (failure). Re-check state under lock.
+	s.syncMu.Lock()
+	ok := s.syncState.Supported && s.shellPID > 0
+	s.syncMu.Unlock()
+	if !ok {
+		return dirsync.Error(dirSyncErrUnsupported)
 	}
 	return nil
 }

--- a/internal/service/ssh_svc/dirsync_shell.go
+++ b/internal/service/ssh_svc/dirsync_shell.go
@@ -62,82 +62,54 @@ func generateSyncToken() (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
-func buildInteractiveShellCommand(shellPath, shellType, syncToken, promptNonce string) string {
+// buildEnableSyncCommand returns a single-line shell statement to be written
+// to the running interactive shell's stdin. It installs the prompt-proof
+// hook, sets the initial nonce, and emits the init:pid marker so the host
+// can confirm the shell received the injection.
+//
+// shellType MUST be one of shellTypeBash/shellTypeZsh/shellTypeKsh/shellTypeMksh.
+// Returns empty string for shellTypeUnsupported (or anything else).
+func buildEnableSyncCommand(shellType, syncToken, promptNonce string) string {
 	switch shellType {
 	case shellTypeBash:
-		return fmt.Sprintf(`rc="$(mktemp "${TMPDIR:-/tmp}/opskat-bash-XXXXXX")" && cat >"$rc" <<'EOF'
-[ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"
-opskat_next_prompt_nonce() {
-  local opskat_now opskat_rand
-  opskat_now=$(date +%%s%%N 2>/dev/null || date +%%s 2>/dev/null || printf '0')
-  opskat_rand=${RANDOM:-0}
-  printf '%%s-%%s-%%s' "$$" "$opskat_rand" "$opskat_now"
-}
-opskat_prompt_proof() {
-  local opskat_pwd opskat_current opskat_next
-  opskat_current=${OPSKAT_PROMPT_NONCE:-}
-  [ -n "$opskat_current" ] || return
-  opskat_next=$(opskat_next_prompt_nonce)
-  opskat_pwd=$(builtin pwd -P 2>/dev/null || builtin pwd 2>/dev/null || printf '')
-  printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$opskat_current" "$opskat_next" "$opskat_pwd"
-  OPSKAT_PROMPT_NONCE=$opskat_next
-}
-OPSKAT_PROMPT_NONCE=%s
-PROMPT_COMMAND="opskat_prompt_proof${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
-EOF
-printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"
-exec %s --rcfile "$rc" -i`, syncToken, shellQuote(promptNonce), syncToken, shellQuote(shellPath))
+		return fmt.Sprintf(
+			`opskat_next_prompt_nonce(){ local n r;n=$(date +%%s%%N 2>/dev/null||date +%%s 2>/dev/null||printf 0);r=${RANDOM:-0};printf '%%s-%%s-%%s' "$$" "$r" "$n";};`+
+				`opskat_prompt_proof(){ local p c x;c=${OPSKAT_PROMPT_NONCE:-};[ -n "$c" ]||return;x=$(opskat_next_prompt_nonce);p=$(builtin pwd -P 2>/dev/null||builtin pwd 2>/dev/null||printf '');printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$c" "$x" "$p";OPSKAT_PROMPT_NONCE=$x;};`+
+				`OPSKAT_PROMPT_NONCE=%s;`+
+				`PROMPT_COMMAND="opskat_prompt_proof${PROMPT_COMMAND:+;$PROMPT_COMMAND}";`+
+				`printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"`+"\r",
+			syncToken, shellQuote(promptNonce), syncToken)
 	case shellTypeZsh:
-		return fmt.Sprintf(`dir="$(mktemp -d "${TMPDIR:-/tmp}/opskat-zsh-XXXXXX")" && cat >"$dir/.zshenv" <<'EOF_ENV'
-[[ -f "$HOME/.zshenv" ]] && source "$HOME/.zshenv"
-EOF_ENV
-cat >"$dir/.zshrc" <<'EOF_RC'
-[[ -f "$HOME/.zprofile" ]] && source "$HOME/.zprofile"
-[[ -f "$HOME/.zshrc" ]] && source "$HOME/.zshrc"
-autoload -Uz add-zsh-hook
-opskat_next_prompt_nonce() {
-  local opskat_now opskat_rand
-  opskat_now=$(date +%%s%%N 2>/dev/null || date +%%s 2>/dev/null || printf '0')
-  opskat_rand=${RANDOM:-0}
-  printf '%%s-%%s-%%s' "$$" "$opskat_rand" "$opskat_now"
-}
-opskat_prompt_proof() {
-  local opskat_pwd opskat_current opskat_next
-  opskat_current=${OPSKAT_PROMPT_NONCE:-}
-  [[ -n "$opskat_current" ]] || return
-  opskat_next=$(opskat_next_prompt_nonce)
-  opskat_pwd=$(pwd -P 2>/dev/null || pwd 2>/dev/null || printf '')
-  printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$opskat_current" "$opskat_next" "$opskat_pwd"
-  OPSKAT_PROMPT_NONCE=$opskat_next
-}
-OPSKAT_PROMPT_NONCE=%s
-add-zsh-hook precmd opskat_prompt_proof
-EOF_RC
-export ZDOTDIR="$dir"
-printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"
-exec %s -i`, syncToken, shellQuote(promptNonce), syncToken, shellQuote(shellPath))
+		return fmt.Sprintf(
+			`opskat_next_prompt_nonce(){ local n r;n=$(date +%%s%%N 2>/dev/null||date +%%s 2>/dev/null||printf 0);r=${RANDOM:-0};printf '%%s-%%s-%%s' "$$" "$r" "$n";};`+
+				`opskat_prompt_proof(){ local p c x;c=${OPSKAT_PROMPT_NONCE:-};[[ -n "$c" ]]||return;x=$(opskat_next_prompt_nonce);p=$(pwd -P 2>/dev/null||pwd 2>/dev/null||printf '');printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$c" "$x" "$p";OPSKAT_PROMPT_NONCE=$x;};`+
+				`OPSKAT_PROMPT_NONCE=%s;`+
+				`autoload -Uz add-zsh-hook;add-zsh-hook precmd opskat_prompt_proof;`+
+				`printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"`+"\r",
+			syncToken, shellQuote(promptNonce), syncToken)
 	case shellTypeKsh, shellTypeMksh:
-		return fmt.Sprintf(`envfile="$(mktemp "${TMPDIR:-/tmp}/opskat-ksh-XXXXXX")" && cat >"$envfile" <<'EOF'
-[ -f "$HOME/.profile" ] && . "$HOME/.profile"
-opskat_next_prompt_nonce() {
-  OPSKAT_NOW=$(date +%%s%%N 2>/dev/null || date +%%s 2>/dev/null || printf '0')
-  OPSKAT_RAND=${RANDOM:-0}
-  printf '%%s-%%s-%%s' "$$" "$OPSKAT_RAND" "$OPSKAT_NOW"
+		return fmt.Sprintf(
+			`opskat_next_prompt_nonce(){ OPSKAT_NOW=$(date +%%s%%N 2>/dev/null||date +%%s 2>/dev/null||printf 0);OPSKAT_RAND=${RANDOM:-0};printf '%%s-%%s-%%s' "$$" "$OPSKAT_RAND" "$OPSKAT_NOW";};`+
+				`opskat_prompt_proof(){ OPSKAT_CURRENT=${OPSKAT_PROMPT_NONCE:-};[ -n "$OPSKAT_CURRENT" ]||return;OPSKAT_NEXT=$(opskat_next_prompt_nonce);OPSKAT_PWD=$(pwd -P 2>/dev/null||pwd 2>/dev/null||printf '');printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$OPSKAT_CURRENT" "$OPSKAT_NEXT" "$OPSKAT_PWD";OPSKAT_PROMPT_NONCE=$OPSKAT_NEXT;};`+
+				`OPSKAT_PROMPT_NONCE=%s;`+
+				`OPSKAT_ORIG_PS1=${OPSKAT_ORIG_PS1:-$PS1};PS1='$(opskat_prompt_proof)'"$OPSKAT_ORIG_PS1";`+
+				`printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"`+"\r",
+			syncToken, shellQuote(promptNonce), syncToken)
+	default:
+		return ""
+	}
 }
-opskat_prompt_proof() {
-  OPSKAT_CURRENT=${OPSKAT_PROMPT_NONCE:-}
-  [ -n "$OPSKAT_CURRENT" ] || return
-  OPSKAT_NEXT=$(opskat_next_prompt_nonce)
-  OPSKAT_PWD=$(pwd -P 2>/dev/null || pwd 2>/dev/null || printf '')
-  printf '\033]1337;opskat:%s:prompt:%%s:%%s:%%s\007' "$OPSKAT_CURRENT" "$OPSKAT_NEXT" "$OPSKAT_PWD"
-  OPSKAT_PROMPT_NONCE=$OPSKAT_NEXT
-}
-OPSKAT_PROMPT_NONCE=%s
-PS1='$(opskat_prompt_proof)'"$PS1"
-EOF
-export ENV="$envfile"
-printf '\033]1337;opskat:%s:init:pid:%%s\007' "$$"
-exec %s -i`, syncToken, shellQuote(promptNonce), syncToken, shellQuote(shellPath))
+
+// buildDisableSyncCommand returns a one-line statement that removes the hook
+// and unsets helper functions. Safe to send even if EnableSync was never run.
+func buildDisableSyncCommand(shellType string) string {
+	switch shellType {
+	case shellTypeBash:
+		return `PROMPT_COMMAND=${PROMPT_COMMAND#opskat_prompt_proof};PROMPT_COMMAND=${PROMPT_COMMAND#;};unset -f opskat_prompt_proof opskat_next_prompt_nonce 2>/dev/null;unset OPSKAT_PROMPT_NONCE` + "\r"
+	case shellTypeZsh:
+		return `add-zsh-hook -d precmd opskat_prompt_proof 2>/dev/null;unset -f opskat_prompt_proof opskat_next_prompt_nonce 2>/dev/null;unset OPSKAT_PROMPT_NONCE` + "\r"
+	case shellTypeKsh, shellTypeMksh:
+		return `[ -n "$OPSKAT_ORIG_PS1" ] && PS1=$OPSKAT_ORIG_PS1;unset -f opskat_prompt_proof opskat_next_prompt_nonce 2>/dev/null;unset OPSKAT_PROMPT_NONCE OPSKAT_ORIG_PS1` + "\r"
 	default:
 		return ""
 	}

--- a/internal/service/ssh_svc/dirsync_shell_test.go
+++ b/internal/service/ssh_svc/dirsync_shell_test.go
@@ -1,0 +1,78 @@
+package ssh_svc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildEnableSyncCommandBash(t *testing.T) {
+	cmd := buildEnableSyncCommand(shellTypeBash, "TOK", "NONCE")
+	if !strings.Contains(cmd, "opskat_prompt_proof") {
+		t.Fatalf("missing function name: %s", cmd)
+	}
+	if !strings.Contains(cmd, "OPSKAT_PROMPT_NONCE='NONCE'") {
+		t.Fatalf("missing nonce assignment (shellQuote'd): %s", cmd)
+	}
+	if !strings.Contains(cmd, `PROMPT_COMMAND="opskat_prompt_proof`) {
+		t.Fatalf("missing PROMPT_COMMAND wiring: %s", cmd)
+	}
+	if !strings.Contains(cmd, `1337;opskat:TOK:init:pid:`) {
+		t.Fatalf("missing init marker: %s", cmd)
+	}
+	if strings.ContainsAny(cmd, "\n") {
+		t.Fatalf("command must be single-line, got newline: %q", cmd)
+	}
+	if !strings.HasSuffix(cmd, "\r") {
+		t.Fatalf("command must end with carriage return: %q", cmd)
+	}
+}
+
+func TestBuildEnableSyncCommandZsh(t *testing.T) {
+	cmd := buildEnableSyncCommand(shellTypeZsh, "TOK", "NONCE")
+	if !strings.Contains(cmd, "add-zsh-hook precmd opskat_prompt_proof") {
+		t.Fatalf("missing add-zsh-hook: %s", cmd)
+	}
+	if !strings.Contains(cmd, "1337;opskat:TOK:init:pid:") {
+		t.Fatalf("missing init marker: %s", cmd)
+	}
+	if strings.ContainsAny(cmd, "\n") {
+		t.Fatalf("must be single line: %q", cmd)
+	}
+	if !strings.HasSuffix(cmd, "\r") {
+		t.Fatalf("must end with \\r: %q", cmd)
+	}
+}
+
+func TestBuildEnableSyncCommandKsh(t *testing.T) {
+	cmd := buildEnableSyncCommand(shellTypeKsh, "TOK", "NONCE")
+	if !strings.Contains(cmd, `PS1='$(opskat_prompt_proof)'`) {
+		t.Fatalf("missing PS1 wiring: %s", cmd)
+	}
+	if strings.ContainsAny(cmd, "\n") {
+		t.Fatalf("must be single line: %q", cmd)
+	}
+	if !strings.HasSuffix(cmd, "\r") {
+		t.Fatalf("must end with \\r: %q", cmd)
+	}
+}
+
+func TestBuildEnableSyncCommandUnsupported(t *testing.T) {
+	if got := buildEnableSyncCommand(shellTypeUnsupported, "T", "N"); got != "" {
+		t.Fatalf("unsupported shell must return empty, got: %q", got)
+	}
+}
+
+func TestBuildDisableSyncCommand(t *testing.T) {
+	for _, sh := range []string{shellTypeBash, shellTypeZsh, shellTypeKsh, shellTypeMksh} {
+		got := buildDisableSyncCommand(sh)
+		if got == "" || !strings.HasSuffix(got, "\r") {
+			t.Fatalf("disable cmd for %s should be non-empty and end in \\r, got %q", sh, got)
+		}
+		if strings.ContainsAny(got, "\n") {
+			t.Fatalf("must be single line: %q", got)
+		}
+	}
+	if buildDisableSyncCommand(shellTypeUnsupported) != "" {
+		t.Fatal("unsupported should return empty")
+	}
+}

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -72,13 +72,13 @@ type Session struct {
 	onClosed func(sessionID string) // 会话关闭回调
 	onSync   func(sessionID string, state DirectorySyncState)
 
-	// shellPath / shellType are detected once at session creation by
-	// detectRemoteShell. They are read by EnableSync to build the right
-	// hook-installer payload. Empty / "unsupported" means lazy sync is
-	// not available for this session.
+	// shellPath / shellType are detected lazily by EnableSync. Empty means no
+	// sync attempt has needed shell detection yet; "unsupported" means the
+	// remote shell cannot host the directory-sync prompt hook.
 	shellPath string
 	shellType string
 
+	syncEnableMu       sync.Mutex
 	syncMu             sync.Mutex
 	syncState          DirectorySyncState
 	pendingDirChange   chan error

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -91,6 +91,7 @@ type Session struct {
 	promptPendingNonce string
 	shellPID           int
 	syncDirty          bool
+	syncBootstrapCh    chan struct{} // closed when EnableSync receives init:pid; nil when not bootstrapping
 	syncProbeActive    bool
 	probeShellStateFn  func(int) (shellProbeResult, error)
 }

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -351,25 +351,12 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 	}
 
 	shellPath, shellType := detectRemoteShell(shared.client)
-	supported := shellType == shellTypeBash || shellType == shellTypeZsh || shellType == shellTypeKsh || shellType == shellTypeMksh
-	sess.initSyncState(shellPath, shellType, supported)
+	// Lazy injection: always start a native interactive shell so sshd can emit
+	// "Last login" / motd / banner. Sync hooks are installed on demand via
+	// Session.EnableSync (added in a later task). Until then, sync stays off.
+	sess.initSyncState(shellPath, shellType, false)
 
-	if supported {
-		if err := session.Start(buildInteractiveShellCommand(shellPath, shellType, syncToken, promptNonce)); err != nil {
-			logger.Default().Warn("wrapped shell start failed, fallback to plain shell",
-				zap.Error(err),
-				zap.String("shellPath", shellPath),
-				zap.String("shellType", shellType),
-			)
-			sess.initSyncState(shellPath, shellType, false)
-			if err := session.Shell(); err != nil {
-				if closeErr := session.Close(); closeErr != nil {
-					logger.Default().Warn("close session after shell fallback failure", zap.Error(closeErr))
-				}
-				return "", fmt.Errorf("启动shell失败: %w", err)
-			}
-		}
-	} else if err := session.Shell(); err != nil {
+	if err := session.Shell(); err != nil {
 		if closeErr := session.Close(); closeErr != nil {
 			logger.Default().Warn("close session after shell start failure", zap.Error(closeErr))
 		}

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -327,27 +327,25 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 	sessionID := fmt.Sprintf("ssh-%d", m.counter)
 	m.mu.Unlock()
 
-	shellPath, shellType := detectRemoteShell(shared.client)
 	sess := &Session{
-		ID:        sessionID,
-		AssetID:   assetID,
-		shared:    shared,
-		session:   session,
-		stdin:     stdin,
-		stdout:    stdout,
-		shellPath: shellPath,
-		shellType: shellType,
-		onData:    func(data []byte) { onData(sessionID, data) },
-		onClosed:  onClosed,
+		ID:       sessionID,
+		AssetID:  assetID,
+		shared:   shared,
+		session:  session,
+		stdin:    stdin,
+		stdout:   stdout,
+		onData:   func(data []byte) { onData(sessionID, data) },
+		onClosed: onClosed,
 	}
 	if onSync != nil {
 		sess.onSync = func(_ string, state DirectorySyncState) { onSync(sessionID, state) }
 	}
 
-	// Always start a native interactive shell so sshd emits "Last login" /
-	// motd / banner. Sync hooks are installed on demand via Session.EnableSync
-	// (added in Task 3); until then, sync stays off.
-	sess.initSyncState(shellPath, shellType, false)
+	// Start a native interactive shell so sshd emits "Last login" / motd /
+	// banner natively. Shell-type detection and sync hooks are deferred to
+	// Session.EnableSync — opening a probe SSH channel here would consume the
+	// PAM motd output before the user's main session sees it.
+	sess.initSyncState("", "", false)
 
 	if err := session.Shell(); err != nil {
 		if closeErr := session.Close(); closeErr != nil {

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -72,6 +72,13 @@ type Session struct {
 	onClosed func(sessionID string) // 会话关闭回调
 	onSync   func(sessionID string, state DirectorySyncState)
 
+	// shellPath / shellType are detected once at session creation by
+	// detectRemoteShell. They are read by EnableSync to build the right
+	// hook-installer payload. Empty / "unsupported" means lazy sync is
+	// not available for this session.
+	shellPath string
+	shellType string
+
 	syncMu             sync.Mutex
 	syncState          DirectorySyncState
 	pendingDirChange   chan error
@@ -319,41 +326,26 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 	sessionID := fmt.Sprintf("ssh-%d", m.counter)
 	m.mu.Unlock()
 
-	syncToken, err := generateSyncToken()
-	if err != nil {
-		if closeErr := session.Close(); closeErr != nil {
-			logger.Default().Warn("close session after sync token failure", zap.Error(closeErr))
-		}
-		return "", fmt.Errorf("生成目录同步令牌失败: %w", err)
-	}
-	promptNonce, err := generateSyncToken()
-	if err != nil {
-		if closeErr := session.Close(); closeErr != nil {
-			logger.Default().Warn("close session after prompt nonce failure", zap.Error(closeErr))
-		}
-		return "", fmt.Errorf("生成提示符校验令牌失败: %w", err)
-	}
-
+	shellPath, shellType := detectRemoteShell(shared.client)
 	sess := &Session{
-		ID:          sessionID,
-		AssetID:     assetID,
-		shared:      shared,
-		session:     session,
-		stdin:       stdin,
-		stdout:      stdout,
-		onData:      func(data []byte) { onData(sessionID, data) },
-		onClosed:    onClosed,
-		syncToken:   syncToken,
-		promptNonce: promptNonce,
+		ID:        sessionID,
+		AssetID:   assetID,
+		shared:    shared,
+		session:   session,
+		stdin:     stdin,
+		stdout:    stdout,
+		shellPath: shellPath,
+		shellType: shellType,
+		onData:    func(data []byte) { onData(sessionID, data) },
+		onClosed:  onClosed,
 	}
 	if onSync != nil {
 		sess.onSync = func(_ string, state DirectorySyncState) { onSync(sessionID, state) }
 	}
 
-	shellPath, shellType := detectRemoteShell(shared.client)
-	// Lazy injection: always start a native interactive shell so sshd can emit
-	// "Last login" / motd / banner. Sync hooks are installed on demand via
-	// Session.EnableSync (added in a later task). Until then, sync stays off.
+	// Always start a native interactive shell so sshd emits "Last login" /
+	// motd / banner. Sync hooks are installed on demand via Session.EnableSync
+	// (added in Task 3); until then, sync stays off.
 	sess.initSyncState(shellPath, shellType, false)
 
 	if err := session.Shell(); err != nil {

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -1,6 +1,7 @@
 package ssh_svc
 
 import (
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -445,5 +446,54 @@ func TestSessionStartsWithSupportedFalse(t *testing.T) {
 	}
 	if state.Status != directorySyncUnsupported {
 		t.Fatalf("Status should be unsupported initially, got %q", state.Status)
+	}
+}
+
+func TestEnableSyncTimesOutWhenNoMarker(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+	sess := &Session{
+		ID:        "test-timeout",
+		stdin:     pw,
+		shellPath: "/bin/bash",
+		shellType: shellTypeBash,
+	}
+	sess.initSyncState(sess.shellPath, sess.shellType, false)
+
+	// Drain the pipe so writeInternal doesn't block.
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+
+	prev := syncEnableTimeout
+	syncEnableTimeout = 100 * time.Millisecond
+	defer func() { syncEnableTimeout = prev }()
+
+	err := sess.EnableSync()
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if state := sess.GetSyncState(); state.Supported {
+		t.Fatalf("Supported must remain false on timeout, got %#v", state)
+	}
+}
+
+func TestEnableSyncUnsupportedShellReturnsError(t *testing.T) {
+	sess := &Session{ID: "u", shellType: shellTypeUnsupported}
+	sess.initSyncState("/bin/sh", shellTypeUnsupported, false)
+	if err := sess.EnableSync(); err == nil {
+		t.Fatal("expected error for unsupported shell")
+	}
+}
+
+func TestEnableSyncIdempotent(t *testing.T) {
+	sess := &Session{ID: "i", shellType: shellTypeBash, shellPath: "/bin/bash"}
+	sess.initSyncState(sess.shellPath, sess.shellType, true)
+	sess.syncMu.Lock()
+	sess.syncState.Supported = true
+	sess.syncState.Status = directorySyncReady
+	sess.shellPID = 12345
+	sess.syncMu.Unlock()
+
+	if err := sess.EnableSync(); err != nil {
+		t.Fatalf("idempotent enable should return nil, got %v", err)
 	}
 }

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -1,8 +1,10 @@
 package ssh_svc
 
 import (
+	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +22,62 @@ func newTestSyncSession(token string) *Session {
 
 func buildTestSyncSequence(token, payload string) []byte {
 	return []byte(syncSequencePrefix + token + ":" + payload + syncSequenceTerm)
+}
+
+type recordingWriteCloser struct {
+	mu      sync.Mutex
+	writes  [][]byte
+	err     error
+	onWrite func([]byte)
+}
+
+func (w *recordingWriteCloser) Write(data []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	copied := append([]byte(nil), data...)
+	w.mu.Lock()
+	w.writes = append(w.writes, copied)
+	w.mu.Unlock()
+	if w.onWrite != nil {
+		w.onWrite(copied)
+	}
+	return len(data), nil
+}
+
+func (w *recordingWriteCloser) Close() error {
+	return nil
+}
+
+func (w *recordingWriteCloser) writeCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.writes)
+}
+
+func (w *recordingWriteCloser) lastWrite() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.writes) == 0 {
+		return nil
+	}
+	return append([]byte(nil), w.writes[len(w.writes)-1]...)
+}
+
+func extractInitTokenFromEnableCommand(t *testing.T, cmd []byte) string {
+	t.Helper()
+	const marker = "1337;opskat:"
+	text := string(cmd)
+	idx := strings.LastIndex(text, marker)
+	if idx < 0 {
+		t.Fatalf("enable command missing init marker: %q", text)
+	}
+	remainder := text[idx+len(marker):]
+	token, _, ok := strings.Cut(remainder, ":init:pid:")
+	if !ok || token == "" {
+		t.Fatalf("enable command missing init token: %q", text)
+	}
+	return token
 }
 
 func TestManager_Basic(t *testing.T) {
@@ -130,6 +188,7 @@ func TestNormalizeShellType(t *testing.T) {
 
 func TestSession_FilterOutputCapturesInitMarker(t *testing.T) {
 	sess := newTestSyncSession("real-token")
+	sess.syncBootstrapCh = make(chan struct{})
 
 	raw := []byte("hello" + syncSequencePrefix + "real-token:init:pid:4242" + syncSequenceTerm + "world")
 	filtered := sess.filterOutput(raw)
@@ -137,6 +196,7 @@ func TestSession_FilterOutputCapturesInitMarker(t *testing.T) {
 	assert.Equal(t, "helloworld", string(filtered))
 	assert.Equal(t, 4242, sess.shellPID)
 	assert.True(t, sess.syncDirty)
+	assert.Nil(t, sess.syncBootstrapCh)
 }
 
 func TestSession_FilterOutputAcceptsValidatedPromptProof(t *testing.T) {
@@ -450,18 +510,14 @@ func TestSessionStartsWithSupportedFalse(t *testing.T) {
 }
 
 func TestEnableSyncTimesOutWhenNoMarker(t *testing.T) {
-	pr, pw := io.Pipe()
-	defer func() { _ = pw.Close() }()
+	stdin := &recordingWriteCloser{}
 	sess := &Session{
 		ID:        "test-timeout",
-		stdin:     pw,
+		stdin:     stdin,
 		shellPath: "/bin/bash",
 		shellType: shellTypeBash,
 	}
 	sess.initSyncState(sess.shellPath, sess.shellType, false)
-
-	// Drain the pipe so writeInternal doesn't block.
-	go func() { _, _ = io.Copy(io.Discard, pr) }()
 
 	prev := syncEnableTimeout
 	syncEnableTimeout = 100 * time.Millisecond
@@ -474,6 +530,56 @@ func TestEnableSyncTimesOutWhenNoMarker(t *testing.T) {
 	if state := sess.GetSyncState(); state.Supported {
 		t.Fatalf("Supported must remain false on timeout, got %#v", state)
 	}
+	if sess.syncToken != "" || sess.promptNonce != "" || sess.promptPendingNonce != "" {
+		t.Fatal("timeout must invalidate sync tokens")
+	}
+	if sess.shellPID != 0 {
+		t.Fatalf("timeout must clear shellPID, got %d", sess.shellPID)
+	}
+}
+
+func TestEnableSyncIgnoresLateInitMarkerAfterTimeout(t *testing.T) {
+	stdin := &recordingWriteCloser{}
+	sess := &Session{
+		ID:        "test-late-marker",
+		stdin:     stdin,
+		shellPath: "/bin/bash",
+		shellType: shellTypeBash,
+	}
+	sess.initSyncState(sess.shellPath, sess.shellType, false)
+
+	prevTimeout := syncEnableTimeout
+	syncEnableTimeout = 20 * time.Millisecond
+	defer func() { syncEnableTimeout = prevTimeout }()
+
+	err := sess.EnableSync()
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	token := extractInitTokenFromEnableCommand(t, stdin.lastWrite())
+	filtered := sess.filterOutput(buildTestSyncSequence(token, "init:pid:999"))
+	assert.NotEmpty(t, filtered, "late marker should be replayed as ordinary output")
+
+	state := sess.GetSyncState()
+	assert.False(t, state.Supported)
+	assert.Equal(t, directorySyncUnsupported, state.Status)
+	assert.Equal(t, 0, sess.shellPID)
+}
+
+func TestSessionIgnoresPromptAfterDisable(t *testing.T) {
+	sess := newTestSyncSession("real-token")
+	sess.promptNonce = "prompt-one"
+	sess.shellPID = 4242
+	sess.disableDirectorySync(dirSyncErrUnsupported)
+
+	filtered := sess.filterOutput(buildTestSyncSequence("real-token", "prompt:prompt-one:prompt-two:/srv/app"))
+	assert.NotEmpty(t, filtered, "stale prompt marker should not be consumed after disable")
+
+	state := sess.GetSyncState()
+	assert.False(t, state.Supported)
+	assert.False(t, state.CwdKnown)
+	assert.Equal(t, 0, sess.shellPID)
 }
 
 func TestEnableSyncUnsupportedShellReturnsError(t *testing.T) {
@@ -498,6 +604,70 @@ func TestEnableSyncIdempotent(t *testing.T) {
 	}
 }
 
+func TestEnableSyncSerializesConcurrentFirstEnable(t *testing.T) {
+	stdin := &recordingWriteCloser{}
+	sess := &Session{
+		ID:        "test-concurrent",
+		stdin:     stdin,
+		shellPath: "/bin/bash",
+		shellType: shellTypeBash,
+	}
+	sess.initSyncState(sess.shellPath, sess.shellType, false)
+	stdin.onWrite = func(data []byte) {
+		token := extractInitTokenFromEnableCommand(t, data)
+		_ = sess.filterOutput(buildTestSyncSequence(token, "init:pid:4242"))
+	}
+
+	prevGrace := syncFirstCwdGrace
+	syncFirstCwdGrace = time.Millisecond
+	defer func() { syncFirstCwdGrace = prevGrace }()
+
+	start := make(chan struct{})
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errCh <- sess.EnableSync()
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, 1, stdin.writeCount(), "concurrent first enable should write one bootstrap command")
+	state := sess.GetSyncState()
+	assert.True(t, state.Supported)
+	assert.Equal(t, 4242, sess.shellPID)
+}
+
+func TestEnableSyncWriteFailureRollsBackBootstrap(t *testing.T) {
+	stdin := &recordingWriteCloser{err: errors.New("broken pipe")}
+	sess := &Session{
+		ID:        "test-write-failure",
+		stdin:     stdin,
+		shellPath: "/bin/bash",
+		shellType: shellTypeBash,
+	}
+	sess.initSyncState(sess.shellPath, sess.shellType, false)
+
+	err := sess.EnableSync()
+	assert.EqualError(t, err, dirsync.CodeSessionClosed)
+
+	state := sess.GetSyncState()
+	assert.False(t, state.Supported)
+	assert.False(t, state.Busy)
+	assert.Equal(t, directorySyncUnsupported, state.Status)
+	assert.Empty(t, sess.syncToken)
+	assert.Empty(t, sess.promptNonce)
+	assert.Nil(t, sess.syncBootstrapCh)
+}
+
 func TestEnableSyncReturnsErrorIfDisableRacesIn(t *testing.T) {
 	pr, pw := io.Pipe()
 	defer func() { _ = pw.Close() }()
@@ -517,8 +687,17 @@ func TestEnableSyncReturnsErrorIfDisableRacesIn(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() { errCh <- sess.EnableSync() }()
 
-	// Wait briefly so EnableSync has set up syncBootstrapCh.
-	time.Sleep(50 * time.Millisecond)
+	assert.Eventually(t, func() bool {
+		sess.syncMu.Lock()
+		bootstrapping := sess.syncBootstrapCh != nil
+		state := sess.syncState
+		sess.syncMu.Unlock()
+		return bootstrapping &&
+			state.Supported &&
+			state.Busy &&
+			state.Status == directorySyncInitializing &&
+			!state.CwdKnown
+	}, 500*time.Millisecond, 10*time.Millisecond, "EnableSync should enter busy initializing state")
 
 	// Simulate a disable racing in before init:pid arrives.
 	sess.disableDirectorySync(dirSyncErrUnsupported)

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -352,15 +352,6 @@ func TestParseShellProbeOutput(t *testing.T) {
 	assert.True(t, result.promptReady)
 }
 
-func TestBuildInteractiveShellCommand_BashDoesNotSourceProfiles(t *testing.T) {
-	command := buildInteractiveShellCommand("/bin/bash", shellTypeBash, "token", "nonce")
-
-	assert.NotContains(t, command, ".bash_profile")
-	assert.NotContains(t, command, ".bash_login")
-	assert.NotContains(t, command, ".profile")
-	assert.Contains(t, command, ".bashrc")
-}
-
 func TestSession_PendingDirectoryChangeAcceptsCanonicalCwd(t *testing.T) {
 	sess := newTestSyncSession("real-token")
 	sess.notePrompt("/home/me")

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -447,13 +447,3 @@ func TestSessionStartsWithSupportedFalse(t *testing.T) {
 		t.Fatalf("Status should be unsupported initially, got %q", state.Status)
 	}
 }
-
-func TestSessionPersistsShellInfo(t *testing.T) {
-	sess := &Session{ID: "test", shellPath: "/usr/bin/zsh", shellType: shellTypeZsh}
-	if sess.shellPath != "/usr/bin/zsh" {
-		t.Fatalf("shellPath not persisted: %q", sess.shellPath)
-	}
-	if sess.shellType != shellTypeZsh {
-		t.Fatalf("shellType not persisted: %q", sess.shellType)
-	}
-}

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -497,3 +497,42 @@ func TestEnableSyncIdempotent(t *testing.T) {
 		t.Fatalf("idempotent enable should return nil, got %v", err)
 	}
 }
+
+func TestEnableSyncReturnsErrorIfDisableRacesIn(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+	sess := &Session{
+		ID:        "test-race",
+		stdin:     pw,
+		shellPath: "/bin/bash",
+		shellType: shellTypeBash,
+	}
+	sess.initSyncState(sess.shellPath, sess.shellType, false)
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+
+	prev := syncEnableTimeout
+	syncEnableTimeout = 500 * time.Millisecond
+	defer func() { syncEnableTimeout = prev }()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- sess.EnableSync() }()
+
+	// Wait briefly so EnableSync has set up syncBootstrapCh.
+	time.Sleep(50 * time.Millisecond)
+
+	// Simulate a disable racing in before init:pid arrives.
+	sess.disableDirectorySync(dirSyncErrUnsupported)
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("EnableSync must report error when DisableSync races in")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("EnableSync did not return after DisableSync; bootstrap channel not closed?")
+	}
+
+	if state := sess.GetSyncState(); state.Supported {
+		t.Fatalf("Supported must be false after disable race, got %#v", state)
+	}
+}

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -431,3 +431,29 @@ func TestSession_ProbeLoopDisablesSyncWhenPromptProbeHasNoCwd(t *testing.T) {
 			state.LastError == dirSyncErrProbeUnsupported
 	}, 500*time.Millisecond, 10*time.Millisecond)
 }
+
+func TestSessionStartsWithSupportedFalse(t *testing.T) {
+	sess := &Session{ID: "test"}
+	sess.initSyncState("/bin/bash", shellTypeBash, false)
+
+	state := sess.GetSyncState()
+	if state.Supported {
+		t.Fatal("Supported must be false until EnableSync is invoked")
+	}
+	if state.ShellType != shellTypeBash {
+		t.Fatalf("ShellType not retained: %q", state.ShellType)
+	}
+	if state.Status != directorySyncUnsupported {
+		t.Fatalf("Status should be unsupported initially, got %q", state.Status)
+	}
+}
+
+func TestSessionPersistsShellInfo(t *testing.T) {
+	sess := &Session{ID: "test", shellPath: "/usr/bin/zsh", shellType: shellTypeZsh}
+	if sess.shellPath != "/usr/bin/zsh" {
+		t.Fatalf("shellPath not persisted: %q", sess.shellPath)
+	}
+	if sess.shellType != shellTypeZsh {
+		t.Fatalf("shellType not persisted: %q", sess.shellType)
+	}
+}


### PR DESCRIPTION
## 概要

- 将交互式 SSH 终端改回普通 shell request 启动，让服务端登录输出可以正常显示，例如 `Last login` 和 MOTD。
- 目录同步改为按需启用：连接 SSH、打开文件管理器时都不注入 prompt hook；只有点击文件管理器里的 `T→F`、`F→T`、跟随同步按钮时才调用 `EnableSSHDirectorySync` 并注入。
- 保留 cwd 同步能力：启用后在已启动的 shell 中注入 prompt hook，覆盖 bash、zsh、ksh 和 mksh，并避免重复注入。
- 增加回归测试，覆盖按需启用、重复启用不重复注入、按钮触发启用、bootstrap 命令、token 格式化、echo 恢复，以及 bootstrap 写入失败时目录同步降级。

Refs #63

## 测试

- [x] `go test ./internal/service/ssh_svc`
- [x] `go test ./internal/service/ssh_svc ./internal/app ./cmd/opsctl/command ./internal/sshpool`
- [x] `pnpm --dir frontend test -- FileManagerPanel.test.tsx`
- [x] `pnpm --dir frontend test -- FileManagerPanel.test.tsx terminalStore.test.ts`
- [x] `pnpm --dir frontend build`
- [x] `pnpm --dir frontend/packages/devserver-ui build`
- [x] `go test ./...`
- [x] `git diff --check`
