### PR TITLE
Fix AI mention popup fallback

### DIFF
--- a/frontend/src/__tests__/AIChatInput.test.tsx
+++ b/frontend/src/__tests__/AIChatInput.test.tsx
@@ -41,6 +41,39 @@ describe("AIChatInput", () => {
     expect(screen.getByRole("option").textContent).toContain("prod-db");
   });
 
+  it("空输入只输入 @ 也弹出 MentionList", async () => {
+    render(<AIChatInput onSubmit={vi.fn()} sendOnEnter={true} />);
+    const editor = screen.getByRole("textbox");
+    await userEvent.click(editor);
+    await userEvent.keyboard("@");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    expect(screen.getByRole("option").textContent).toContain("prod-db");
+  });
+
+  it("TipTap 暂时拿不到 @ decoration 位置时仍会弹出 MentionList", async () => {
+    const originalQuerySelector = Element.prototype.querySelector;
+    const querySelectorSpy = vi.spyOn(Element.prototype, "querySelector").mockImplementation(function (
+      this: Element,
+      selector: string
+    ) {
+      if (typeof selector === "string" && selector.startsWith("[data-decoration-id=")) {
+        return null;
+      }
+      return originalQuerySelector.call(this, selector);
+    });
+
+    try {
+      render(<AIChatInput onSubmit={vi.fn()} sendOnEnter={true} />);
+      const editor = screen.getByRole("textbox");
+      await userEvent.click(editor);
+      await userEvent.keyboard("@");
+      await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+      expect(screen.getByRole("option").textContent).toContain("prod-db");
+    } finally {
+      querySelectorSpy.mockRestore();
+    }
+  });
+
   it("提及弹窗激活时 Enter 选中候选项而不触发发送", async () => {
     const onSubmit = vi.fn();
     render(<AIChatInput onSubmit={onSubmit} sendOnEnter={true} />);

--- a/frontend/src/components/ai/AIChatInput.tsx
+++ b/frontend/src/components/ai/AIChatInput.tsx
@@ -206,6 +206,57 @@ function firstLine(s: string): string {
   return i === -1 ? s.trim() : s.slice(0, i).trim();
 }
 
+function createClientRect(left: number, top: number, right: number, bottom: number): DOMRect {
+  const width = Math.max(0, right - left);
+  const height = Math.max(0, bottom - top);
+  return {
+    x: left,
+    y: top,
+    width,
+    height,
+    left,
+    top,
+    right,
+    bottom,
+    toJSON: () => ({ x: left, y: top, width, height, left, top, right, bottom }),
+  } as DOMRect;
+}
+
+function fallbackSuggestionClientRect(props: SuggestionProps<unknown>): DOMRect {
+  const docSize = props.editor.state.doc.content.size;
+  const from = Math.max(0, Math.min(props.range.from, docSize));
+  const to = Math.max(from, Math.min(props.range.to, docSize));
+
+  try {
+    const start = props.editor.view.coordsAtPos(from);
+    const end = props.editor.view.coordsAtPos(to);
+    return createClientRect(
+      Math.min(start.left, end.left),
+      Math.min(start.top, end.top),
+      Math.max(start.right, end.right),
+      Math.max(start.bottom, end.bottom)
+    );
+  } catch {
+    return createClientRect(0, 0, 0, 0);
+  }
+}
+
+function suggestionReferenceClientRect<TItem>(props: SuggestionProps<TItem>) {
+  return () => props.clientRect?.() ?? fallbackSuggestionClientRect(props as SuggestionProps<unknown>);
+}
+
+function createSuggestionPopup<TItem>(props: SuggestionProps<TItem>, content: Element): Instance[] {
+  return tippy("body", {
+    getReferenceClientRect: suggestionReferenceClientRect(props),
+    appendTo: () => document.body,
+    content,
+    showOnCreate: true,
+    interactive: true,
+    trigger: "manual",
+    placement: "bottom-start",
+  });
+}
+
 /**
  * Build a ProseMirror plugin that triggers on `/` and inserts the picked snippet
  * as PLAIN TEXT (not a Mention node) — prompt snippets are just template text.
@@ -280,21 +331,14 @@ function createSnippetSuggestionExtension(activeRef: MutableRefObject<boolean>) 
                   props: buildProps(props),
                   editor: props.editor,
                 });
-                if (!props.clientRect) return;
-                popup = tippy("body", {
-                  getReferenceClientRect: props.clientRect as () => DOMRect,
-                  appendTo: () => document.body,
-                  content: component.element,
-                  showOnCreate: true,
-                  interactive: true,
-                  trigger: "manual",
-                  placement: "bottom-start",
-                });
+                popup = createSuggestionPopup(props, component.element);
               },
               onUpdate: (props) => {
                 component?.updateProps(buildProps(props));
-                if (popup[0] && props.clientRect) {
-                  popup[0].setProps({ getReferenceClientRect: props.clientRect as () => DOMRect });
+                if (popup[0]) {
+                  popup[0].setProps({ getReferenceClientRect: suggestionReferenceClientRect(props) });
+                } else if (component) {
+                  popup = createSuggestionPopup(props, component.element);
                 }
               },
               onKeyDown: (props: SuggestionKeyDownProps) => {
@@ -433,21 +477,14 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
                   props: makeProps(props),
                   editor: props.editor,
                 });
-                if (!props.clientRect) return;
-                popup = tippy("body", {
-                  getReferenceClientRect: props.clientRect as () => DOMRect,
-                  appendTo: () => document.body,
-                  content: component.element,
-                  showOnCreate: true,
-                  interactive: true,
-                  trigger: "manual",
-                  placement: "bottom-start",
-                });
+                popup = createSuggestionPopup(props, component.element);
               },
               onUpdate: (props: SuggestionProps<MentionItem>) => {
                 component?.updateProps(makeProps(props));
-                if (popup[0] && props.clientRect) {
-                  popup[0].setProps({ getReferenceClientRect: props.clientRect as () => DOMRect });
+                if (popup[0]) {
+                  popup[0].setProps({ getReferenceClientRect: suggestionReferenceClientRect(props) });
+                } else if (component) {
+                  popup = createSuggestionPopup(props, component.element);
                 }
               },
               onKeyDown: (props: SuggestionKeyDownProps) => {


### PR DESCRIPTION
## Summary
- Keep AI `@` and `/` suggestion popups creatable when TipTap does not provide a decoration `clientRect`.
- Fall back to editor cursor coordinates and rebuild missing tippy popups during suggestion updates.
- Add regression coverage for empty-input `@` and missing decoration position.

## Tests
- `cd frontend && pnpm test -- AIChatInput.test.tsx MentionList.test.tsx`
- `cd frontend && pnpm exec tsc -b --pretty false`
- `cd frontend && pnpm lint` (passes with existing warnings)

Reference: https://github.com/opskat/opskat/issues/34#issuecomment-4311733651