### PR TITLE
✨ 支持 AI 对话框 Ctrl+Enter 换行

### DIFF
--- a/frontend/src/__tests__/AIChatInput.test.tsx
+++ b/frontend/src/__tests__/AIChatInput.test.tsx
@@ -338,4 +338,63 @@ describe("AIChatInput", () => {
     await userEvent.keyboard("{ArrowUp}");
     await waitFor(() => expect(editorRef.current!.getText()).toBe("最新"));
   });
+
+  it("Ctrl+Enter 在 sendOnEnter=true 模式下插入换行而不触发发送", async () => {
+    const onSubmit = vi.fn();
+    const editorRef = { current: null as Editor | null };
+    const handleRef = createRef<AIChatInputHandle>();
+    render(
+      <AIChatInput ref={handleRef} onSubmit={onSubmit} sendOnEnter={true} editorRef={editorRef} />
+    );
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+
+    const editor = screen.getByRole("textbox");
+    await userEvent.click(editor);
+    await userEvent.keyboard("hello");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    // Ctrl+Enter 应插入换行段落，不应触发 onSubmit
+    expect(onSubmit).not.toHaveBeenCalled();
+    const text = editorRef.current!.getText({ blockSeparator: "\n" });
+    expect(text).toContain("\n");
+  });
+
+  it("Ctrl+Enter 换行后 Enter 可正常提交包含换行的文本", async () => {
+    const onSubmit = vi.fn();
+    const editorRef = { current: null as Editor | null };
+    const handleRef = createRef<AIChatInputHandle>();
+    render(
+      <AIChatInput ref={handleRef} onSubmit={onSubmit} sendOnEnter={true} editorRef={editorRef} />
+    );
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+
+    const editor = screen.getByRole("textbox");
+    await userEvent.click(editor);
+    await userEvent.keyboard("first line");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    await userEvent.keyboard("second line");
+    await userEvent.keyboard("{Enter}");
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const [text, mentions] = onSubmit.mock.calls[0];
+    expect(text).toBe("first line\nsecond line");
+    expect(mentions).toEqual([]);
+  });
+
+  it("Ctrl+Enter 在提及弹窗激活时不拦截，仍由 suggestion 处理", async () => {
+    const onSubmit = vi.fn();
+    render(<AIChatInput onSubmit={onSubmit} sendOnEnter={true} />);
+    const editor = screen.getByRole("textbox");
+    await userEvent.click(editor);
+    await userEvent.keyboard("@prod");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    // Ctrl+Enter 在 suggestion 激活时不应被拦截——
+    // suggestion 插件会消费 Enter，Ctrl 修饰键不影响这个路径。
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    // 提及弹窗应被 Enter 选中关闭
+    await waitFor(() => expect(screen.queryByRole("listbox")).not.toBeInTheDocument());
+    // 再次 Enter 发送包含 mention 的内容
+    await userEvent.keyboard("{Enter}");
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const [text] = onSubmit.mock.calls[0];
+    expect(text).toMatch(/@prod-db/);
+  });
 });

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -472,8 +472,8 @@ export function AIChatContent({
               <div className="flex items-center justify-between px-3 pb-2">
                 <span className="text-xs text-muted-foreground/40 select-none">
                   {sendOnEnter
-                    ? `Enter ${t("ai.sendShortcutHint")}`
-                    : `${formatModKey("Enter")} ${t("ai.sendShortcutHint")}`}
+                    ? `Enter ${t("ai.sendShortcutHint")} · ${formatModKey("Enter")} ${t("ai.newlineShortcutHint")}`
+                    : `${formatModKey("Enter")} ${t("ai.sendShortcutHint")} · Enter ${t("ai.newlineShortcutHint")}`}
                 </span>
                 {sending ? (
                   <Button

--- a/frontend/src/components/ai/AIChatInput.tsx
+++ b/frontend/src/components/ai/AIChatInput.tsx
@@ -517,6 +517,13 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
           triggerSubmitRef.current();
           return true;
         }
+        // Ctrl/Cmd+Enter 在默认 Enter 发送模式下显式插入换行段落，
+        // 避免不同 WebView 对 modifier+Enter 的默认行为不一致。
+        if (isEnter && shouldSendOnEnter && mod) {
+          event.preventDefault();
+          editor.commands.splitBlock();
+          return true;
+        }
         if (isEnter && !shouldSendOnEnter && mod) {
           event.preventDefault();
           triggerSubmitRef.current();

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -607,6 +607,7 @@
     "placeholder": "Type a message...",
     "sendPlaceholder": "Type a message...",
     "sendShortcutHint": "to send",
+    "newlineShortcutHint": "for new line",
     "send": "Send",
     "notConfigured": "Please configure AI Provider in Settings",
     "permissionTitle": "Tool Execution Approval",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -607,6 +607,7 @@
     "placeholder": "输入消息...",
     "sendPlaceholder": "输入消息...",
     "sendShortcutHint": "发送",
+    "newlineShortcutHint": "换行",
     "send": "发送",
     "notConfigured": "请在设置中配置 AI Provider",
     "permissionTitle": "工具执行确认",


### PR DESCRIPTION
## 变更说明

在 AI 对话输入框中，当 **Enter 发送模式**开启时（默认行为），`Ctrl+Enter`（macOS 为 `Cmd+Enter`）现在会**显式插入换行段落**，而不是依赖浏览器/WebView 的默认回退行为。

### 改动内容

**核心逻辑** — `AIChatInput.tsx`
- 在 `editorProps.handleKeyDown` 中新增 `Ctrl/Cmd+Enter` 显式换行处理（`editor.commands.splitBlock()`），避免不同 WebView 对 modifier+Enter 的默认行为不一致
- 保持现有 `Shift+Enter` 换行、`@mention` / `/snippet` 弹窗选择优先级不变

**快捷键提示** — `AIChatContent.tsx`
- 输入框底部提示从单一发送快捷键改为组合提示：
  - Enter 发送模式：`Enter 发送 · Ctrl+Enter 换行`
  - 非 Enter 发送模式：`Ctrl+Enter 发送 · Enter 换行`

**国际化** — `common.json`
- 中文：新增 `ai.newlineShortcutHint: "换行"`
- 英文：新增 `ai.newlineShortcutHint: "for new line"`

**回归测试** — `AIChatInput.test.tsx`
- `Ctrl+Enter` 在 sendOnEnter=true 模式下插入换行而不触发发送
- 换行后 Enter 可正常提交包含换行的文本
- 提及弹窗激活时 Ctrl+Enter 不拦截，仍由 suggestion 处理

### 测试结果

全部 18 个 AIChatInput 测试通过（含 3 个新增用例）。