### PR TITLE
✨ 为 OpenAI 兼容 provider 添加思考模式（reasoning effort）支持

### DIFF
--- a/frontend/src/components/ai/AIProviderForm.tsx
+++ b/frontend/src/components/ai/AIProviderForm.tsx
@@ -19,7 +19,7 @@ import { FetchAIModels, GetModelDefaults } from "../../../wailsjs/go/app/App";
 import { app } from "../../../wailsjs/go/models";
 import { toast } from "sonner";
 
-export function getDefaultApiBase(providerType: string): string {
+function getDefaultApiBase(providerType: string): string {
   if (providerType === "anthropic") return "https://api.anthropic.com";
   return "https://api.openai.com/v1";
 }
@@ -32,6 +32,19 @@ export interface AIProviderFormValues {
   model: string;
   maxOutputTokens: number;
   contextWindow: number;
+  reasoningEnabled: boolean;
+  reasoningEffort: "none" | "low" | "medium" | "high" | "xhigh";
+}
+
+function supportsOpenAIReasoningModel(model: string): boolean {
+  const lower = model.trim().toLowerCase();
+  return (
+    lower.startsWith("o1") ||
+    lower.startsWith("o3") ||
+    lower.startsWith("o4") ||
+    lower.startsWith("gpt-5") ||
+    lower.startsWith("deepseek")
+  );
 }
 
 export interface AIProviderFormProps {
@@ -44,6 +57,7 @@ export interface AIProviderFormProps {
     model: string;
     maxOutputTokens: number;
     contextWindow: number;
+    reasoningEffort: "none" | "low" | "medium" | "high" | "xhigh";
   };
   isEditing?: boolean;
   /** Locks the provider type (used by wizard where cards handle type selection) */
@@ -74,11 +88,16 @@ export function AIProviderForm({
   const [formModel, setFormModel] = useState(initialValues?.model ?? "");
   const [formMaxOutputTokens, setFormMaxOutputTokens] = useState(initialValues?.maxOutputTokens ?? 0);
   const [formContextWindow, setFormContextWindow] = useState(initialValues?.contextWindow ?? 0);
+  const [formReasoningEffort, setFormReasoningEffort] = useState<"none" | "low" | "medium" | "high" | "xhigh">(
+    initialValues?.reasoningEffort ?? "none"
+  );
 
   const [modelOptions, setModelOptions] = useState<app.AIModelInfo[]>([]);
   const [modelPopoverOpen, setModelPopoverOpen] = useState(false);
   const [modelSearch, setModelSearch] = useState("");
   const [fetchingModels, setFetchingModels] = useState(false);
+  const isOpenAIProvider = formType === "openai";
+  const currentModelSupportsReasoning = supportsOpenAIReasoningModel(formModel);
 
   // When external providerType prop changes (wizard card click), reset relevant fields
   useEffect(() => {
@@ -90,6 +109,7 @@ export function AIProviderForm({
       setFormModel("");
       setFormMaxOutputTokens(0);
       setFormContextWindow(0);
+      setFormReasoningEffort("none");
       setModelOptions([]);
     }
   }, [externalType, t]);
@@ -161,6 +181,8 @@ export function AIProviderForm({
       model: formModel,
       maxOutputTokens: formMaxOutputTokens,
       contextWindow: formContextWindow,
+      reasoningEnabled: isOpenAIProvider && formReasoningEffort !== "none",
+      reasoningEffort: formReasoningEffort,
     });
   };
 
@@ -207,6 +229,8 @@ export function AIProviderForm({
                   <button
                     type="button"
                     className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    aria-label={t("settings.selectModel")}
+                    title={t("settings.selectModel")}
                     onClick={() => setModelPopoverOpen(!modelPopoverOpen)}
                   >
                     <ChevronsUpDown className="h-4 w-4" />
@@ -301,6 +325,32 @@ export function AIProviderForm({
           <p className="text-xs text-muted-foreground">{t("settings.contextWindowHint")}</p>
         </div>
       </div>
+
+      {isOpenAIProvider && (
+        <div className="rounded-lg border p-4 space-y-2">
+          <Label>{t("settings.reasoningEffort")}</Label>
+          <Select
+            value={formReasoningEffort}
+            onValueChange={(value) => setFormReasoningEffort(value as "none" | "low" | "medium" | "high" | "xhigh")}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">{t("settings.reasoningEffortNone")}</SelectItem>
+              <SelectItem value="low">{t("settings.reasoningEffortLow")}</SelectItem>
+              <SelectItem value="medium">{t("settings.reasoningEffortMedium")}</SelectItem>
+              <SelectItem value="high">{t("settings.reasoningEffortHigh")}</SelectItem>
+              <SelectItem value="xhigh">{t("settings.reasoningEffortXHigh")}</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {currentModelSupportsReasoning || !formModel
+              ? t("settings.reasoningEffortHint")
+              : t("settings.reasoningEffortUnsupportedHint")}
+          </p>
+        </div>
+      )}
 
       <Button
         onClick={handleSubmit}

--- a/frontend/src/components/ai/AISetupWizard.tsx
+++ b/frontend/src/components/ai/AISetupWizard.tsx
@@ -38,7 +38,9 @@ export function AISetupWizard() {
         values.apiKey,
         values.model,
         values.maxOutputTokens,
-        values.contextWindow
+        values.contextWindow,
+        values.reasoningEnabled,
+        values.reasoningEffort
       );
       await SetActiveAIProvider(created.id);
       await useAIStore.getState().checkConfigured();

--- a/frontend/src/components/settings/AISettingsSection.tsx
+++ b/frontend/src/components/settings/AISettingsSection.tsx
@@ -398,7 +398,9 @@ export function AISettingsSection() {
           values.apiKey,
           values.model,
           values.maxOutputTokens,
-          values.contextWindow
+          values.contextWindow,
+          values.reasoningEnabled,
+          values.reasoningEffort
         );
       } else {
         const created = await CreateAIProvider(
@@ -408,7 +410,9 @@ export function AISettingsSection() {
           values.apiKey,
           values.model,
           values.maxOutputTokens,
-          values.contextWindow
+          values.contextWindow,
+          values.reasoningEnabled,
+          values.reasoningEffort
         );
         if (providers.length === 0 && created.id) {
           await SetActiveAIProvider(created.id);
@@ -527,6 +531,7 @@ export function AISettingsSection() {
                     model: editingProvider.model,
                     maxOutputTokens: editingProvider.maxOutputTokens,
                     contextWindow: editingProvider.contextWindow,
+                    reasoningEffort: (editingProvider.reasoningEffort || "none") as "none" | "low" | "medium" | "high" | "xhigh",
                   }
                 : undefined
             }

--- a/frontend/src/components/settings/AISettingsSection.tsx
+++ b/frontend/src/components/settings/AISettingsSection.tsx
@@ -531,7 +531,12 @@ export function AISettingsSection() {
                     model: editingProvider.model,
                     maxOutputTokens: editingProvider.maxOutputTokens,
                     contextWindow: editingProvider.contextWindow,
-                    reasoningEffort: (editingProvider.reasoningEffort || "none") as "none" | "low" | "medium" | "high" | "xhigh",
+                    reasoningEffort: (editingProvider.reasoningEffort || "none") as
+                      | "none"
+                      | "low"
+                      | "medium"
+                      | "high"
+                      | "xhigh",
                   }
                 : undefined
             }

--- a/frontend/src/components/settings/AISettingsSection.tsx
+++ b/frontend/src/components/settings/AISettingsSection.tsx
@@ -531,7 +531,8 @@ export function AISettingsSection() {
                     model: editingProvider.model,
                     maxOutputTokens: editingProvider.maxOutputTokens,
                     contextWindow: editingProvider.contextWindow,
-                    reasoningEffort: (editingProvider.reasoningEffort || "none") as
+                    reasoningEffort: (editingProvider.reasoningEffort ||
+                      (editingProvider.reasoningEnabled ? "medium" : "none")) as
                       | "none"
                       | "low"
                       | "medium"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -620,7 +620,15 @@
     "fetchModelsError": "Failed to fetch models",
     "selectModel": "Select or type a model",
     "noModelsFound": "No models found",
-    "modelDefaultsApplied": "Applied defaults for this model"
+    "modelDefaultsApplied": "Applied defaults for this model",
+    "reasoningEffort": "Thinking depth",
+    "reasoningEffortNone": "Off",
+    "reasoningEffortHint": "Off: no reasoning. Low: fast, fewer tokens. Medium: balanced (default). High: deep reasoning. XHigh: deepest reasoning, highest latency & cost.",
+    "reasoningEffortUnsupportedHint": "This model may not support this setting; it only applies on compatible models.",
+    "reasoningEffortLow": "Low",
+    "reasoningEffortMedium": "Medium",
+    "reasoningEffortHigh": "High",
+    "reasoningEffortXHigh": "XHigh"
   },
   "backup": {
     "title": "Backup",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -605,7 +605,15 @@
     "fetchModelsError": "获取模型列表失败",
     "selectModel": "选择或输入模型名称",
     "noModelsFound": "未找到模型",
-    "modelDefaultsApplied": "已应用该模型的默认参数"
+    "modelDefaultsApplied": "已应用该模型的默认参数",
+    "reasoningEffort": "思考深度",
+    "reasoningEffortNone": "关闭",
+    "reasoningEffortHint": "关闭：不使用推理；低：快速省 token；中：均衡（默认）；高：深度推理；极深：最深度推理，延迟和成本最高。",
+    "reasoningEffortUnsupportedHint": "该模型可能不支持此设置，仅在兼容模型上生效。",
+    "reasoningEffortLow": "低",
+    "reasoningEffortMedium": "中",
+    "reasoningEffortHigh": "高",
+    "reasoningEffortXHigh": "极深"
   },
   "backup": {
     "title": "备份",

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -17,21 +17,25 @@ import (
 
 // OpenAIProvider OpenAI 兼容 API provider
 type OpenAIProvider struct {
-	apiBase         string
-	apiKey          string
-	model           string
-	name            string
-	maxOutputTokens int
+	apiBase          string
+	apiKey           string
+	model            string
+	name             string
+	maxOutputTokens  int
+	reasoningEnabled bool
+	reasoningEffort  string
 }
 
 // NewOpenAIProvider 创建 OpenAI 兼容 provider
-func NewOpenAIProvider(name, apiBase, apiKey, model string, maxOutputTokens int) *OpenAIProvider {
+func NewOpenAIProvider(name, apiBase, apiKey, model string, maxOutputTokens int, reasoningEnabled bool, reasoningEffort string) *OpenAIProvider {
 	return &OpenAIProvider{
-		name:            name,
-		apiBase:         strings.TrimRight(apiBase, "/"),
-		apiKey:          apiKey,
-		model:           model,
-		maxOutputTokens: maxOutputTokens,
+		name:             name,
+		apiBase:          strings.TrimRight(apiBase, "/"),
+		apiKey:           apiKey,
+		model:            model,
+		maxOutputTokens:  maxOutputTokens,
+		reasoningEnabled: reasoningEnabled,
+		reasoningEffort:  normalizeOpenAIReasoningEffort(reasoningEffort),
 	}
 }
 
@@ -41,12 +45,20 @@ func (p *OpenAIProvider) Model() string { return p.model }
 
 // openAIRequest OpenAI API 请求体
 type openAIRequest struct {
-	Model         string               `json:"model"`
-	Messages      []Message            `json:"messages"`
-	Tools         []Tool               `json:"tools,omitempty"`
-	Stream        bool                 `json:"stream"`
-	StreamOptions *openAIStreamOptions `json:"stream_options,omitempty"`
-	MaxTokens     int                  `json:"max_tokens,omitempty"`
+	Model           string               `json:"model"`
+	Messages        []Message            `json:"messages"`
+	Tools           []Tool               `json:"tools,omitempty"`
+	Stream          bool                 `json:"stream"`
+	StreamOptions   *openAIStreamOptions `json:"stream_options,omitempty"`
+	MaxTokens       int                  `json:"max_tokens,omitempty"`
+	ReasoningEffort string               `json:"reasoning_effort,omitempty"`
+	// DeepSeek thinking mode: {"type":"enabled"} or {"type":"disabled"}
+	Thinking *deepSeekThinking `json:"thinking,omitempty"`
+}
+
+// deepSeekThinking DeepSeek 思考模式控制
+type deepSeekThinking struct {
+	Type string `json:"type"` // "enabled" | "disabled"
 }
 
 // openAIStreamOptions stream 专用选项，include_usage=true 后最后一个 chunk 会带 usage
@@ -83,6 +95,29 @@ type openAIUsage struct {
 	} `json:"prompt_tokens_details"`
 }
 
+func supportsOpenAIReasoningEffort(model string) bool {
+	lower := strings.ToLower(strings.TrimSpace(model))
+	return strings.HasPrefix(lower, "o1") ||
+		strings.HasPrefix(lower, "o3") ||
+		strings.HasPrefix(lower, "o4") ||
+		strings.HasPrefix(lower, "gpt-5")
+}
+
+func normalizeOpenAIReasoningEffort(effort string) string {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
+	case "low", "medium", "high", "xhigh":
+		return strings.ToLower(strings.TrimSpace(effort))
+	case "none":
+		return "none"
+	default:
+		return "medium"
+	}
+}
+
+func isDeepSeekModel(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "deepseek")
+}
+
 func (p *OpenAIProvider) Chat(ctx context.Context, messages []Message, tools []Tool) (<-chan StreamEvent, error) {
 	reqBody := openAIRequest{
 		Model:         p.model,
@@ -90,6 +125,18 @@ func (p *OpenAIProvider) Chat(ctx context.Context, messages []Message, tools []T
 		Stream:        true,
 		StreamOptions: &openAIStreamOptions{IncludeUsage: true},
 		MaxTokens:     p.maxOutputTokens,
+	}
+	if p.reasoningEnabled && supportsOpenAIReasoningEffort(p.model) {
+		reqBody.ReasoningEffort = normalizeOpenAIReasoningEffort(p.reasoningEffort)
+	}
+	// DeepSeek thinking mode: needs explicit thinking.type field
+	if isDeepSeekModel(p.model) {
+		if p.reasoningEnabled && p.reasoningEffort != "none" {
+			reqBody.Thinking = &deepSeekThinking{Type: "enabled"}
+			reqBody.ReasoningEffort = normalizeOpenAIReasoningEffort(p.reasoningEffort)
+		} else {
+			reqBody.Thinking = &deepSeekThinking{Type: "disabled"}
+		}
 	}
 	if len(tools) > 0 {
 		reqBody.Tools = tools

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -1,0 +1,72 @@
+package ai
+
+import "testing"
+
+func TestSupportsOpenAIReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{name: "o1 model", model: "o1-preview", want: true},
+		{name: "o3 model", model: "o3-mini", want: true},
+		{name: "o4 model", model: "o4-mini", want: true},
+		{name: "gpt-5 model", model: "gpt-5.4", want: true},
+		{name: "gpt-4o model", model: "gpt-4o", want: false},
+		{name: "deepseek model", model: "deepseek-chat", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supportsOpenAIReasoningEffort(tt.model); got != tt.want {
+				t.Fatalf("supportsOpenAIReasoningEffort(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDeepSeekModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{name: "deepseek-chat", model: "deepseek-chat", want: true},
+		{name: "deepseek-v4-pro", model: "deepseek-v4-pro", want: true},
+		{name: "DeepSeek-V4", model: "DeepSeek-V4", want: true},
+		{name: "gpt-5", model: "gpt-5.4", want: false},
+		{name: "o3-mini", model: "o3-mini", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDeepSeekModel(tt.model); got != tt.want {
+				t.Fatalf("isDeepSeekModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeOpenAIReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name   string
+		effort string
+		want   string
+	}{
+		{name: "low", effort: "low", want: "low"},
+		{name: "upper medium", effort: "MEDIUM", want: "medium"},
+		{name: "trim high", effort: "  high ", want: "high"},
+		{name: "xhigh", effort: "xhigh", want: "xhigh"},
+		{name: "none", effort: "none", want: "none"},
+		{name: "empty defaults to medium", effort: "", want: "medium"},
+		{name: "unknown defaults to medium", effort: "ultra", want: "medium"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeOpenAIReasoningEffort(tt.effort); got != tt.want {
+				t.Fatalf("normalizeOpenAIReasoningEffort(%q) = %q, want %q", tt.effort, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/app_ai.go
+++ b/internal/app/app_ai.go
@@ -58,7 +58,15 @@ func (a *App) activateProvider(p *ai_provider_entity.AIProvider) error {
 	case "anthropic":
 		provider = ai.NewAnthropicProvider(p.Name, p.APIBase, apiKey, p.Model, maxOutputTokens)
 	default: // "openai"
-		provider = ai.NewOpenAIProvider(p.Name, p.APIBase, apiKey, p.Model, maxOutputTokens)
+		provider = ai.NewOpenAIProvider(
+			p.Name,
+			p.APIBase,
+			apiKey,
+			p.Model,
+			maxOutputTokens,
+			p.ReasoningEnabled,
+			p.ReasoningEffort,
+		)
 	}
 
 	config := ai.NewDefaultConfig()

--- a/internal/app/app_ai_provider.go
+++ b/internal/app/app_ai_provider.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/opskat/opskat/internal/ai"
 	"github.com/opskat/opskat/internal/model/entity/ai_provider_entity"
@@ -10,30 +11,53 @@ import (
 
 // AIProviderInfo 返回给前端的 Provider 信息
 type AIProviderInfo struct {
-	ID              int64  `json:"id"`
-	Name            string `json:"name"`
-	Type            string `json:"type"`
-	APIBase         string `json:"apiBase"`
-	APIKey          string `json:"apiKey"`
-	MaskedAPIKey    string `json:"maskedApiKey"`
-	Model           string `json:"model"`
-	MaxOutputTokens int    `json:"maxOutputTokens"`
-	ContextWindow   int    `json:"contextWindow"`
-	IsActive        bool   `json:"isActive"`
+	ID               int64  `json:"id"`
+	Name             string `json:"name"`
+	Type             string `json:"type"`
+	APIBase          string `json:"apiBase"`
+	APIKey           string `json:"apiKey"`
+	MaskedAPIKey     string `json:"maskedApiKey"`
+	Model            string `json:"model"`
+	MaxOutputTokens  int    `json:"maxOutputTokens"`
+	ContextWindow    int    `json:"contextWindow"`
+	ReasoningEnabled bool   `json:"reasoningEnabled"`
+	ReasoningEffort  string `json:"reasoningEffort"`
+	IsActive         bool   `json:"isActive"`
 }
 
 func toProviderInfo(p *ai_provider_entity.AIProvider, apiKey string) AIProviderInfo {
 	return AIProviderInfo{
-		ID:              p.ID,
-		Name:            p.Name,
-		Type:            p.Type,
-		APIBase:         p.APIBase,
-		APIKey:          apiKey,
-		MaskedAPIKey:    maskAPIKey(apiKey),
-		Model:           p.Model,
-		MaxOutputTokens: p.MaxOutputTokens,
-		ContextWindow:   p.ContextWindow,
-		IsActive:        p.IsActive,
+		ID:               p.ID,
+		Name:             p.Name,
+		Type:             p.Type,
+		APIBase:          p.APIBase,
+		APIKey:           apiKey,
+		MaskedAPIKey:     maskAPIKey(apiKey),
+		Model:            p.Model,
+		MaxOutputTokens:  p.MaxOutputTokens,
+		ContextWindow:    p.ContextWindow,
+		ReasoningEnabled: p.ReasoningEnabled,
+		ReasoningEffort:  p.ReasoningEffort,
+		IsActive:         p.IsActive,
+	}
+}
+
+func normalizeProviderReasoningConfig(providerType string, reasoningEnabled bool, reasoningEffort string) (bool, string) {
+	if providerType != "openai" {
+		return false, ""
+	}
+	effort := strings.ToLower(strings.TrimSpace(reasoningEffort))
+	switch effort {
+	case "low", "medium", "high", "xhigh":
+		return true, effort
+	case "none":
+		return false, ""
+	default:
+		// Backwards compat: old data with toggle=true but no effort → medium
+		if reasoningEnabled {
+			return true, "medium"
+		}
+		return false, ""
 	}
 }
 
@@ -63,34 +87,40 @@ func (a *App) GetActiveAIProvider() (*AIProviderInfo, error) {
 }
 
 // CreateAIProvider 创建新 Provider
-func (a *App) CreateAIProvider(name, providerType, apiBase, apiKey, model string, maxOutputTokens, contextWindow int) (*AIProviderInfo, error) {
+func (a *App) CreateAIProvider(name, providerType, apiBase, apiKey, model string, maxOutputTokens, contextWindow int, reasoningEnabled bool, reasoningEffort string) (*AIProviderInfo, error) {
+	reasoningEnabled, reasoningEffort = normalizeProviderReasoningConfig(providerType, reasoningEnabled, reasoningEffort)
 	p := &ai_provider_entity.AIProvider{
-		Name:            name,
-		Type:            providerType,
-		APIBase:         apiBase,
-		Model:           model,
-		MaxOutputTokens: maxOutputTokens,
-		ContextWindow:   contextWindow,
+		Name:             name,
+		Type:             providerType,
+		APIBase:          apiBase,
+		Model:            model,
+		MaxOutputTokens:  maxOutputTokens,
+		ContextWindow:    contextWindow,
+		ReasoningEnabled: reasoningEnabled,
+		ReasoningEffort:  reasoningEffort,
 	}
 	if err := ai_provider_svc.AIProvider().Create(a.langCtx(), p, apiKey); err != nil {
 		return nil, fmt.Errorf("创建 Provider 失败: %w", err)
 	}
-	info := toProviderInfo(p, maskAPIKey(apiKey))
+	info := toProviderInfo(p, apiKey)
 	return &info, nil
 }
 
 // UpdateAIProvider 更新 Provider
-func (a *App) UpdateAIProvider(id int64, name, providerType, apiBase, apiKey, model string, maxOutputTokens, contextWindow int) error {
+func (a *App) UpdateAIProvider(id int64, name, providerType, apiBase, apiKey, model string, maxOutputTokens, contextWindow int, reasoningEnabled bool, reasoningEffort string) error {
 	p, err := ai_provider_svc.AIProvider().Get(a.langCtx(), id)
 	if err != nil {
 		return fmt.Errorf("provider 不存在: %w", err)
 	}
+	reasoningEnabled, reasoningEffort = normalizeProviderReasoningConfig(providerType, reasoningEnabled, reasoningEffort)
 	p.Name = name
 	p.Type = providerType
 	p.APIBase = apiBase
 	p.Model = model
 	p.MaxOutputTokens = maxOutputTokens
 	p.ContextWindow = contextWindow
+	p.ReasoningEnabled = reasoningEnabled
+	p.ReasoningEffort = reasoningEffort
 	if err := ai_provider_svc.AIProvider().Update(a.langCtx(), p, apiKey); err != nil {
 		return fmt.Errorf("更新 Provider 失败: %w", err)
 	}

--- a/internal/model/entity/ai_provider_entity/ai_provider.go
+++ b/internal/model/entity/ai_provider_entity/ai_provider.go
@@ -2,17 +2,19 @@ package ai_provider_entity
 
 // AIProvider AI Provider 配置
 type AIProvider struct {
-	ID              int64  `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	Name            string `gorm:"column:name;type:varchar(100);not null" json:"name"`
-	Type            string `gorm:"column:type;type:varchar(50);not null" json:"type"` // "openai" | "anthropic"
-	APIBase         string `gorm:"column:api_base;type:varchar(500);not null" json:"apiBase"`
-	APIKey          string `gorm:"column:api_key;type:text" json:"-"` // 加密存储，JSON 忽略
-	Model           string `gorm:"column:model;type:varchar(100)" json:"model"`
-	MaxOutputTokens int    `gorm:"column:max_output_tokens;default:0" json:"maxOutputTokens"` // 0 表示使用默认值
-	ContextWindow   int    `gorm:"column:context_window;default:0" json:"contextWindow"`      // 0 表示使用默认值
-	IsActive        bool   `gorm:"column:is_active;default:false" json:"isActive"`
-	Createtime      int64  `gorm:"column:createtime" json:"createtime"`
-	Updatetime      int64  `gorm:"column:updatetime" json:"updatetime"`
+	ID               int64  `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	Name             string `gorm:"column:name;type:varchar(100);not null" json:"name"`
+	Type             string `gorm:"column:type;type:varchar(50);not null" json:"type"` // "openai" | "anthropic"
+	APIBase          string `gorm:"column:api_base;type:varchar(500);not null" json:"apiBase"`
+	APIKey           string `gorm:"column:api_key;type:text" json:"-"` // 加密存储，JSON 忽略
+	Model            string `gorm:"column:model;type:varchar(100)" json:"model"`
+	MaxOutputTokens  int    `gorm:"column:max_output_tokens;default:0" json:"maxOutputTokens"` // 0 表示使用默认值
+	ContextWindow    int    `gorm:"column:context_window;default:0" json:"contextWindow"`      // 0 表示使用默认值
+	ReasoningEnabled bool   `gorm:"column:reasoning_enabled;default:false" json:"reasoningEnabled"`
+	ReasoningEffort  string `gorm:"column:reasoning_effort;type:varchar(20);default:''" json:"reasoningEffort"` // 仅 OpenAI reasoning 模型使用
+	IsActive         bool   `gorm:"column:is_active;default:false" json:"isActive"`
+	Createtime       int64  `gorm:"column:createtime" json:"createtime"`
+	Updatetime       int64  `gorm:"column:updatetime" json:"updatetime"`
 }
 
 func (AIProvider) TableName() string {

--- a/migrations/202605060001_ai_provider_reasoning.go
+++ b/migrations/202605060001_ai_provider_reasoning.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func migration202605060001() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202605060001",
+		Migrate: func(tx *gorm.DB) error {
+			if !tx.Migrator().HasColumn("ai_providers", "reasoning_enabled") {
+				if err := tx.Exec("ALTER TABLE ai_providers ADD COLUMN reasoning_enabled INTEGER DEFAULT 0").Error; err != nil {
+					return err
+				}
+			}
+
+			if !tx.Migrator().HasColumn("ai_providers", "reasoning_effort") {
+				if err := tx.Exec("ALTER TABLE ai_providers ADD COLUMN reasoning_effort VARCHAR(20) DEFAULT ''").Error; err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -23,6 +23,7 @@ func RunMigrations(db *gorm.DB) error {
 		migration202604230001(),
 		migration202604270001(),
 		migration202605010001(),
+		migration202605060001(),
 	})
 	return m.Migrate()
 }


### PR DESCRIPTION
## 变更概述

为 OpenAI 兼容 provider 添加思考模式（reasoning effort）配置支持，允许用户控制 AI 模型的推理深度。

## 主要变更

### 后端 (Go)
- **实体层**: `AIProvider` 新增 `ReasoningEnabled` 和 `ReasoningEffort` 字段
- **数据库迁移**: 新增 `202605060001` 迁移，添加 `reasoning_enabled` 和 `reasoning_effort` 列到 `ai_providers` 表
- **OpenAI Provider**: 
  - 支持 OpenAI 原生 reasoning 模型（o1/o3/o4/gpt-5 系列）的 `reasoning_effort` 参数
  - 支持 DeepSeek 模型的 `thinking.type` 字段（enabled/disabled）
  - 新增 `supportsOpenAIReasoningEffort`、`normalizeOpenAIReasoningEffort`、`isDeepSeekModel` 辅助函数
- **App 层**: `CreateAIProvider` 和 `UpdateAIProvider` 方法新增 reasoning 配置参数，含归一化处理
- **单元测试**: 覆盖模型判断和 effort 归一化逻辑

### 前端 (React/TypeScript)
- **AIProviderForm**: 新增思考深度选择器（关闭/低/中/高/极深），仅 OpenAI provider 可见
- **AISettingsSection**: 编辑/创建时传递 reasoning 配置
- **AISetupWizard**: 向导流程同步支持 reasoning 配置
- **i18n**: 新增中英文翻译（`reasoningEffort` 系列键）

## 思考深度级别

| 级别 | 说明 |
|------|------|
| 关闭 | 不使用推理 |
| 低 | 快速省 token |
| 中 | 均衡（默认） |
| 高 | 深度推理 |
| 极深 | 最深度推理，延迟和成本最高 |