### PR TITLE
🐛 Fix ungrouped asset tree expansion

### DIFF
--- a/frontend/src/__tests__/AssetTree.test.tsx
+++ b/frontend/src/__tests__/AssetTree.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ConnectSSHAsync } from "../../wailsjs/go/app/App";
+import { TooltipProvider } from "@opskat/ui";
+import { ConnectSSHAsync, ListAssets, ListGroups } from "../../wailsjs/go/app/App";
+import { AssetTree } from "@/components/layout/AssetTree";
 import { useAssetStore } from "../stores/assetStore";
 import { useTabStore } from "../stores/tabStore";
 import { useTerminalStore } from "../stores/terminalStore";
@@ -386,5 +388,53 @@ describe("AssetTree double-click → connection flow", () => {
 
     expect(ConnectSSHAsync).not.toHaveBeenCalled();
     expect(useTabStore.getState().tabs).toHaveLength(0);
+  });
+});
+
+describe("AssetTree ungrouped virtual folder", () => {
+  const renderAssetTree = () =>
+    render(
+      <TooltipProvider>
+        <AssetTree
+          collapsed={false}
+          onAddAsset={() => {}}
+          onAddGroup={() => {}}
+          onEditGroup={() => {}}
+          onGroupDetail={() => {}}
+          onEditAsset={() => {}}
+          onCopyAsset={() => {}}
+          onConnectAsset={() => {}}
+          onSelectAsset={() => {}}
+        />
+      </TooltipProvider>
+    );
+
+  beforeEach(() => {
+    localStorage.clear();
+    useAssetStore.setState({
+      assets: [],
+      groups: [],
+      selectedAssetId: null,
+      selectedGroupId: null,
+      collapsedGroupIds: [0],
+      loading: false,
+      initialized: false,
+    });
+    useTerminalStore.setState({ tabData: {}, connections: {}, connectingAssetIds: new Set() });
+    useTabStore.setState({ tabs: [], activeTabId: null });
+    vi.mocked(ListAssets).mockResolvedValue([makeAsset(1, "ssh", "Ungrouped Server")]);
+    vi.mocked(ListGroups).mockResolvedValue([]);
+  });
+
+  it("renders ungrouped assets after expanding the virtual folder", async () => {
+    const user = userEvent.setup();
+    renderAssetTree();
+
+    expect(await screen.findByText("asset.ungrouped")).toBeTruthy();
+    expect(screen.queryByText("Ungrouped Server")).toBeNull();
+
+    await user.click(screen.getByText("asset.ungrouped"));
+
+    expect(screen.getByText("Ungrouped Server")).toBeTruthy();
   });
 });

--- a/frontend/src/components/layout/AssetTree.tsx
+++ b/frontend/src/components/layout/AssetTree.tsx
@@ -523,8 +523,8 @@ function GroupItem({
       ) : (
         groupRow
       )}
-      <div className="tree-group-content" data-collapsed={!expanded ? "true" : undefined}>
-        <div>
+      {expanded && (
+        <div className="tree-group-content">
           {children.map((child) => (
             <GroupItem
               key={child.ID}
@@ -660,7 +660,7 @@ function GroupItem({
             </div>
           )}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -210,16 +210,4 @@
     background-image: linear-gradient(oklch(0.55 0.09 85 / 35%), oklch(0.55 0.09 85 / 35%));
   }
 
-  .tree-group-content {
-    display: grid;
-    grid-template-rows: 1fr;
-    transition: grid-template-rows 200ms ease;
-  }
-  .tree-group-content[data-collapsed="true"] {
-    grid-template-rows: 0fr;
-  }
-  .tree-group-content > div {
-    overflow: hidden;
-  }
-
 }


### PR DESCRIPTION
## Summary
- Render asset tree group contents only while expanded so the virtual ungrouped folder cannot get stuck with a zero-height collapsed container.
- Remove the grid-row collapse CSS that could hide expanded children in WebView.
- Add regression coverage for expanding the ungrouped virtual folder after imported SSH assets land in `GroupID=0`.

## Tests
- `cd frontend && pnpm test -- AssetTree.test.tsx`
- `cd frontend && pnpm lint`

Closes #40