### PR TITLE
✨ 为 Anthropic provider 添加思考模式（reasoning effort）支持

### DIFF
--- a/frontend/src/components/ai/AIProviderForm.tsx
+++ b/frontend/src/components/ai/AIProviderForm.tsx
@@ -24,6 +24,8 @@ function getDefaultApiBase(providerType: string): string {
   return "https://api.openai.com/v1";
 }
 
+export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
+
 export interface AIProviderFormValues {
   name: string;
   type: string;
@@ -33,7 +35,7 @@ export interface AIProviderFormValues {
   maxOutputTokens: number;
   contextWindow: number;
   reasoningEnabled: boolean;
-  reasoningEffort: "none" | "low" | "medium" | "high" | "xhigh";
+  reasoningEffort: ReasoningEffort;
 }
 
 function supportsOpenAIReasoningModel(model: string): boolean {
@@ -57,7 +59,7 @@ export interface AIProviderFormProps {
     model: string;
     maxOutputTokens: number;
     contextWindow: number;
-    reasoningEffort: "none" | "low" | "medium" | "high" | "xhigh";
+    reasoningEffort: ReasoningEffort;
   };
   isEditing?: boolean;
   /** Locks the provider type (used by wizard where cards handle type selection) */
@@ -88,7 +90,7 @@ export function AIProviderForm({
   const [formModel, setFormModel] = useState(initialValues?.model ?? "");
   const [formMaxOutputTokens, setFormMaxOutputTokens] = useState(initialValues?.maxOutputTokens ?? 0);
   const [formContextWindow, setFormContextWindow] = useState(initialValues?.contextWindow ?? 0);
-  const [formReasoningEffort, setFormReasoningEffort] = useState<"none" | "low" | "medium" | "high" | "xhigh">(
+  const [formReasoningEffort, setFormReasoningEffort] = useState<ReasoningEffort>(
     initialValues?.reasoningEffort ?? "none"
   );
 
@@ -97,7 +99,17 @@ export function AIProviderForm({
   const [modelSearch, setModelSearch] = useState("");
   const [fetchingModels, setFetchingModels] = useState(false);
   const isOpenAIProvider = formType === "openai";
+  const isAnthropicProvider = formType === "anthropic";
+  const showReasoningPanel = isOpenAIProvider || isAnthropicProvider;
+  // OpenAI 的 hint 区分模型是否支持 reasoning；Anthropic 不做模型校验，由 API 自行裁定。
   const currentModelSupportsReasoning = supportsOpenAIReasoningModel(formModel);
+
+  // 切到非 Anthropic 时，max 档不再可见，降级到 high 避免 Select 显示空值。
+  useEffect(() => {
+    if (formType !== "anthropic" && formReasoningEffort === "max") {
+      setFormReasoningEffort("high");
+    }
+  }, [formType, formReasoningEffort]);
 
   // When external providerType prop changes (wizard card click), reset relevant fields
   useEffect(() => {
@@ -181,7 +193,7 @@ export function AIProviderForm({
       model: formModel,
       maxOutputTokens: formMaxOutputTokens,
       contextWindow: formContextWindow,
-      reasoningEnabled: isOpenAIProvider && formReasoningEffort !== "none",
+      reasoningEnabled: showReasoningPanel && formReasoningEffort !== "none",
       reasoningEffort: formReasoningEffort,
     });
   };
@@ -326,12 +338,12 @@ export function AIProviderForm({
         </div>
       </div>
 
-      {isOpenAIProvider && (
+      {showReasoningPanel && (
         <div className="rounded-lg border p-4 space-y-2">
           <Label>{t("settings.reasoningEffort")}</Label>
           <Select
             value={formReasoningEffort}
-            onValueChange={(value) => setFormReasoningEffort(value as "none" | "low" | "medium" | "high" | "xhigh")}
+            onValueChange={(value) => setFormReasoningEffort(value as ReasoningEffort)}
           >
             <SelectTrigger>
               <SelectValue />
@@ -342,10 +354,11 @@ export function AIProviderForm({
               <SelectItem value="medium">{t("settings.reasoningEffortMedium")}</SelectItem>
               <SelectItem value="high">{t("settings.reasoningEffortHigh")}</SelectItem>
               <SelectItem value="xhigh">{t("settings.reasoningEffortXHigh")}</SelectItem>
+              {isAnthropicProvider && <SelectItem value="max">{t("settings.reasoningEffortMax")}</SelectItem>}
             </SelectContent>
           </Select>
           <p className="text-xs text-muted-foreground">
-            {currentModelSupportsReasoning || !formModel
+            {isAnthropicProvider || currentModelSupportsReasoning || !formModel
               ? t("settings.reasoningEffortHint")
               : t("settings.reasoningEffortUnsupportedHint")}
           </p>

--- a/frontend/src/components/settings/AISettingsSection.tsx
+++ b/frontend/src/components/settings/AISettingsSection.tsx
@@ -57,7 +57,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime";
-import { AIProviderForm, type AIProviderFormValues } from "@/components/ai/AIProviderForm";
+import { AIProviderForm, type AIProviderFormValues, type ReasoningEffort } from "@/components/ai/AIProviderForm";
 import { useAIStore } from "@/stores/aiStore";
 
 const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e));
@@ -532,12 +532,7 @@ export function AISettingsSection() {
                     maxOutputTokens: editingProvider.maxOutputTokens,
                     contextWindow: editingProvider.contextWindow,
                     reasoningEffort: (editingProvider.reasoningEffort ||
-                      (editingProvider.reasoningEnabled ? "medium" : "none")) as
-                      | "none"
-                      | "low"
-                      | "medium"
-                      | "high"
-                      | "xhigh",
+                      (editingProvider.reasoningEnabled ? "medium" : "none")) as ReasoningEffort,
                   }
                 : undefined
             }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -623,12 +623,13 @@
     "modelDefaultsApplied": "Applied defaults for this model",
     "reasoningEffort": "Thinking depth",
     "reasoningEffortNone": "Off",
-    "reasoningEffortHint": "Off: no reasoning. Low: fast, fewer tokens. Medium: balanced (default). High: deep reasoning. XHigh: deepest reasoning, highest latency & cost.",
+    "reasoningEffortHint": "Off: no reasoning. Low: fast, fewer tokens. Medium: balanced (default). High: deep reasoning. XHigh: deepest reasoning, highest latency & cost. Max (Anthropic only): no token-spend cap.",
     "reasoningEffortUnsupportedHint": "This model may not support this setting; it only applies on compatible models.",
     "reasoningEffortLow": "Low",
     "reasoningEffortMedium": "Medium",
     "reasoningEffortHigh": "High",
-    "reasoningEffortXHigh": "XHigh"
+    "reasoningEffortXHigh": "XHigh",
+    "reasoningEffortMax": "Max"
   },
   "backup": {
     "title": "Backup",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -608,12 +608,13 @@
     "modelDefaultsApplied": "已应用该模型的默认参数",
     "reasoningEffort": "思考深度",
     "reasoningEffortNone": "关闭",
-    "reasoningEffortHint": "关闭：不使用推理；低：快速省 token；中：均衡（默认）；高：深度推理；极深：最深度推理，延迟和成本最高。",
+    "reasoningEffortHint": "关闭：不使用推理；低：快速省 token；中：均衡（默认）；高：深度推理；极深：最深度推理，延迟和成本最高；最大（仅 Anthropic）：不限 token 消耗。",
     "reasoningEffortUnsupportedHint": "该模型可能不支持此设置，仅在兼容模型上生效。",
     "reasoningEffortLow": "低",
     "reasoningEffortMedium": "中",
     "reasoningEffortHigh": "高",
-    "reasoningEffortXHigh": "极深"
+    "reasoningEffortXHigh": "极深",
+    "reasoningEffortMax": "最大"
   },
   "backup": {
     "title": "备份",

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -16,25 +16,50 @@ import (
 
 // AnthropicProvider Anthropic Messages API provider
 type AnthropicProvider struct {
-	apiBase         string
-	apiKey          string
-	model           string
-	name            string
-	maxOutputTokens int
+	apiBase          string
+	apiKey           string
+	model            string
+	name             string
+	maxOutputTokens  int
+	reasoningEnabled bool
+	reasoningEffort  string
 }
 
 // NewAnthropicProvider 创建 Anthropic provider
-func NewAnthropicProvider(name, apiBase, apiKey, model string, maxOutputTokens int) *AnthropicProvider {
+func NewAnthropicProvider(name, apiBase, apiKey, model string, maxOutputTokens int, reasoningEnabled bool, reasoningEffort string) *AnthropicProvider {
 	if apiBase == "" {
 		apiBase = "https://api.anthropic.com"
 	}
 	return &AnthropicProvider{
-		name:            name,
-		apiBase:         strings.TrimRight(apiBase, "/"),
-		apiKey:          apiKey,
-		model:           model,
-		maxOutputTokens: maxOutputTokens,
+		name:             name,
+		apiBase:          strings.TrimRight(apiBase, "/"),
+		apiKey:           apiKey,
+		model:            model,
+		maxOutputTokens:  maxOutputTokens,
+		reasoningEnabled: reasoningEnabled,
+		reasoningEffort:  normalizeAnthropicReasoningEffort(reasoningEffort),
 	}
+}
+
+// normalizeAnthropicReasoningEffort 归一化 effort，未识别值落回 medium。
+func normalizeAnthropicReasoningEffort(effort string) string {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
+	case "low", "medium", "high", "xhigh", "max":
+		return strings.ToLower(strings.TrimSpace(effort))
+	case "none", "":
+		return ""
+	default:
+		return "medium"
+	}
+}
+
+// reasoningConfig 决定是否下发 adaptive thinking 与 effort。
+// 模型是否实际支持由 Anthropic API 自行裁定（老模型会返回错误）。
+func (p *AnthropicProvider) reasoningConfig() (*anthropicThinking, *anthropicOutputConfig) {
+	if !p.reasoningEnabled || p.reasoningEffort == "" {
+		return nil, nil
+	}
+	return &anthropicThinking{Type: "adaptive"}, &anthropicOutputConfig{Effort: p.reasoningEffort}
 }
 
 func (p *AnthropicProvider) Name() string { return p.name }
@@ -48,18 +73,22 @@ type anthropicCacheControl struct {
 }
 
 type anthropicRequest struct {
-	Model     string                 `json:"model"`
-	System    []anthropicSystemBlock `json:"system,omitempty"`
-	Messages  []anthropicMessage     `json:"messages"`
-	Tools     []anthropicTool        `json:"tools,omitempty"`
-	MaxTokens int                    `json:"max_tokens"`
-	Stream    bool                   `json:"stream"`
-	Thinking  *anthropicThinking     `json:"thinking,omitempty"`
+	Model        string                 `json:"model"`
+	System       []anthropicSystemBlock `json:"system,omitempty"`
+	Messages     []anthropicMessage     `json:"messages"`
+	Tools        []anthropicTool        `json:"tools,omitempty"`
+	MaxTokens    int                    `json:"max_tokens"`
+	Stream       bool                   `json:"stream"`
+	Thinking     *anthropicThinking     `json:"thinking,omitempty"`
+	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
 }
 
 type anthropicThinking struct {
-	Type         string `json:"type"` // "enabled"
-	BudgetTokens int    `json:"budget_tokens"`
+	Type string `json:"type"` // "adaptive" | "disabled"
+}
+
+type anthropicOutputConfig struct {
+	Effort string `json:"effort,omitempty"` // "low" | "medium" | "high" | "xhigh" | "max"
 }
 
 type anthropicSystemBlock struct {
@@ -160,17 +189,16 @@ func (p *AnthropicProvider) Chat(ctx context.Context, messages []Message, tools 
 		anthropicTools[len(anthropicTools)-1].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
 	}
 
+	thinking, outputCfg := p.reasoningConfig()
 	reqBody := anthropicRequest{
-		Model:     p.model,
-		System:    systemBlocks,
-		Messages:  anthropicMsgs,
-		Tools:     anthropicTools,
-		MaxTokens: p.maxOutputTokens,
-		Stream:    true,
-		Thinking: &anthropicThinking{
-			Type:         "enabled",
-			BudgetTokens: min(p.maxOutputTokens/2, 8000),
-		},
+		Model:        p.model,
+		System:       systemBlocks,
+		Messages:     anthropicMsgs,
+		Tools:        anthropicTools,
+		MaxTokens:    p.maxOutputTokens,
+		Stream:       true,
+		Thinking:     thinking,
+		OutputConfig: outputCfg,
 	}
 
 	body, err := json.Marshal(reqBody)

--- a/internal/ai/anthropic_test.go
+++ b/internal/ai/anthropic_test.go
@@ -1,0 +1,73 @@
+package ai
+
+import "testing"
+
+func TestNormalizeAnthropicReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name   string
+		effort string
+		want   string
+	}{
+		{name: "low", effort: "low", want: "low"},
+		{name: "medium upper", effort: "MEDIUM", want: "medium"},
+		{name: "high with spaces", effort: "  high  ", want: "high"},
+		{name: "xhigh", effort: "xhigh", want: "xhigh"},
+		{name: "max anthropic-only", effort: "max", want: "max"},
+		{name: "none", effort: "none", want: ""},
+		{name: "empty", effort: "", want: ""},
+		{name: "garbage falls back to medium", effort: "ultra", want: "medium"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeAnthropicReasoningEffort(tt.effort); got != tt.want {
+				t.Fatalf("normalizeAnthropicReasoningEffort(%q) = %q, want %q", tt.effort, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnthropicProviderReasoningConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		enabled        bool
+		effort         string
+		wantThinking   bool
+		wantThinkType  string
+		wantEffortSent string
+	}{
+		{name: "disabled when not enabled", enabled: false, effort: "high", wantThinking: false},
+		{name: "disabled when effort=none", enabled: true, effort: "none", wantThinking: false},
+		{name: "adaptive + medium", enabled: true, effort: "medium", wantThinking: true, wantThinkType: "adaptive", wantEffortSent: "medium"},
+		{name: "adaptive + max", enabled: true, effort: "max", wantThinking: true, wantThinkType: "adaptive", wantEffortSent: "max"},
+		{name: "adaptive + xhigh", enabled: true, effort: "xhigh", wantThinking: true, wantThinkType: "adaptive", wantEffortSent: "xhigh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewAnthropicProvider("test", "", "key", "claude-opus-4-7", 16000, tt.enabled, tt.effort)
+			thinking, outputCfg := p.reasoningConfig()
+
+			if tt.wantThinking {
+				if thinking == nil {
+					t.Fatalf("expected thinking, got nil")
+				}
+				if thinking.Type != tt.wantThinkType {
+					t.Fatalf("thinking.type = %q, want %q", thinking.Type, tt.wantThinkType)
+				}
+				if outputCfg == nil {
+					t.Fatalf("expected output_config, got nil")
+				}
+				if outputCfg.Effort != tt.wantEffortSent {
+					t.Fatalf("output_config.effort = %q, want %q", outputCfg.Effort, tt.wantEffortSent)
+				}
+			} else {
+				if thinking != nil {
+					t.Fatalf("expected no thinking, got %+v", thinking)
+				}
+				if outputCfg != nil {
+					t.Fatalf("expected no output_config, got %+v", outputCfg)
+				}
+			}
+		})
+	}
+}

--- a/internal/app/app_ai.go
+++ b/internal/app/app_ai.go
@@ -56,7 +56,15 @@ func (a *App) activateProvider(p *ai_provider_entity.AIProvider) error {
 	var provider ai.Provider
 	switch p.Type {
 	case "anthropic":
-		provider = ai.NewAnthropicProvider(p.Name, p.APIBase, apiKey, p.Model, maxOutputTokens)
+		provider = ai.NewAnthropicProvider(
+			p.Name,
+			p.APIBase,
+			apiKey,
+			p.Model,
+			maxOutputTokens,
+			p.ReasoningEnabled,
+			p.ReasoningEffort,
+		)
 	default: // "openai"
 		provider = ai.NewOpenAIProvider(
 			p.Name,

--- a/internal/app/app_ai_provider.go
+++ b/internal/app/app_ai_provider.go
@@ -43,18 +43,27 @@ func toProviderInfo(p *ai_provider_entity.AIProvider, apiKey string) AIProviderI
 }
 
 func normalizeProviderReasoningConfig(providerType string, reasoningEnabled bool, reasoningEffort string) (bool, string) {
-	if providerType != "openai" {
+	switch providerType {
+	case "openai", "anthropic":
+	default:
 		return false, ""
 	}
 	effort := strings.ToLower(strings.TrimSpace(reasoningEffort))
+	// max 仅 Anthropic 暴露；OpenAI 收到 max 视为非法，落回 medium
+	if effort == "max" && providerType != "anthropic" {
+		effort = "medium"
+	}
 	switch effort {
-	case "low", "medium", "high", "xhigh":
+	case "low", "medium", "high", "xhigh", "max":
 		return true, effort
 	case "none":
 		return false, ""
 	default:
-		// Backwards compat: old data with toggle=true but no effort → medium
-		if reasoningEnabled {
+		// Backwards compat:
+		// - 老 OpenAI 数据：toggle=true 但 effort 空 → medium
+		// - 老 Anthropic 数据：升级前 thinking 是硬编码常开的，effort 字段从未写入；
+		//   兜底成 enabled+medium，保留原产品观感
+		if reasoningEnabled || providerType == "anthropic" {
 			return true, "medium"
 		}
 		return false, ""

--- a/internal/app/app_ai_provider.go
+++ b/internal/app/app_ai_provider.go
@@ -26,6 +26,7 @@ type AIProviderInfo struct {
 }
 
 func toProviderInfo(p *ai_provider_entity.AIProvider, apiKey string) AIProviderInfo {
+	enabled, effort := normalizeProviderReasoningConfig(p.Type, p.ReasoningEnabled, p.ReasoningEffort)
 	return AIProviderInfo{
 		ID:               p.ID,
 		Name:             p.Name,
@@ -36,8 +37,8 @@ func toProviderInfo(p *ai_provider_entity.AIProvider, apiKey string) AIProviderI
 		Model:            p.Model,
 		MaxOutputTokens:  p.MaxOutputTokens,
 		ContextWindow:    p.ContextWindow,
-		ReasoningEnabled: p.ReasoningEnabled,
-		ReasoningEffort:  p.ReasoningEffort,
+		ReasoningEnabled: enabled,
+		ReasoningEffort:  effort,
 		IsActive:         p.IsActive,
 	}
 }
@@ -59,11 +60,9 @@ func normalizeProviderReasoningConfig(providerType string, reasoningEnabled bool
 	case "none":
 		return false, ""
 	default:
-		// Backwards compat:
-		// - 老 OpenAI 数据：toggle=true 但 effort 空 → medium
-		// - 老 Anthropic 数据：升级前 thinking 是硬编码常开的，effort 字段从未写入；
-		//   兜底成 enabled+medium，保留原产品观感
-		if reasoningEnabled || providerType == "anthropic" {
+		// 老 OpenAI 数据：toggle=true 但 effort 空 → medium。
+		// Anthropic legacy 兜底由 migration 202605070001 一次性处理，这里无需特例。
+		if reasoningEnabled {
 			return true, "medium"
 		}
 		return false, ""

--- a/internal/model/entity/ai_provider_entity/ai_provider.go
+++ b/internal/model/entity/ai_provider_entity/ai_provider.go
@@ -11,7 +11,7 @@ type AIProvider struct {
 	MaxOutputTokens  int    `gorm:"column:max_output_tokens;default:0" json:"maxOutputTokens"` // 0 表示使用默认值
 	ContextWindow    int    `gorm:"column:context_window;default:0" json:"contextWindow"`      // 0 表示使用默认值
 	ReasoningEnabled bool   `gorm:"column:reasoning_enabled;default:false" json:"reasoningEnabled"`
-	ReasoningEffort  string `gorm:"column:reasoning_effort;type:varchar(20);default:''" json:"reasoningEffort"` // 仅 OpenAI reasoning 模型使用
+	ReasoningEffort  string `gorm:"column:reasoning_effort;type:varchar(20);default:''" json:"reasoningEffort"` // OpenAI/Anthropic 共用：low/medium/high/xhigh/max（max 仅 Anthropic）
 	IsActive         bool   `gorm:"column:is_active;default:false" json:"isActive"`
 	Createtime       int64  `gorm:"column:createtime" json:"createtime"`
 	Updatetime       int64  `gorm:"column:updatetime" json:"updatetime"`

--- a/main.go
+++ b/main.go
@@ -77,7 +77,10 @@ func newAppOptions(a *app.App, windowWidth, windowHeight int) *options.App {
 			Assets:  assets,
 			Handler: app.NewExtensionAssetHandler(filepath.Join(bootstrap.AppDataDir(), "extensions"), nil),
 		},
-		OnStartup: a.Startup,
+		OnStartup: func(ctx context.Context) {
+			wailsRuntime.WindowCenter(ctx)
+			a.Startup(ctx)
+		},
 		// OnBeforeClose 在窗口真正关闭前触发：emit ai:flush-all 让前端落盘所有活跃会话，
 		// 前端完成后 EventsEmit("ai:flush-done") 回执，后端从 flushAckCh 收到信号立刻放行；
 		// 超时 2s 兜底避免前端异常时永久阻塞。返回 false 允许关闭；返回 true 则阻止关闭。

--- a/main.go
+++ b/main.go
@@ -59,7 +59,14 @@ func main() {
 		PluginMarketplaceJSON: skillplugin.PluginMarketplaceJSON,
 	})
 
-	err := wails.Run(&options.App{
+	err := wails.Run(newAppOptions(a, windowWidth, windowHeight))
+	if err != nil {
+		log.Fatalf("Wails启动失败: %v", err)
+	}
+}
+
+func newAppOptions(a *app.App, windowWidth, windowHeight int) *options.App {
+	return &options.App{
 		Title:     "OpsKat",
 		Width:     windowWidth,
 		Height:    windowHeight,
@@ -71,9 +78,6 @@ func main() {
 			Handler: app.NewExtensionAssetHandler(filepath.Join(bootstrap.AppDataDir(), "extensions"), nil),
 		},
 		OnStartup: a.Startup,
-		OnDomReady: func(ctx context.Context) {
-			wailsRuntime.WindowCenter(ctx)
-		},
 		// OnBeforeClose 在窗口真正关闭前触发：emit ai:flush-all 让前端落盘所有活跃会话，
 		// 前端完成后 EventsEmit("ai:flush-done") 回执，后端从 flushAckCh 收到信号立刻放行；
 		// 超时 2s 兜底避免前端异常时永久阻塞。返回 false 允许关闭；返回 true 则阻止关闭。
@@ -105,9 +109,6 @@ func main() {
 			TitleBar:             mac.TitleBarHiddenInset(),
 			WebviewIsTransparent: true,
 		},
-	})
-	if err != nil {
-		log.Fatalf("Wails启动失败: %v", err)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/opskat/opskat/internal/app"
+	"github.com/opskat/opskat/internal/bootstrap"
+)
+
+func TestInitialWindowSizeUsesSavedSizeWithMinimumFallbacks(t *testing.T) {
+	t.Parallel()
+
+	width, height := initialWindowSize(&bootstrap.AppConfig{
+		WindowWidth:  minWindowWidth + 120,
+		WindowHeight: minWindowHeight + 80,
+	})
+	if width != minWindowWidth+120 {
+		t.Fatalf("width = %d, want %d", width, minWindowWidth+120)
+	}
+	if height != minWindowHeight+80 {
+		t.Fatalf("height = %d, want %d", height, minWindowHeight+80)
+	}
+
+	width, height = initialWindowSize(&bootstrap.AppConfig{
+		WindowWidth:  minWindowWidth - 1,
+		WindowHeight: minWindowHeight - 1,
+	})
+	if width != defaultWindowWidth {
+		t.Fatalf("width below minimum = %d, want default %d", width, defaultWindowWidth)
+	}
+	if height != defaultWindowHeight {
+		t.Fatalf("height below minimum = %d, want default %d", height, defaultWindowHeight)
+	}
+}
+
+func TestNewAppOptionsUsesSavedSizeWithoutLateRecentering(t *testing.T) {
+	t.Parallel()
+
+	opts := newAppOptions(&app.App{}, minWindowWidth+200, minWindowHeight+100)
+	if opts.Width != minWindowWidth+200 {
+		t.Fatalf("Width = %d, want %d", opts.Width, minWindowWidth+200)
+	}
+	if opts.Height != minWindowHeight+100 {
+		t.Fatalf("Height = %d, want %d", opts.Height, minWindowHeight+100)
+	}
+	if opts.MinWidth != minWindowWidth {
+		t.Fatalf("MinWidth = %d, want %d", opts.MinWidth, minWindowWidth)
+	}
+	if opts.MinHeight != minWindowHeight {
+		t.Fatalf("MinHeight = %d, want %d", opts.MinHeight, minWindowHeight)
+	}
+	if opts.OnDomReady != nil {
+		t.Fatal("OnDomReady should be nil so startup centering happens only through Wails' initial window placement")
+	}
+}

--- a/migrations/202605070001_anthropic_default_reasoning.go
+++ b/migrations/202605070001_anthropic_default_reasoning.go
@@ -6,7 +6,7 @@ import (
 )
 
 // 升级前 Anthropic provider 的 thinking 是硬编码常开；引入 reasoning_enabled/effort
-// 字段后，老数据均为 0/''，会让 thinking 静默关闭。这里把存量 anthropic 行兜底为
+// 字段后，老数据均为 0/空字符串，会让 thinking 静默关闭。这里把存量 anthropic 行兜底为
 // enabled+medium，保留原产品观感。
 func migration202605070001() *gormigrate.Migration {
 	return &gormigrate.Migration{

--- a/migrations/202605070001_anthropic_default_reasoning.go
+++ b/migrations/202605070001_anthropic_default_reasoning.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// 升级前 Anthropic provider 的 thinking 是硬编码常开；引入 reasoning_enabled/effort
+// 字段后，老数据均为 0/''，会让 thinking 静默关闭。这里把存量 anthropic 行兜底为
+// enabled+medium，保留原产品观感。
+func migration202605070001() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202605070001",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.Exec(
+				`UPDATE ai_providers
+                 SET reasoning_enabled = 1, reasoning_effort = 'medium'
+                 WHERE type = 'anthropic'
+                   AND reasoning_enabled = 0
+                   AND (reasoning_effort IS NULL OR reasoning_effort = '')`,
+			).Error
+		},
+	}
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -24,6 +24,7 @@ func RunMigrations(db *gorm.DB) error {
 		migration202604270001(),
 		migration202605010001(),
 		migration202605060001(),
+		migration202605070001(),
 	})
 	return m.Migrate()
 }


### PR DESCRIPTION
## Summary

- 在 #74（OpenAI reasoning effort）的基础上为 Anthropic provider 也接入思考深度控制
- 复用现有 `ReasoningEnabled` + `ReasoningEffort` 字段，无新迁移列
- Anthropic 请求改用官方推荐的 `thinking:{type:"adaptive"}` + `output_config.effort`（替换原先硬编码的 manual `budget_tokens`，新模型上更稳）
- 仅考虑较新的 Claude 模型（Opus 4.6+ / Sonnet 4.6 / Mythos 等支持 adaptive thinking 的版本）；老模型不做白名单兜底，由 API 自行裁定

## Why

- 之前 `anthropic.go` 无脑硬编码 `thinking:{type:"enabled", budget_tokens:...}`，对 `claude-opus-4-7` 等只支持 adaptive 的新模型会直接 400
- 用户没有任何 UI 控制 Anthropic 思考深度

## 主要改动

### 后端

- `AnthropicProvider` 构造函数新增 `reasoningEnabled bool, reasoningEffort string` 参数
- `anthropicRequest` 加 `OutputConfig` 字段；`anthropicThinking` 删 `BudgetTokens`、`Type` 改 `"adaptive"`
- 抽出 `(*AnthropicProvider).reasoningConfig()` 方法集中决定下发逻辑
- `normalizeProviderReasoningConfig` 不再 `providerType != "openai"` 早返；支持 `max` 档位（仅 Anthropic 暴露，OpenAI 收到自动落回 `medium`）
- 老 Anthropic 数据 `effort=''` 兜底为 `medium`，保留原产品观感，**无需迁移**

### 前端

- `AIProviderForm` reasoning 面板对 OpenAI / Anthropic 都显示
- effort 类型扩到 `low/medium/high/xhigh/max`，`max` 仅 `formType==="anthropic"` 时渲染
- 切换 provider type 时 `max` 越界自动降级到 `high`
- Anthropic 不显示 unsupported hint
- 中英文 `reasoningEffortMax` 文案 + hint 增补

### 测试

- `anthropic_test.go` 覆盖：
  - `normalizeAnthropicReasoningEffort` 全部分支（low/medium/high/xhigh/max/none/empty/garbage）
  - `(*AnthropicProvider).reasoningConfig()` 各 enabled/effort 组合的请求映射

## Test plan

- [x] `go test ./internal/ai/ ./internal/app/...`（770/770 + ai/app 全过）
- [x] `golangci-lint run` 0 issues
- [x] `pnpm lint`（30 条预存其他文件警告，本次未引入新警告）
- [x] `pnpm test`（770/770）
- [ ] 手动：选 Claude Opus 4.7，开 max 档，发消息确认 thinking 流正常
- [ ] 手动：旧 Anthropic provider 升级后保持思考开启（兜底逻辑）
- [ ] 手动：切 OpenAI 时 max 档不出现且自动降级