### PR TITLE
🐛 修复 AI 流式错误处理与思考签名回传

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Bindings stay thin: parse → service → return. Business rules in `service/`, 
 - **Commits:** gitmoji — ✨ feature, 🐛 fix, ♻️ refactor, 🎨 UI, ⚡️ perf, 🔒 security, 🔧 config, ✅ tests, 📄 docs, 🚀 release.
 - **Go mocks:** `go.uber.org/mock` in `mock_*/` subdirs; regen via `go generate ./...`.
 - **Go tests:** goconvey + testify.
+- **Logging:** `cago/pkg/logger` — prefer `logger.Ctx(ctx)` whenever a `context.Context` is reachable (param, struct field like `a.ctx`, captured closure ctx, `cmd.Context()`, `tx.Statement.Context`). `logger.Default()` loses request context — only use it when no ctx is in scope (e.g. `init()`, pure helpers, structs without a ctx field). Don't bolt a ctx parameter onto a function just to log.
 - **Frontend:** Prettier (120 col, 2-space).
 
 ## Fix policy — root cause, in scope, no parking

--- a/cmd/opsctl/command/approval.go
+++ b/cmd/opsctl/command/approval.go
@@ -39,7 +39,7 @@ func requireApproval(ctx context.Context, req approval.ApprovalRequest) (Approva
 	if req.SessionID == "" {
 		id := uuid.New().String()
 		if err := writeActiveSession(id); err != nil {
-			logger.Default().Warn("write active session", zap.String("sessionID", id), zap.Error(err))
+			logger.Ctx(ctx).Warn("write active session", zap.String("sessionID", id), zap.Error(err))
 		}
 		req.SessionID = id
 	}
@@ -78,7 +78,7 @@ func requireApproval(ctx context.Context, req approval.ApprovalRequest) (Approva
 
 	authToken, err := bootstrap.ReadAuthToken(dataDir)
 	if err != nil {
-		logger.Default().Warn("read auth token", zap.Error(err))
+		logger.Ctx(ctx).Warn("read auth token", zap.Error(err))
 	}
 
 	resp, err := approval.RequestApprovalWithToken(sockPath, authToken, req)
@@ -113,7 +113,7 @@ func requireApproval(ctx context.Context, req approval.ApprovalRequest) (Approva
 	// If the desktop app approved the entire session, persist it locally
 	if resp.ApproveGrant && req.SessionID != "" {
 		if err := writeActiveSession(req.SessionID); err != nil {
-			logger.Default().Warn("write active session", zap.String("sessionID", req.SessionID), zap.Error(err))
+			logger.Ctx(ctx).Warn("write active session", zap.String("sessionID", req.SessionID), zap.Error(err))
 		}
 	}
 

--- a/cmd/opsctl/command/batch.go
+++ b/cmd/opsctl/command/batch.go
@@ -363,7 +363,7 @@ func requireBatchApproval(ctx context.Context, items []approval.BatchItem, sessi
 	if session == "" {
 		id := newSessionID()
 		if err := writeActiveSession(id); err != nil {
-			logger.Default().Warn("write active session", zap.Error(err))
+			logger.Ctx(ctx).Warn("write active session", zap.Error(err))
 		}
 		session = id
 	}
@@ -373,7 +373,7 @@ func requireBatchApproval(ctx context.Context, items []approval.BatchItem, sessi
 
 	authToken, err := bootstrap.ReadAuthToken(dataDir)
 	if err != nil {
-		logger.Default().Warn("read auth token", zap.Error(err))
+		logger.Ctx(ctx).Warn("read auth token", zap.Error(err))
 	}
 
 	// Build detail string for the request

--- a/cmd/opsctl/command/grant.go
+++ b/cmd/opsctl/command/grant.go
@@ -210,7 +210,7 @@ func cmdGrantSubmit(ctx context.Context, args []string, session string) int {
 	sockPath := approval.SocketPath(dataDir)
 	authToken, err := bootstrap.ReadAuthToken(dataDir)
 	if err != nil {
-		logger.Default().Warn("read auth token", zap.Error(err))
+		logger.Ctx(ctx).Warn("read auth token", zap.Error(err))
 	}
 
 	// 构建审计用的请求 JSON（使用解析后的 grantItems，包含资产信息）

--- a/cmd/opsctl/command/handler.go
+++ b/cmd/opsctl/command/handler.go
@@ -39,7 +39,7 @@ func callHandler(ctx context.Context, handlers map[string]ai.ToolHandlerFunc, to
 	// 写审计日志
 	argsJSON, marshalErr := json.Marshal(params)
 	if marshalErr != nil {
-		logger.Default().Warn("marshal audit params", zap.Error(marshalErr))
+		logger.Ctx(ctx).Warn("marshal audit params", zap.Error(marshalErr))
 	}
 	var dec *ai.CheckResult
 	if len(decision) > 0 {
@@ -57,7 +57,7 @@ func callHandler(ctx context.Context, handlers map[string]ai.ToolHandlerFunc, to
 		dataDir := bootstrap.AppDataDir()
 		token, tokenErr := bootstrap.ReadAuthToken(dataDir)
 		if tokenErr != nil {
-			logger.Default().Warn("read auth token", zap.Error(tokenErr))
+			logger.Ctx(ctx).Warn("read auth token", zap.Error(tokenErr))
 		}
 		approval.SendNotification(
 			approval.SocketPath(dataDir),

--- a/cmd/opsctl/command/resolve.go
+++ b/cmd/opsctl/command/resolve.go
@@ -78,7 +78,7 @@ func resolveAsset(ctx context.Context, identifier string) (*asset_entity.Asset, 
 	// Ambiguous - list candidates
 	groupMap, err := buildGroupPathMap(ctx)
 	if err != nil {
-		logger.Default().Warn("build group path map", zap.Error(err))
+		logger.Ctx(ctx).Warn("build group path map", zap.Error(err))
 	}
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "ambiguous name %q, matches:\n", identifier)

--- a/cmd/opsctl/command/ssh.go
+++ b/cmd/opsctl/command/ssh.go
@@ -92,7 +92,7 @@ func cmdSSHDirect(ctx context.Context, assetID int64) int {
 	}
 	defer func() {
 		if err := session.Close(); err != nil {
-			logger.Default().Warn("close SSH session", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSH session", zap.Error(err))
 		}
 	}()
 
@@ -104,7 +104,7 @@ func cmdSSHDirect(ctx context.Context, assetID int64) int {
 	}
 	defer func() {
 		if err := term.Restore(fd, oldState); err != nil {
-			logger.Default().Warn("restore terminal state", zap.Error(err))
+			logger.Ctx(ctx).Warn("restore terminal state", zap.Error(err))
 		}
 	}()
 
@@ -120,7 +120,7 @@ func cmdSSHDirect(ctx context.Context, assetID int64) int {
 	}
 	if err := session.RequestPty("xterm-256color", height, width, modes); err != nil {
 		if restoreErr := term.Restore(fd, oldState); restoreErr != nil {
-			logger.Default().Warn("restore terminal state", zap.Error(restoreErr))
+			logger.Ctx(ctx).Warn("restore terminal state", zap.Error(restoreErr))
 		}
 		fmt.Fprintf(os.Stderr, "Error: failed to request PTY: %v\n", err)
 		return 1
@@ -135,7 +135,7 @@ func cmdSSHDirect(ctx context.Context, assetID int64) int {
 
 	if err := session.Shell(); err != nil {
 		if restoreErr := term.Restore(fd, oldState); restoreErr != nil {
-			logger.Default().Warn("restore terminal state", zap.Error(restoreErr))
+			logger.Ctx(ctx).Warn("restore terminal state", zap.Error(restoreErr))
 		}
 		fmt.Fprintf(os.Stderr, "Error: failed to start shell: %v\n", err)
 		return 1

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -817,6 +817,7 @@
       "tooltip": "Token usage for this reply"
     },
     "retrying": "Retrying",
+    "errorUnknown": "AI error (no details)",
     "newConversation": "New conversation",
     "sidebar": {
       "title": "AI Assistant",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -802,6 +802,7 @@
       "tooltip": "本次回复 token 使用量"
     },
     "retrying": "重试中",
+    "errorUnknown": "AI 接口错误（无详细信息）",
     "newConversation": "新对话",
     "sidebar": {
       "title": "AI 助手",

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -34,6 +34,8 @@ export interface ContentBlock {
   toolName?: string;
   toolInput?: string;
   toolCallId?: string; // 跨 turn 还原 tool_calls 历史；老数据无此字段，发送时退化为塌缩消息
+  // thinking 块专用：Anthropic adaptive thinking 的签名，跨 turn 必须原样回传，否则真 Anthropic 400。
+  thinkingSignature?: string;
   status?: "running" | "completed" | "error" | "pending_confirm" | "cancelled";
   confirmId?: string;
   // agent 块专用
@@ -80,6 +82,8 @@ export interface PendingQueueItem {
 interface StreamEventData {
   type: string;
   content?: string;
+  // type=thinking_done 时携带 Anthropic adaptive thinking 块的签名，需随消息持久化用于跨 turn 回传
+  thinking_signature?: string;
   tool_name?: string;
   tool_input?: string;
   tool_call_id?: string;
@@ -1179,10 +1183,15 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
     }
 
     case "thinking_done": {
+      // 后端在 content_block_stop 时把累积的 signature_delta 一起下发，跨 turn 必须随 thinking 内容回传。
+      const sig = event.thinking_signature;
       const updated = updateLastAssistant(msgs, (msg) => {
-        const newBlocks = msg.blocks.map((b) =>
-          b.type === "thinking" && b.status === "running" ? { ...b, status: "completed" as const } : b
-        );
+        const newBlocks = msg.blocks.map((b) => {
+          if (b.type === "thinking" && b.status === "running") {
+            return { ...b, status: "completed" as const, ...(sig ? { thinkingSignature: sig } : {}) };
+          }
+          return b;
+        });
         return { ...msg, blocks: newBlocks };
       });
       if (updated) {
@@ -1325,15 +1334,50 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
 
     case "error": {
       cleanupStreamBuffer(convId);
-      const updated = updateLastAssistant(msgs, (msg) => ({
-        ...msg,
-        blocks: appendText(msg.blocks, `\n\n**Error:** ${event.error}`),
-        streaming: false,
-      }));
+      const errText =
+        (event.error && String(event.error).trim()) || i18n.t("ai.errorUnknown", "AI 接口错误（无详细信息）");
+      const updated = updateLastAssistant(msgs, (msg) => {
+        // 终结仍在运行的中间块，避免 spinner 永远转下去
+        const newBlocks = msg.blocks.map((b) => {
+          if (b.type === "tool" && (b.status === "running" || b.status === "pending_confirm")) {
+            return { ...b, status: "cancelled" as const };
+          }
+          if (b.type === "thinking" && b.status === "running") {
+            return { ...b, status: "completed" as const };
+          }
+          if (b.type === "agent" && b.status === "running") {
+            return {
+              ...b,
+              status: "cancelled" as const,
+              childBlocks: b.childBlocks?.map((c) =>
+                c.status === "running" ? { ...c, status: "cancelled" as const } : c
+              ),
+            };
+          }
+          return b;
+        });
+        // 没有任何先前内容时，避免前导空行让首屏看起来错位
+        const prefix = newBlocks.length === 0 ? "" : "\n\n";
+        return {
+          ...msg,
+          blocks: appendText(newBlocks, `${prefix}**Error:** ${errText}`),
+          streaming: false,
+        };
+      });
       if (updated) {
         updateConversation(convId, { messages: updated, sending: false });
       } else {
-        updateConversation(convId, { sending: false });
+        // 没有 assistant 占位（极端情况：流在创建占位前就挂了）—— 兜底插入一条
+        const errMsg: ChatMessage = {
+          role: "assistant",
+          content: "",
+          blocks: [{ type: "text", content: `**Error:** ${errText}` }],
+          streaming: false,
+        };
+        updateConversation(convId, {
+          messages: [...msgs, errMsg],
+          sending: false,
+        });
       }
 
       // 错误态同样需要落盘，否则强制重启后会丢掉最后一次失败上下文。
@@ -1395,6 +1439,10 @@ function expandToAPIMessages(messages: ChatMessage[]): ai.Message[] {
 
     // assistant 累加器：在遇到 tool block 时刷出当前 assistant + 跟一条 tool 消息
     let thinking = "";
+    // Anthropic adaptive thinking 块的签名，跨 turn 必须原样回传。
+    // 单轮通常只有一个 thinking 块，取最后一次见到的签名即可；
+    // 没有签名（如 DeepSeek 兼容端）就保持空，由后端 omitempty 略掉。
+    let thinkingSignature = "";
     let text = "";
     const pendingToolCalls: { id: string; type: string; function: { name: string; arguments: string } }[] = [];
 
@@ -1404,10 +1452,12 @@ function expandToAPIMessages(messages: ChatMessage[]): ai.Message[] {
       if (thinking) {
         payload.thinking = thinking;
         payload.reasoning_content = thinking;
+        if (thinkingSignature) payload.thinking_signature = thinkingSignature;
       }
       if (pendingToolCalls.length > 0) payload.tool_calls = pendingToolCalls.slice();
       out.push(new ai.Message(payload));
       thinking = "";
+      thinkingSignature = "";
       text = "";
       pendingToolCalls.length = 0;
     };
@@ -1426,10 +1476,13 @@ function expandToAPIMessages(messages: ChatMessage[]): ai.Message[] {
         .filter((b) => b.type === "thinking")
         .map((b) => b.content)
         .join("");
+      // 单轮塌缩场景下，取首个有签名的 thinking 块（拼接会破坏单一签名对应单一文本的假设）。
+      const sig = m.blocks.find((b) => b.type === "thinking" && b.thinkingSignature)?.thinkingSignature;
       const payload: Record<string, unknown> = { role: "assistant", content: m.content };
       if (allThinking) {
         payload.thinking = allThinking;
         payload.reasoning_content = allThinking;
+        if (sig) payload.thinking_signature = sig;
       }
       out.push(new ai.Message(payload));
       continue;
@@ -1438,6 +1491,7 @@ function expandToAPIMessages(messages: ChatMessage[]): ai.Message[] {
     for (const b of m.blocks) {
       if (b.type === "thinking") {
         thinking += b.content;
+        if (b.thinkingSignature) thinkingSignature = b.thinkingSignature;
       } else if (b.type === "text") {
         text += b.content;
       } else if (b.type === "tool" && b.toolCallId) {

--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -70,7 +70,7 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 	if closer, ok := executor.(io.Closer); ok {
 		defer func() {
 			if err := closer.Close(); err != nil {
-				logger.Default().Warn("close tool executor", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tool executor", zap.Error(err))
 			}
 		}()
 	}
@@ -86,7 +86,7 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 	for round := 0; round < maxRounds; round++ {
 		// 检查是否需要压缩上下文
 		if a.config.ContextWindow > 0 && needsCompression(messages, a.config.ContextWindow) {
-			logger.Default().Info("compressing conversation context",
+			logger.Ctx(ctx).Info("compressing conversation context",
 				zap.Int("messages", len(messages)),
 				zap.Int("estimated_tokens", estimateTokens(messages)),
 				zap.Int("context_window", a.config.ContextWindow))
@@ -100,6 +100,7 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 
 		var contentBuf string
 		var thinkingBuf string
+		var thinkingSignature string
 		var toolCalls []ToolCall
 		hasToolCall := false
 
@@ -112,6 +113,9 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 				thinkingBuf += event.Content
 				onEvent(event)
 			case "thinking_done":
+				if event.ThinkingSignature != "" {
+					thinkingSignature = event.ThinkingSignature
+				}
 				onEvent(event)
 			case "tool_start", "tool_result", "approval_request", "approval_result":
 				onEvent(event)
@@ -140,10 +144,11 @@ func (a *Agent) Chat(ctx context.Context, messages []Message, onEvent func(Strea
 		// reasoning_content 仅 DeepSeek-v4 thinking 模式强制要求回传（否则多轮 400），
 		// 其他 provider 保持原有行为，避免引入未知字段触发严格 OpenAI-compat 后端报错。
 		assistantMsg := Message{
-			Role:      RoleAssistant,
-			Content:   contentBuf,
-			Thinking:  thinkingBuf,
-			ToolCalls: toolCalls,
+			Role:              RoleAssistant,
+			Content:           contentBuf,
+			Thinking:          thinkingBuf,
+			ThinkingSignature: thinkingSignature,
+			ToolCalls:         toolCalls,
 		}
 		if needsReasoningContent(a.provider.Model()) {
 			assistantMsg.ReasoningContent = thinkingBuf

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -103,8 +103,14 @@ type anthropicMessage struct {
 }
 
 type anthropicContentBlock struct {
-	Type         string                 `json:"type"`
-	Text         string                 `json:"text,omitempty"`
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+	// Thinking / Signature: type=thinking 块的内容字段（不是 text）。
+	// 真 Anthropic 在 adaptive thinking + tool_use 多轮会话中要求把 thinking 块
+	// 连同 signature 原样回传，否则 400。DeepSeek-v4 的 Anthropic 兼容端
+	// 不签名但仍然校验 thinking 字段名，缺字段会报 "missing field thinking"。
+	Thinking     string                 `json:"thinking,omitempty"`
+	Signature    string                 `json:"signature,omitempty"`
 	ID           string                 `json:"id,omitempty"`
 	Name         string                 `json:"name,omitempty"`
 	Input        interface{}            `json:"input,omitempty"`
@@ -153,9 +159,10 @@ type anthropicBlockStart struct {
 }
 
 type anthropicDelta struct {
-	Type        string `json:"type"` // "text_delta" | "input_json_delta" | "thinking_delta"
+	Type        string `json:"type"` // "text_delta" | "input_json_delta" | "thinking_delta" | "signature_delta"
 	Text        string `json:"text,omitempty"`
 	Thinking    string `json:"thinking,omitempty"`
+	Signature   string `json:"signature,omitempty"`
 	PartialJSON string `json:"partial_json,omitempty"`
 }
 
@@ -166,10 +173,12 @@ type anthropicStreamError struct {
 
 // blockState 跟踪流式 content block 的状态
 type blockState struct {
-	blockType string // "text" | "tool_use"
+	blockType string // "text" | "tool_use" | "thinking"
 	toolID    string
 	toolName  string
 	inputJSON strings.Builder
+	// signature 仅 thinking 块使用：累积 signature_delta 事件，content_block_stop 时落到 thinking_done。
+	signature strings.Builder
 }
 
 func (p *AnthropicProvider) Chat(ctx context.Context, messages []Message, tools []Tool) (<-chan StreamEvent, error) {
@@ -221,15 +230,22 @@ func (p *AnthropicProvider) Chat(ctx context.Context, messages []Message, tools 
 	if resp.StatusCode != http.StatusOK {
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				logger.Default().Warn("close HTTP response body", zap.Error(err))
+				logger.Ctx(ctx).Warn("close HTTP response body", zap.Error(err))
 			}
 		}()
 		errBody, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
-			logger.Default().Warn("read error response body", zap.Error(readErr))
+			logger.Ctx(ctx).Warn("read error response body", zap.Error(readErr))
+		}
+		errMsg := strings.TrimSpace(string(errBody))
+		if errMsg == "" {
+			errMsg = http.StatusText(resp.StatusCode)
+			if errMsg == "" {
+				errMsg = "(empty response body)"
+			}
 		}
 		return nil, &ProviderError{
-			Err:        fmt.Errorf("API error %d: %s", resp.StatusCode, string(errBody)),
+			Err:        fmt.Errorf("API error %d: %s", resp.StatusCode, errMsg),
 			RetryAfter: resp.Header.Get("Retry-After"),
 			StatusCode: resp.StatusCode,
 		}
@@ -262,8 +278,9 @@ func (p *AnthropicProvider) convertMessages(messages []Message) (string, []anthr
 				var blocks []anthropicContentBlock
 				if msg.Thinking != "" {
 					blocks = append(blocks, anthropicContentBlock{
-						Type: "thinking",
-						Text: msg.Thinking,
+						Type:      "thinking",
+						Thinking:  msg.Thinking,
+						Signature: msg.ThinkingSignature,
 					})
 				}
 				if msg.Content != "" {
@@ -341,7 +358,7 @@ func (p *AnthropicProvider) readStream(ctx context.Context, body io.ReadCloser, 
 	defer close(ch)
 	defer func() {
 		if err := body.Close(); err != nil {
-			logger.Default().Warn("close SSE stream body", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSE stream body", zap.Error(err))
 		}
 	}()
 
@@ -369,6 +386,10 @@ func (p *AnthropicProvider) readStream(ctx context.Context, body io.ReadCloser, 
 
 		var event anthropicSSEEvent
 		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			logger.Ctx(ctx).Warn("anthropic SSE event unmarshal failed",
+				zap.String("model", p.model),
+				zap.String("raw", data),
+				zap.Error(err))
 			continue
 		}
 
@@ -417,6 +438,10 @@ func (p *AnthropicProvider) readStream(ctx context.Context, body io.ReadCloser, 
 				if event.Delta.Thinking != "" {
 					ch <- StreamEvent{Type: "thinking", Content: event.Delta.Thinking}
 				}
+			case "signature_delta":
+				// 不立即转发，累积到 content_block_stop 时随 thinking_done 一并下发，
+				// 避免前端为 signature 引入额外事件类型。
+				bs.signature.WriteString(event.Delta.Signature)
 			case "input_json_delta":
 				bs.inputJSON.WriteString(event.Delta.PartialJSON)
 			}
@@ -433,7 +458,7 @@ func (p *AnthropicProvider) readStream(ctx context.Context, body io.ReadCloser, 
 				tc.Function.Arguments = bs.inputJSON.String()
 				ch <- StreamEvent{Type: "tool_call", ToolCalls: []ToolCall{tc}}
 			case "thinking":
-				ch <- StreamEvent{Type: "thinking_done"}
+				ch <- StreamEvent{Type: "thinking_done", ThinkingSignature: bs.signature.String()}
 			}
 			delete(blocks, event.Index)
 
@@ -450,19 +475,36 @@ func (p *AnthropicProvider) readStream(ctx context.Context, body io.ReadCloser, 
 			if event.Error != nil {
 				errMsg = event.Error.Message
 			}
+			logger.Ctx(ctx).Warn("anthropic stream error event",
+				zap.String("model", p.model),
+				zap.String("message", errMsg),
+				zap.String("raw", data))
 			ch <- StreamEvent{Type: "error", Error: errMsg}
 			return
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		logger.Default().Warn("SSE stream scanner error", zap.Error(err))
+		logger.Ctx(ctx).Warn("anthropic SSE stream scanner error",
+			zap.String("model", p.model),
+			zap.Error(err))
+		if usageStarted {
+			u := accumulated
+			ch <- StreamEvent{Type: "usage", Usage: &u}
+		}
+		ch <- StreamEvent{Type: "error", Error: fmt.Sprintf("stream interrupted: %v", err)}
+		return
 	}
 
-	// 如果流意外结束（没有 message_stop），仍发送 done
+	// 流自然结束但没收到 message_stop —— 视为异常，不能伪装成 done，
+	// 否则前端会把空消息当成功完成。runner 看到 error 后会按重试策略处理。
+	logger.Ctx(ctx).Warn("anthropic stream ended without message_stop",
+		zap.String("model", p.model),
+		zap.Bool("had_usage", usageStarted),
+		zap.Int("pending_blocks", len(blocks)))
 	if usageStarted {
 		u := accumulated
 		ch <- StreamEvent{Type: "usage", Usage: &u}
 	}
-	ch <- StreamEvent{Type: "done"}
+	ch <- StreamEvent{Type: "error", Error: "stream ended unexpectedly without message_stop"}
 }

--- a/internal/ai/anthropic_test.go
+++ b/internal/ai/anthropic_test.go
@@ -1,6 +1,14 @@
 package ai
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 func TestNormalizeAnthropicReasoningEffort(t *testing.T) {
 	tests := []struct {
@@ -23,6 +31,157 @@ func TestNormalizeAnthropicReasoningEffort(t *testing.T) {
 				t.Fatalf("normalizeAnthropicReasoningEffort(%q) = %q, want %q", tt.effort, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestAnthropicConvertMessages_ThinkingBlockSerialization 回归测试：
+// thinking 块必须以 "thinking" 字段而不是 "text" 字段输出，
+// 否则 DeepSeek-v4 等 Anthropic 兼容端会 400: "missing field thinking"。
+func TestAnthropicConvertMessages_ThinkingBlockSerialization(t *testing.T) {
+	p := NewAnthropicProvider("test", "", "key", "claude-opus-4-7", 16000, true, "medium")
+
+	tc := ToolCall{ID: "call_1", Type: "function"}
+	tc.Function.Name = "list_assets"
+	tc.Function.Arguments = `{}`
+
+	_, msgs := p.convertMessages([]Message{
+		{Role: RoleUser, Content: "list assets"},
+		{
+			Role:      RoleAssistant,
+			Thinking:  "let me think",
+			Content:   "ok",
+			ToolCalls: []ToolCall{tc},
+		},
+	})
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	data, err := json.Marshal(msgs[1])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	blocks, ok := raw["content"].([]any)
+	if !ok || len(blocks) == 0 {
+		t.Fatalf("expected content block array, got %#v", raw["content"])
+	}
+	first, ok := blocks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first block to be object, got %#v", blocks[0])
+	}
+	if first["type"] != "thinking" {
+		t.Fatalf("first block type = %v, want \"thinking\"", first["type"])
+	}
+	if first["thinking"] != "let me think" {
+		t.Fatalf("first block thinking = %v, want \"let me think\"", first["thinking"])
+	}
+	if _, hasText := first["text"]; hasText {
+		t.Fatalf("thinking block must not contain \"text\" field, got %#v", first)
+	}
+}
+
+// TestAnthropicConvertMessages_ThinkingSignatureRoundtrip 验证 thinking 块的 signature
+// 在 Message → 出站 JSON 这一段被原样回传。真 Anthropic 在 reasoning + tool_use 多轮
+// 会话中没有签名会 400，所以必须确保签名不被丢弃。
+func TestAnthropicConvertMessages_ThinkingSignatureRoundtrip(t *testing.T) {
+	p := NewAnthropicProvider("test", "", "key", "claude-opus-4-7", 16000, true, "medium")
+
+	tc := ToolCall{ID: "call_1", Type: "function"}
+	tc.Function.Name = "list_assets"
+	tc.Function.Arguments = `{}`
+
+	_, msgs := p.convertMessages([]Message{
+		{Role: RoleUser, Content: "go"},
+		{
+			Role:              RoleAssistant,
+			Thinking:          "let me think",
+			ThinkingSignature: "sig-abc-123",
+			ToolCalls:         []ToolCall{tc},
+		},
+	})
+
+	data, err := json.Marshal(msgs[1])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	first := raw["content"].([]any)[0].(map[string]any)
+	if first["signature"] != "sig-abc-123" {
+		t.Fatalf("expected signature \"sig-abc-123\" on thinking block, got %#v", first)
+	}
+
+	// 没有签名时（DeepSeek 兼容端）omitempty 应当略掉 signature 字段，避免空字符串混淆后端。
+	_, msgs2 := p.convertMessages([]Message{
+		{Role: RoleUser, Content: "go"},
+		{Role: RoleAssistant, Thinking: "x", ToolCalls: []ToolCall{tc}},
+	})
+	data2, _ := json.Marshal(msgs2[1])
+	var raw2 map[string]any
+	_ = json.Unmarshal(data2, &raw2)
+	first2 := raw2["content"].([]any)[0].(map[string]any)
+	if _, has := first2["signature"]; has {
+		t.Fatalf("expected signature field to be omitted when empty, got %#v", first2)
+	}
+}
+
+// TestAnthropicReadStream_CapturesSignature 验证流式解析把 signature_delta 累积起来，
+// 并在 thinking 块结束时随 thinking_done 事件下发，供上层写入 Message.ThinkingSignature。
+func TestAnthropicReadStream_CapturesSignature(t *testing.T) {
+	// 模拟一个真 Anthropic 风格的 SSE 流：thinking 块 + signature_delta + tool_use + 结束。
+	sse := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"think "}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hard"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"xyz"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_delta","usage":{"output_tokens":5}}`,
+		`data: {"type":"message_stop"}`,
+		"",
+	}, "\n")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer srv.Close()
+
+	p := NewAnthropicProvider("test", srv.URL, "key", "claude-opus-4-7", 1000, true, "medium")
+	ch, err := p.Chat(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	var sawDone bool
+	var capturedSig string
+	var thinkingBuf strings.Builder
+	for ev := range ch {
+		switch ev.Type {
+		case "thinking":
+			thinkingBuf.WriteString(ev.Content)
+		case "thinking_done":
+			capturedSig = ev.ThinkingSignature
+		case "done":
+			sawDone = true
+		}
+	}
+	if !sawDone {
+		t.Fatalf("stream did not complete with done")
+	}
+	if thinkingBuf.String() != "think hard" {
+		t.Fatalf("thinking buf = %q, want \"think hard\"", thinkingBuf.String())
+	}
+	if capturedSig != "sig-xyz" {
+		t.Fatalf("thinking_done signature = %q, want \"sig-xyz\"", capturedSig)
 	}
 }
 

--- a/internal/ai/audit.go
+++ b/internal/ai/audit.go
@@ -103,7 +103,7 @@ func NewDefaultAuditWriter() *DefaultAuditWriter {
 func (w *DefaultAuditWriter) WriteToolCall(ctx context.Context, info ToolCallInfo) {
 	var args map[string]any
 	if err := json.Unmarshal([]byte(info.ArgsJSON), &args); err != nil {
-		logger.Default().Warn("unmarshal audit args", zap.Error(err))
+		logger.Ctx(ctx).Warn("unmarshal audit args", zap.Error(err))
 	}
 
 	assetID := argInt64(args, "asset_id")
@@ -152,7 +152,7 @@ func (w *DefaultAuditWriter) WriteToolCall(ctx context.Context, info ToolCallInf
 
 	if repo := audit_repo.Audit(); repo != nil {
 		if err := repo.Create(context.Background(), entry); err != nil {
-			logger.Default().Error("audit log write failed", zap.Error(err))
+			logger.Ctx(ctx).Error("audit log write failed", zap.Error(err))
 		}
 	}
 }
@@ -214,7 +214,7 @@ func writeGrantSubmitAudit(ctx context.Context, assetID int64, assetName string,
 			Createtime: time.Now().Unix(),
 		}
 		if err := repo.Create(context.Background(), entry); err != nil {
-			logger.Default().Error("write grant submit audit", zap.Error(err))
+			logger.Ctx(ctx).Error("write grant submit audit", zap.Error(err))
 		}
 	}
 }
@@ -234,7 +234,7 @@ func WriteGrantSubmitAudit(ctx context.Context, assetID int64, assetName string,
 			Createtime: time.Now().Unix(),
 		}
 		if err := repo.Create(context.Background(), entry); err != nil {
-			logger.Default().Error("write grant submit audit", zap.Error(err))
+			logger.Ctx(ctx).Error("write grant submit audit", zap.Error(err))
 		}
 	}
 }

--- a/internal/ai/command_policy.go
+++ b/internal/ai/command_policy.go
@@ -134,7 +134,7 @@ func (c *CommandPolicyChecker) SubmitGrant(ctx context.Context, assetID int64, p
 	if assetID > 0 {
 		asset, err := asset_svc.Asset().Get(ctx, assetID)
 		if err != nil {
-			logger.Default().Warn("get asset for grant submission", zap.Int64("assetID", assetID), zap.Error(err))
+			logger.Ctx(ctx).Warn("get asset for grant submission", zap.Int64("assetID", assetID), zap.Error(err))
 		}
 		if asset != nil {
 			assetName = asset.Name
@@ -179,7 +179,7 @@ func (c *CommandPolicyChecker) SubmitGrantMulti(ctx context.Context, items []Gra
 		if item.AssetID > 0 {
 			asset, err := asset_svc.Asset().Get(ctx, item.AssetID)
 			if err != nil {
-				logger.Default().Warn("get asset for grant submission", zap.Int64("assetID", item.AssetID), zap.Error(err))
+				logger.Ctx(ctx).Warn("get asset for grant submission", zap.Int64("assetID", item.AssetID), zap.Error(err))
 			}
 			if asset != nil {
 				assetName = asset.Name
@@ -321,7 +321,7 @@ func (c *CommandPolicyChecker) handleConfirm(ctx context.Context, assetID int64,
 
 	asset, err := asset_svc.Asset().Get(ctx, assetID)
 	if err != nil {
-		logger.Default().Warn("get asset for confirm", zap.Int64("assetID", assetID), zap.Error(err))
+		logger.Ctx(ctx).Warn("get asset for confirm", zap.Int64("assetID", assetID), zap.Error(err))
 	}
 	assetName := ""
 	if asset != nil {
@@ -426,7 +426,7 @@ func formatDenyMessage(_ context.Context, assetName, command, reason string, hin
 func resolveAssetPolicyChain(ctx context.Context, assetID int64) (*asset_entity.Asset, []policy.Holder) {
 	asset, err := asset_svc.Asset().Get(ctx, assetID)
 	if err != nil {
-		logger.Default().Warn("get asset for policy check", zap.Int64("assetID", assetID), zap.Error(err))
+		logger.Ctx(ctx).Warn("get asset for policy check", zap.Int64("assetID", assetID), zap.Error(err))
 		return nil, nil
 	}
 	var holders []policy.Holder

--- a/internal/ai/compress.go
+++ b/internal/ai/compress.go
@@ -93,7 +93,9 @@ func compressMessages(ctx context.Context, provider Provider, messages []Message
 	})
 	for _, msg := range recentMsgs {
 		stripped := msg
-		stripped.Thinking = "" // 压缩时丢弃思考内容，节省 token
+		// 压缩时丢弃思考内容，节省 token；签名跟着一起清，不能脱离 thinking 单独存在。
+		stripped.Thinking = ""
+		stripped.ThinkingSignature = ""
 		result = append(result, stripped)
 	}
 	return result
@@ -161,7 +163,7 @@ Conversation:
 
 	ch, err := provider.Chat(ctx, messages, nil)
 	if err != nil {
-		logger.Default().Warn("compress conversation failed", zap.Error(err))
+		logger.Ctx(ctx).Warn("compress conversation failed", zap.Error(err))
 		return "[Previous conversation context was compressed]\n\n" + truncateRunes(conversationText, 2000)
 	}
 
@@ -171,7 +173,7 @@ Conversation:
 			result.WriteString(event.Content)
 		}
 		if event.Type == "error" {
-			logger.Default().Warn("compress conversation error", zap.String("error", event.Error))
+			logger.Ctx(ctx).Warn("compress conversation error", zap.String("error", event.Error))
 			return "[Previous conversation context was compressed]\n\n" + truncateRunes(conversationText, 2000)
 		}
 	}

--- a/internal/ai/database_helper.go
+++ b/internal/ai/database_helper.go
@@ -102,14 +102,14 @@ func handleExecSQL(ctx context.Context, args map[string]any) (string, error) {
 		if db != nil {
 			defer func() {
 				if err := db.Close(); err != nil {
-					logger.Default().Warn("close database connection", zap.Error(err))
+					logger.Ctx(ctx).Warn("close database connection", zap.Error(err))
 				}
 			}()
 		}
 		if closer != nil {
 			defer func() {
 				if err := closer.Close(); err != nil {
-					logger.Default().Warn("close database tunnel", zap.Error(err))
+					logger.Ctx(ctx).Warn("close database tunnel", zap.Error(err))
 				}
 			}()
 		}
@@ -142,7 +142,7 @@ func ExecuteSQL(ctx context.Context, db *sql.DB, sqlText string) (string, error)
 		}
 		defer func() {
 			if err := rows.Close(); err != nil {
-				logger.Default().Warn("close SQL rows", zap.Error(err))
+				logger.Ctx(ctx).Warn("close SQL rows", zap.Error(err))
 			}
 		}()
 		return formatRowsJSON(rows)
@@ -154,7 +154,7 @@ func ExecuteSQL(ctx context.Context, db *sql.DB, sqlText string) (string, error)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
-		logger.Default().Warn("get rows affected", zap.Error(err))
+		logger.Ctx(ctx).Warn("get rows affected", zap.Error(err))
 	}
 	return fmt.Sprintf(`{"affected_rows":%d}`, affected), nil
 }
@@ -196,7 +196,7 @@ func ExecuteSQLPaged(ctx context.Context, db *sql.DB, sqlText string, page, page
 	}
 	defer func() {
 		if err := rows.Close(); err != nil {
-			logger.Default().Warn("close SQL rows", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SQL rows", zap.Error(err))
 		}
 	}()
 

--- a/internal/ai/mongodb_helper.go
+++ b/internal/ai/mongodb_helper.go
@@ -79,14 +79,14 @@ func handleExecMongo(ctx context.Context, args map[string]any) (string, error) {
 		if client != nil {
 			defer func() {
 				if err := client.Disconnect(context.Background()); err != nil {
-					logger.Default().Warn("close MongoDB connection", zap.Error(err))
+					logger.Ctx(ctx).Warn("close MongoDB connection", zap.Error(err))
 				}
 			}()
 		}
 		if closer != nil {
 			defer func() {
 				if err := closer.Close(); err != nil {
-					logger.Default().Warn("close MongoDB tunnel", zap.Error(err))
+					logger.Ctx(ctx).Warn("close MongoDB tunnel", zap.Error(err))
 				}
 			}()
 		}
@@ -248,7 +248,7 @@ func mongoFind(ctx context.Context, client *mongo.Client, database, collection s
 	}
 	defer func() {
 		if err := cursor.Close(ctx); err != nil {
-			logger.Default().Warn("close MongoDB cursor", zap.Error(err))
+			logger.Ctx(ctx).Warn("close MongoDB cursor", zap.Error(err))
 		}
 	}()
 
@@ -502,7 +502,7 @@ func mongoAggregate(ctx context.Context, client *mongo.Client, database, collect
 	}
 	defer func() {
 		if err := cursor.Close(ctx); err != nil {
-			logger.Default().Warn("close MongoDB cursor", zap.Error(err))
+			logger.Ctx(ctx).Warn("close MongoDB cursor", zap.Error(err))
 		}
 	}()
 

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -85,6 +85,14 @@ type openAIStreamChunk struct {
 	} `json:"choices"`
 	// include_usage 时 API 在最后一个 chunk 返回 usage（choices 为空数组）
 	Usage *openAIUsage `json:"usage,omitempty"`
+	// 部分 OpenAI 兼容 provider 在流中以 {"error": {...}} 形式回报错误
+	Error *openAIStreamError `json:"error,omitempty"`
+}
+
+type openAIStreamError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code"`
 }
 
 type openAIUsage struct {
@@ -161,15 +169,22 @@ func (p *OpenAIProvider) Chat(ctx context.Context, messages []Message, tools []T
 	if resp.StatusCode != http.StatusOK {
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				logger.Default().Warn("close HTTP response body", zap.Error(err))
+				logger.Ctx(ctx).Warn("close HTTP response body", zap.Error(err))
 			}
 		}()
 		errBody, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
-			logger.Default().Warn("read error response body", zap.Error(readErr))
+			logger.Ctx(ctx).Warn("read error response body", zap.Error(readErr))
+		}
+		errMsg := strings.TrimSpace(string(errBody))
+		if errMsg == "" {
+			errMsg = http.StatusText(resp.StatusCode)
+			if errMsg == "" {
+				errMsg = "(empty response body)"
+			}
 		}
 		return nil, &ProviderError{
-			Err:        fmt.Errorf("API error %d: %s", resp.StatusCode, string(errBody)),
+			Err:        fmt.Errorf("API error %d: %s", resp.StatusCode, errMsg),
 			RetryAfter: resp.Header.Get("Retry-After"),
 			StatusCode: resp.StatusCode,
 		}
@@ -184,7 +199,7 @@ func (p *OpenAIProvider) readStream(ctx context.Context, body io.ReadCloser, ch 
 	defer close(ch)
 	defer func() {
 		if err := body.Close(); err != nil {
-			logger.Default().Warn("close SSE stream body", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSE stream body", zap.Error(err))
 		}
 	}()
 
@@ -192,6 +207,10 @@ func (p *OpenAIProvider) readStream(ctx context.Context, body io.ReadCloser, ch 
 	thinkingActive := false
 	// include_usage=true 时最后一个 chunk 的 choices 为空，usage 字段带最终统计
 	var finalUsage *openAIUsage
+	sawDone := false
+	// 部分 OpenAI 兼容 provider 不发 [DONE]，但会在最后一个 content chunk 上带 finish_reason —
+	// 看到任何非空 finish_reason 也视为正常结束。
+	sawFinishReason := false
 
 	scanner := bufio.NewScanner(body)
 	for scanner.Scan() {
@@ -208,12 +227,34 @@ func (p *OpenAIProvider) readStream(ctx context.Context, body io.ReadCloser, ch 
 		}
 		data := strings.TrimPrefix(line, "data: ")
 		if data == "[DONE]" {
+			sawDone = true
 			break
 		}
 
 		var chunk openAIStreamChunk
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			// 把无法解析的行记下来，方便排查 provider 直接吐了非 JSON 错误的情况
+			logger.Ctx(ctx).Warn("openai SSE chunk unmarshal failed",
+				zap.String("model", p.model),
+				zap.String("raw", data),
+				zap.Error(err))
 			continue
+		}
+
+		// 流中错误（OpenAI 兼容 provider 常见做法）—— 直接上报并终止
+		if chunk.Error != nil {
+			msg := strings.TrimSpace(chunk.Error.Message)
+			if msg == "" {
+				msg = "(empty error message)"
+			}
+			logger.Ctx(ctx).Warn("openai stream error chunk",
+				zap.String("model", p.model),
+				zap.String("type", chunk.Error.Type),
+				zap.String("code", chunk.Error.Code),
+				zap.String("message", chunk.Error.Message),
+				zap.String("raw", data))
+			ch <- StreamEvent{Type: "error", Error: msg}
+			return
 		}
 
 		// 最后一个 usage-only chunk：choices 为空，usage 为最终值
@@ -260,6 +301,10 @@ func (p *OpenAIProvider) readStream(ctx context.Context, body io.ReadCloser, ch 
 			existing.Function.Arguments += tc.Function.Arguments
 		}
 
+		if chunk.Choices[0].FinishReason != nil && *chunk.Choices[0].FinishReason != "" {
+			sawFinishReason = true
+		}
+
 		// 完成时发送累积的 tool calls
 		if chunk.Choices[0].FinishReason != nil && *chunk.Choices[0].FinishReason == "tool_calls" {
 			if thinkingActive {
@@ -281,6 +326,46 @@ func (p *OpenAIProvider) readStream(ctx context.Context, body io.ReadCloser, ch 
 	// 流结束时如果仍在思考，发 thinking_done
 	if thinkingActive {
 		ch <- StreamEvent{Type: "thinking_done"}
+	}
+
+	// scanner 出错（连接中断、读取失败等），按 error 上报；不要伪装成 done。
+	if err := scanner.Err(); err != nil {
+		logger.Ctx(ctx).Warn("openai SSE stream scanner error",
+			zap.String("model", p.model),
+			zap.Bool("saw_done", sawDone),
+			zap.Bool("saw_finish_reason", sawFinishReason),
+			zap.Error(err))
+		if finalUsage != nil {
+			cached := finalUsage.PromptTokensDetails.CachedTokens
+			input := max(finalUsage.PromptTokens-cached, 0)
+			ch <- StreamEvent{Type: "usage", Usage: &Usage{
+				InputTokens:     input,
+				OutputTokens:    finalUsage.CompletionTokens,
+				CacheReadTokens: cached,
+			}}
+		}
+		ch <- StreamEvent{Type: "error", Error: fmt.Sprintf("stream interrupted: %v", err)}
+		return
+	}
+
+	// 流自然结束但没收到 [DONE]：宽松判定 —— 只要看到过 finish_reason，就当正常结束
+	// （部分 OpenAI 兼容 provider 不发 [DONE]）。否则视为异常并把上下文写日志。
+	if !sawDone && !sawFinishReason {
+		logger.Ctx(ctx).Warn("openai stream ended without [DONE] or finish_reason",
+			zap.String("model", p.model),
+			zap.Bool("had_usage", finalUsage != nil),
+			zap.Int("pending_tool_calls", len(toolCallMap)))
+		if finalUsage != nil {
+			cached := finalUsage.PromptTokensDetails.CachedTokens
+			input := max(finalUsage.PromptTokens-cached, 0)
+			ch <- StreamEvent{Type: "usage", Usage: &Usage{
+				InputTokens:     input,
+				OutputTokens:    finalUsage.CompletionTokens,
+				CacheReadTokens: cached,
+			}}
+		}
+		ch <- StreamEvent{Type: "error", Error: "stream ended unexpectedly without [DONE] or finish_reason"}
+		return
 	}
 
 	// 如果 scanner 结束时还有未发送的 tool calls

--- a/internal/ai/permission.go
+++ b/internal/ai/permission.go
@@ -57,7 +57,7 @@ func checkSSHPermission(ctx context.Context, assetID int64, command string) Chec
 
 	asset, err := asset_svc.Asset().Get(ctx, assetID)
 	if err != nil {
-		logger.Default().Warn("get asset for permission check", zap.Int64("assetID", assetID), zap.Error(err))
+		logger.Ctx(ctx).Warn("get asset for permission check", zap.Int64("assetID", assetID), zap.Error(err))
 	}
 	var groups []*group_entity.Group
 	if asset != nil && asset.GroupID > 0 {
@@ -382,7 +382,7 @@ func SaveGrantPattern(ctx context.Context, sessionID string, assetID int64, asse
 		}
 		if createErr := repo.CreateSession(ctx, session); createErr != nil {
 			// 可能并发创建，忽略重复错误
-			logger.Default().Debug("create grant session (may already exist)", zap.String("sessionID", sessionID), zap.Error(createErr))
+			logger.Ctx(ctx).Debug("create grant session (may already exist)", zap.String("sessionID", sessionID), zap.Error(createErr))
 		}
 	}
 
@@ -395,6 +395,6 @@ func SaveGrantPattern(ctx context.Context, sessionID string, assetID int64, asse
 		Createtime:     time.Now().Unix(),
 	}
 	if err := repo.CreateItems(ctx, []*grant_entity.GrantItem{item}); err != nil {
-		logger.Default().Error("save grant pattern", zap.Error(err))
+		logger.Ctx(ctx).Error("save grant pattern", zap.Error(err))
 	}
 }

--- a/internal/ai/policy_ext.go
+++ b/internal/ai/policy_ext.go
@@ -39,7 +39,7 @@ func checkExtensionPolicy(ctx context.Context, groupIDs []string, action, resour
 	for _, pg := range groups {
 		var rule ExtensionPolicyRule
 		if err := json.Unmarshal([]byte(pg.Policy), &rule); err != nil {
-			logger.Default().Warn("unmarshal extension policy group",
+			logger.Ctx(ctx).Warn("unmarshal extension policy group",
 				zap.String("id", pg.BuiltinID), zap.Error(err))
 			continue
 		}

--- a/internal/ai/policy_group_resolve.go
+++ b/internal/ai/policy_group_resolve.go
@@ -24,7 +24,7 @@ func resolveCommandGroups(ctx context.Context, groupIDs []string) (allow, deny [
 		}
 		var p policy.CommandPolicy
 		if err := json.Unmarshal([]byte(pg.Policy), &p); err != nil {
-			logger.Default().Warn("unmarshal policy group command policy", zap.String("id", pg.BuiltinID), zap.Error(err))
+			logger.Ctx(ctx).Warn("unmarshal policy group command policy", zap.String("id", pg.BuiltinID), zap.Error(err))
 			continue
 		}
 		allow = append(allow, p.AllowList...)
@@ -44,7 +44,7 @@ func resolveQueryGroups(ctx context.Context, groupIDs []string) (allowTypes, den
 		}
 		var p policy.QueryPolicy
 		if err := json.Unmarshal([]byte(pg.Policy), &p); err != nil {
-			logger.Default().Warn("unmarshal policy group query policy", zap.String("id", pg.BuiltinID), zap.Error(err))
+			logger.Ctx(ctx).Warn("unmarshal policy group query policy", zap.String("id", pg.BuiltinID), zap.Error(err))
 			continue
 		}
 		allowTypes = append(allowTypes, p.AllowTypes...)
@@ -65,7 +65,7 @@ func resolveRedisGroups(ctx context.Context, groupIDs []string) (allow, deny []s
 		}
 		var p policy.RedisPolicy
 		if err := json.Unmarshal([]byte(pg.Policy), &p); err != nil {
-			logger.Default().Warn("unmarshal policy group redis policy", zap.String("id", pg.BuiltinID), zap.Error(err))
+			logger.Ctx(ctx).Warn("unmarshal policy group redis policy", zap.String("id", pg.BuiltinID), zap.Error(err))
 			continue
 		}
 		allow = append(allow, p.AllowList...)
@@ -85,7 +85,7 @@ func resolveMongoGroups(ctx context.Context, groupIDs []string) (allowTypes, den
 		}
 		var p policy.MongoPolicy
 		if err := json.Unmarshal([]byte(pg.Policy), &p); err != nil {
-			logger.Default().Warn("unmarshal policy group mongo policy", zap.String("id", pg.BuiltinID), zap.Error(err))
+			logger.Ctx(ctx).Warn("unmarshal policy group mongo policy", zap.String("id", pg.BuiltinID), zap.Error(err))
 			continue
 		}
 		allowTypes = append(allowTypes, p.AllowTypes...)
@@ -105,7 +105,7 @@ func resolveKafkaGroups(ctx context.Context, groupIDs []string) (allow, deny []s
 		}
 		var p policy.KafkaPolicy
 		if err := json.Unmarshal([]byte(pg.Policy), &p); err != nil {
-			logger.Default().Warn("unmarshal policy group kafka policy", zap.String("id", pg.BuiltinID), zap.Error(err))
+			logger.Ctx(ctx).Warn("unmarshal policy group kafka policy", zap.String("id", pg.BuiltinID), zap.Error(err))
 			continue
 		}
 		allow = append(allow, p.AllowList...)
@@ -140,7 +140,7 @@ func fetchPolicyGroups(ctx context.Context, ids []string) []*policy_group_entity
 		if repo != nil {
 			pgs, err := repo.ListByIDs(ctx, dbIDs)
 			if err != nil {
-				logger.Default().Warn("fetch policy groups from DB", zap.Error(err))
+				logger.Ctx(ctx).Warn("fetch policy groups from DB", zap.Error(err))
 			} else {
 				result = append(result, pgs...)
 			}

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -14,12 +14,17 @@ const (
 
 // Message 对话消息
 type Message struct {
-	Role             Role       `json:"role"`
-	Content          string     `json:"content"`
-	Thinking         string     `json:"thinking,omitempty"`          // Anthropic 格式
-	ReasoningContent string     `json:"reasoning_content,omitempty"` // DeepSeek/OpenAI 格式
-	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
-	ToolCallID       string     `json:"tool_call_id,omitempty"` // role=tool 时标识调用
+	Role    Role   `json:"role"`
+	Content string `json:"content"`
+	// Thinking Anthropic / DeepSeek 思考内容文本。
+	Thinking string `json:"thinking,omitempty"`
+	// ThinkingSignature Anthropic adaptive thinking 块的签名。
+	// 真 Anthropic 在 reasoning + tool_use 多轮会话中必须把上一轮的 thinking 块原样回传
+	// （含 signature），否则 400。DeepSeek-v4 的 Anthropic 兼容端不下发签名，留空即可。
+	ThinkingSignature string     `json:"thinking_signature,omitempty"`
+	ReasoningContent  string     `json:"reasoning_content,omitempty"` // DeepSeek/OpenAI 格式
+	ToolCalls         []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID        string     `json:"tool_call_id,omitempty"` // role=tool 时标识调用
 }
 
 // ToolCall AI 发起的工具调用
@@ -57,16 +62,17 @@ type Usage struct {
 
 // StreamEvent 流式响应事件
 type StreamEvent struct {
-	Type       string     `json:"type"`                   // "content" | "tool_start" | "tool_result" | "tool_call" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage"
-	Content    string     `json:"content,omitempty"`      // type=content/tool_result/approval_result/agent_end 时的文本
-	ToolName   string     `json:"tool_name,omitempty"`    // type=tool_start/tool_result 时的工具名
-	ToolInput  string     `json:"tool_input,omitempty"`   // type=tool_start 时的输入摘要
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // type=tool_call 时的工具调用 (OpenAI)
-	ToolCallID string     `json:"tool_call_id,omitempty"` // type=tool_start/tool_result 时的工具调用 ID，前端用于跨 turn 还原 tool_calls 历史
-	ConfirmID  string     `json:"confirm_id,omitempty"`   // type=approval_request/approval_result 时的确认请求 ID
-	Error      string     `json:"error,omitempty"`        // type=error 时的错误信息
-	AgentRole  string     `json:"agent_role,omitempty"`   // type=agent_start/approval_request 时的角色描述
-	AgentTask  string     `json:"agent_task,omitempty"`   // type=agent_start 时的任务描述
+	Type              string     `json:"type"`                         // "content" | "tool_start" | "tool_result" | "tool_call" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage"
+	Content           string     `json:"content,omitempty"`            // type=content/tool_result/approval_result/agent_end 时的文本
+	ThinkingSignature string     `json:"thinking_signature,omitempty"` // type=thinking_done 时下发的 Anthropic 思考块签名（DeepSeek 等不下发）
+	ToolName          string     `json:"tool_name,omitempty"`          // type=tool_start/tool_result 时的工具名
+	ToolInput         string     `json:"tool_input,omitempty"`         // type=tool_start 时的输入摘要
+	ToolCalls         []ToolCall `json:"tool_calls,omitempty"`         // type=tool_call 时的工具调用 (OpenAI)
+	ToolCallID        string     `json:"tool_call_id,omitempty"`       // type=tool_start/tool_result 时的工具调用 ID，前端用于跨 turn 还原 tool_calls 历史
+	ConfirmID         string     `json:"confirm_id,omitempty"`         // type=approval_request/approval_result 时的确认请求 ID
+	Error             string     `json:"error,omitempty"`              // type=error 时的错误信息
+	AgentRole         string     `json:"agent_role,omitempty"`         // type=agent_start/approval_request 时的角色描述
+	AgentTask         string     `json:"agent_task,omitempty"`         // type=agent_start 时的任务描述
 	// approval_request 专用字段
 	Kind        string         `json:"kind,omitempty"`        // "single" | "batch" | "grant"
 	Items       []ApprovalItem `json:"items,omitempty"`       // 审批项列表

--- a/internal/ai/redis_helper.go
+++ b/internal/ai/redis_helper.go
@@ -85,14 +85,14 @@ func handleExecRedis(ctx context.Context, args map[string]any) (string, error) {
 		if client != nil {
 			defer func() {
 				if err := client.Close(); err != nil {
-					logger.Default().Warn("close Redis connection", zap.Error(err))
+					logger.Ctx(ctx).Warn("close Redis connection", zap.Error(err))
 				}
 			}()
 		}
 		if closer != nil {
 			defer func() {
 				if err := closer.Close(); err != nil {
-					logger.Default().Warn("close Redis tunnel", zap.Error(err))
+					logger.Ctx(ctx).Warn("close Redis tunnel", zap.Error(err))
 				}
 			}()
 		}

--- a/internal/ai/ssh_helper.go
+++ b/internal/ai/ssh_helper.go
@@ -58,7 +58,7 @@ func dialAssetSSH(ctx context.Context, assetID int64) (*ssh.Client, func(), erro
 	}
 	cleanup := func() {
 		if err := client.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close SSH client", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSH client", zap.Error(err))
 		}
 		closeExtras(extraClosers)
 	}
@@ -111,7 +111,7 @@ func runSSHCommand(ctx context.Context, client *ssh.Client, command string) (str
 	defer func() {
 		// ctx 取消路径下 session 已经被主动关闭，defer 再次 Close 会拿到已关闭错误，静默跳过。
 		if err := session.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close SSH session", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSH session", zap.Error(err))
 		}
 	}()
 
@@ -136,10 +136,10 @@ func runSSHCommand(ctx context.Context, client *ssh.Client, command string) (str
 		// 仅关闭 session 可能不足以唤醒底层 Run/Wait，这里连 client 一并关闭来打断阻塞。
 		// 上层 defer 会再次 Close，已通过 isExpectedCloseErr 过滤预期错误。
 		if err := session.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close SSH session on cancel", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSH session on cancel", zap.Error(err))
 		}
 		if err := client.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close SSH client on cancel", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSH client on cancel", zap.Error(err))
 		}
 		return "", ctx.Err()
 	}
@@ -167,7 +167,7 @@ func executeWithSFTP(ctx context.Context, assetID int64, fn func(*sftp.Client) e
 	}
 	defer func() {
 		if err := sftpClient.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close SFTP client", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SFTP client", zap.Error(err))
 		}
 	}()
 
@@ -205,7 +205,7 @@ func ExecWithStdio(ctx context.Context, assetID int64, command string, stdin io.
 	}
 	defer func() {
 		if err := session.Close(); err != nil {
-			logger.Default().Warn("close ExecWithStdio SSH session", zap.Error(err))
+			logger.Ctx(ctx).Warn("close ExecWithStdio SSH session", zap.Error(err))
 		}
 	}()
 
@@ -238,7 +238,7 @@ func CopyBetweenAssets(ctx context.Context, srcAssetID int64, srcPath string, ds
 	}
 	defer func() {
 		if err := srcSFTP.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close source SFTP client", zap.Error(err))
+			logger.Ctx(ctx).Warn("close source SFTP client", zap.Error(err))
 		}
 	}()
 
@@ -248,7 +248,7 @@ func CopyBetweenAssets(ctx context.Context, srcAssetID int64, srcPath string, ds
 	}
 	defer func() {
 		if err := dstSFTP.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close destination SFTP client", zap.Error(err))
+			logger.Ctx(ctx).Warn("close destination SFTP client", zap.Error(err))
 		}
 	}()
 
@@ -263,7 +263,7 @@ func CopyBetweenAssets(ctx context.Context, srcAssetID int64, srcPath string, ds
 	}
 	defer func() {
 		if err := srcFile.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close source file", zap.String("path", srcPath), zap.Error(err))
+			logger.Ctx(ctx).Warn("close source file", zap.String("path", srcPath), zap.Error(err))
 		}
 	}()
 
@@ -273,7 +273,7 @@ func CopyBetweenAssets(ctx context.Context, srcAssetID int64, srcPath string, ds
 	}
 	defer func() {
 		if err := dstFile.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close destination file", zap.String("path", dstPath), zap.Error(err))
+			logger.Ctx(ctx).Warn("close destination file", zap.String("path", dstPath), zap.Error(err))
 		}
 	}()
 

--- a/internal/ai/tool_handler_agent.go
+++ b/internal/ai/tool_handler_agent.go
@@ -55,7 +55,7 @@ func handleSpawnAgent(ctx context.Context, args map[string]any) (string, error) 
 	if toolsRaw, ok := args["tools"]; ok {
 		if toolsJSON, err := json.Marshal(toolsRaw); err == nil {
 			if err := json.Unmarshal(toolsJSON, &toolNames); err != nil {
-				logger.Default().Warn("parse spawn_agent tools param", zap.Error(err))
+				logger.Ctx(ctx).Warn("parse spawn_agent tools param", zap.Error(err))
 			}
 		}
 	}
@@ -132,7 +132,7 @@ func handleSpawnAgent(ctx context.Context, args map[string]any) (string, error) 
 	})
 
 	if err != nil {
-		logger.Default().Warn("sub-agent execution failed", zap.Error(err))
+		logger.Ctx(ctx).Warn("sub-agent execution failed", zap.Error(err))
 		return fmt.Sprintf("Sub-agent failed: %s\n\nPartial result:\n%s", err.Error(), summary), nil
 	}
 

--- a/internal/ai/tool_handler_k8s.go
+++ b/internal/ai/tool_handler_k8s.go
@@ -341,7 +341,7 @@ func runSSHCommandWithStdin(ctx context.Context, client *ssh.Client, command str
 	}
 	defer func() {
 		if err := session.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close SSH session", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSH session", zap.Error(err))
 		}
 	}()
 
@@ -368,10 +368,10 @@ func runSSHCommandWithStdin(ctx context.Context, client *ssh.Client, command str
 		}
 	case <-ctx.Done():
 		if err := session.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close SSH session on cancel", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSH session on cancel", zap.Error(err))
 		}
 		if err := client.Close(); err != nil && !isExpectedCloseErr(err) {
-			logger.Default().Warn("close SSH client on cancel", zap.Error(err))
+			logger.Ctx(ctx).Warn("close SSH client on cancel", zap.Error(err))
 		}
 		return "", ctx.Err()
 	}

--- a/internal/ai/tool_handlers_asset.go
+++ b/internal/ai/tool_handlers_asset.go
@@ -125,7 +125,7 @@ func handleListAssets(ctx context.Context, args map[string]any) (string, error) 
 	}
 	data, err := json.Marshal(views)
 	if err != nil {
-		logger.Default().Error("marshal asset list", zap.Error(err))
+		logger.Ctx(ctx).Error("marshal asset list", zap.Error(err))
 		return "", fmt.Errorf("failed to marshal asset list: %w", err)
 	}
 	return string(data), nil
@@ -142,7 +142,7 @@ func handleGetAsset(ctx context.Context, args map[string]any) (string, error) {
 	}
 	data, err := json.Marshal(toSafeView(asset))
 	if err != nil {
-		logger.Default().Error("marshal asset detail", zap.Error(err))
+		logger.Ctx(ctx).Error("marshal asset detail", zap.Error(err))
 		return "", fmt.Errorf("failed to marshal asset detail: %w", err)
 	}
 	return string(data), nil
@@ -245,7 +245,7 @@ func handleListGroups(ctx context.Context, _ map[string]any) (string, error) {
 	}
 	data, err := json.Marshal(views)
 	if err != nil {
-		logger.Default().Error("marshal group list", zap.Error(err))
+		logger.Ctx(ctx).Error("marshal group list", zap.Error(err))
 		return "", fmt.Errorf("failed to marshal group list: %w", err)
 	}
 	return string(data), nil
@@ -272,7 +272,7 @@ func handleGetGroup(ctx context.Context, args map[string]any) (string, error) {
 	}
 	data, err := json.Marshal(view)
 	if err != nil {
-		logger.Default().Error("marshal group detail", zap.Error(err))
+		logger.Ctx(ctx).Error("marshal group detail", zap.Error(err))
 		return "", fmt.Errorf("failed to marshal group detail: %w", err)
 	}
 	return string(data), nil

--- a/internal/ai/tool_handlers_exec.go
+++ b/internal/ai/tool_handlers_exec.go
@@ -145,7 +145,7 @@ func handleUploadFile(ctx context.Context, args map[string]any) (string, error) 
 		}
 		defer func() {
 			if err := srcFile.Close(); err != nil && !isExpectedCloseErr(err) {
-				logger.Default().Warn("close local file", zap.String("path", localPath), zap.Error(err))
+				logger.Ctx(ctx).Warn("close local file", zap.String("path", localPath), zap.Error(err))
 			}
 		}()
 
@@ -155,7 +155,7 @@ func handleUploadFile(ctx context.Context, args map[string]any) (string, error) 
 		}
 		defer func() {
 			if err := dstFile.Close(); err != nil && !isExpectedCloseErr(err) {
-				logger.Default().Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
+				logger.Ctx(ctx).Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
 			}
 		}()
 
@@ -183,7 +183,7 @@ func handleDownloadFile(ctx context.Context, args map[string]any) (string, error
 		}
 		defer func() {
 			if err := srcFile.Close(); err != nil && !isExpectedCloseErr(err) {
-				logger.Default().Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
+				logger.Ctx(ctx).Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
 			}
 		}()
 
@@ -193,7 +193,7 @@ func handleDownloadFile(ctx context.Context, args map[string]any) (string, error
 		}
 		defer func() {
 			if err := dstFile.Close(); err != nil && !isExpectedCloseErr(err) {
-				logger.Default().Warn("close local file", zap.String("path", localPath), zap.Error(err))
+				logger.Ctx(ctx).Warn("close local file", zap.String("path", localPath), zap.Error(err))
 			}
 		}()
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -264,7 +264,7 @@ func (d *appPoolDialer) DialAsset(ctx context.Context, assetID int64) (*ssh.Clie
 func (a *App) resolveSSHCredentialsFull(sshCfg *asset_entity.SSHConfig) (password, key, passphrase string) {
 	p, k, pp, err := credential_resolver.Default().ResolveSSHCredentials(a.langCtx(), sshCfg)
 	if err != nil {
-		logger.Default().Warn("resolve SSH credentials", zap.Error(err))
+		logger.Ctx(a.ctx).Warn("resolve SSH credentials", zap.Error(err))
 	}
 	return p, k, pp
 }

--- a/internal/app/app_ai.go
+++ b/internal/app/app_ai.go
@@ -114,7 +114,7 @@ func (a *App) resetRunners() {
 	select {
 	case <-done:
 	case <-time.After(3 * time.Second):
-		logger.Default().Warn("resetRunners: 部分 runner Stop 未在 3s 内完成，放行关闭")
+		logger.Ctx(a.ctx).Warn("resetRunners: 部分 runner Stop 未在 3s 内完成，放行关闭")
 	}
 }
 
@@ -125,7 +125,7 @@ func (a *App) InitAIProvider() {
 		return // 无激活 provider，跳过
 	}
 	if err := a.activateProvider(p); err != nil {
-		logger.Default().Warn("activate AI provider on startup", zap.Error(err))
+		logger.Ctx(a.ctx).Warn("activate AI provider on startup", zap.Error(err))
 	}
 }
 
@@ -215,15 +215,15 @@ func (a *App) loadConversationDisplayMessages(ctx context.Context, id int64) ([]
 	for _, msg := range msgs {
 		blocks, err := msg.GetBlocks()
 		if err != nil {
-			logger.Default().Warn("get message blocks", zap.Error(err))
+			logger.Ctx(ctx).Warn("get message blocks", zap.Error(err))
 		}
 		mentions, err := msg.GetMentions()
 		if err != nil {
-			logger.Default().Warn("get message mentions", zap.Error(err))
+			logger.Ctx(ctx).Warn("get message mentions", zap.Error(err))
 		}
 		usage, err := msg.GetTokenUsage()
 		if err != nil {
-			logger.Default().Warn("get message token usage", zap.Error(err))
+			logger.Ctx(ctx).Warn("get message token usage", zap.Error(err))
 		}
 		displayMsgs = append(displayMsgs, ConversationDisplayMessage{
 			Role:       msg.Role,
@@ -283,7 +283,7 @@ func (a *App) SendAIMessage(convID int64, messages []ai.Message, aiCtx ai.AICont
 			if msg.Role == ai.RoleUser {
 				title := normalizeConversationTitle(string(msg.Content))
 				if err := conversation_svc.Conversation().UpdateTitle(ctx, convID, title); err != nil {
-					logger.Default().Error("update conversation title", zap.Error(err))
+					logger.Ctx(ctx).Error("update conversation title", zap.Error(err))
 				}
 				break
 			}
@@ -353,7 +353,7 @@ func (a *App) SendAIMessage(convID int64, messages []ai.Message, aiCtx ai.AICont
 		if event.Type == "done" || event.Type == "stopped" {
 			if conv, err := conversation_svc.Conversation().Get(a.ctx, convID); err == nil {
 				if err := conversation_svc.Conversation().Update(a.ctx, conv); err != nil {
-					logger.Default().Warn("update conversation time", zap.Error(err))
+					logger.Ctx(ctx).Warn("update conversation time", zap.Error(err))
 				}
 			}
 		}
@@ -417,13 +417,13 @@ func (a *App) SaveConversationMessages(convID int64, displayMsgs []ConversationD
 			Createtime:     time.Now().Unix(),
 		}
 		if err := msg.SetBlocks(dm.Blocks); err != nil {
-			logger.Default().Error("set message blocks", zap.Error(err))
+			logger.Ctx(ctx).Error("set message blocks", zap.Error(err))
 		}
 		if err := msg.SetMentions(dm.Mentions); err != nil {
-			logger.Default().Error("set message mentions", zap.Error(err))
+			logger.Ctx(ctx).Error("set message mentions", zap.Error(err))
 		}
 		if err := msg.SetTokenUsage(dm.TokenUsage); err != nil {
-			logger.Default().Error("set message token usage", zap.Error(err))
+			logger.Ctx(ctx).Error("set message token usage", zap.Error(err))
 		}
 		msgs = append(msgs, msg)
 	}

--- a/internal/app/app_approval.go
+++ b/internal/app/app_approval.go
@@ -218,12 +218,12 @@ func (a *App) handleGrantApproval(req approval.ApprovalRequest) approval.Approva
 	case resp := <-ch:
 		if resp.Decision == "deny" {
 			if err := grant_repo.Grant().UpdateSessionStatus(ctx, sessionID, grant_entity.GrantStatusRejected); err != nil {
-				logger.Default().Error("update grant session status to rejected", zap.Error(err))
+				logger.Ctx(ctx).Error("update grant session status to rejected", zap.Error(err))
 			}
 			return approval.ApprovalResponse{Approved: false, Reason: "user denied", SessionID: sessionID}
 		}
 		if err := grant_repo.Grant().UpdateSessionStatus(ctx, sessionID, grant_entity.GrantStatusApproved); err != nil {
-			logger.Default().Error("update grant session status to approved", zap.Error(err))
+			logger.Ctx(ctx).Error("update grant session status to approved", zap.Error(err))
 		}
 		// 处理用户编辑的 items
 		if len(resp.EditedItems) > 0 {
@@ -249,7 +249,7 @@ func (a *App) handleGrantApproval(req approval.ApprovalRequest) approval.Approva
 			}
 			if len(items) > 0 {
 				if err := grant_repo.Grant().UpdateItems(ctx, sessionID, items); err != nil {
-					logger.Default().Error("update grant items", zap.Error(err))
+					logger.Ctx(ctx).Error("update grant items", zap.Error(err))
 				}
 			}
 		}
@@ -270,12 +270,12 @@ func (a *App) handleGrantApproval(req approval.ApprovalRequest) approval.Approva
 		return finalResp
 	case <-a.ctx.Done():
 		if err := grant_repo.Grant().UpdateSessionStatus(ctx, sessionID, grant_entity.GrantStatusRejected); err != nil {
-			logger.Default().Error("update grant session status to rejected on shutdown", zap.Error(err))
+			logger.Ctx(ctx).Error("update grant session status to rejected on shutdown", zap.Error(err))
 		}
 		return approval.ApprovalResponse{Approved: false, Reason: "app shutting down"}
 	case <-a.shutdownCh:
 		if err := grant_repo.Grant().UpdateSessionStatus(ctx, sessionID, grant_entity.GrantStatusRejected); err != nil {
-			logger.Default().Error("update grant session status to rejected on shutdown", zap.Error(err))
+			logger.Ctx(ctx).Error("update grant session status to rejected on shutdown", zap.Error(err))
 		}
 		return approval.ApprovalResponse{Approved: false, Reason: "app shutting down"}
 	}

--- a/internal/app/app_k8s.go
+++ b/internal/app/app_k8s.go
@@ -151,7 +151,7 @@ func (a *App) StartK8sPodLogs(assetID int64, namespace, podName, container strin
 	go func() {
 		defer func() {
 			if closeErr := reader.Close(); closeErr != nil {
-				logger.Default().Warn("close k8s log reader", zap.Error(closeErr))
+				logger.Ctx(ctx).Warn("close k8s log reader", zap.Error(closeErr))
 			}
 		}()
 		defer cancel()

--- a/internal/app/app_query.go
+++ b/internal/app/app_query.go
@@ -45,11 +45,11 @@ func (a *App) TestDatabaseConnection(configJSON string, plainPassword string) er
 	}
 	defer func() {
 		if err := db.Close(); err != nil {
-			logger.Default().Warn("close db failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("close db failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -84,11 +84,11 @@ func (a *App) TestRedisConnection(configJSON string, plainPassword string) error
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			logger.Default().Warn("close redis client failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("close redis client failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -125,11 +125,11 @@ func (a *App) ExecuteSQL(assetID int64, sqlText string, database string) (string
 	}
 	defer func() {
 		if err := db.Close(); err != nil {
-			logger.Default().Warn("close db failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("close db failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -171,11 +171,11 @@ func (a *App) ExecuteTableImport(
 	}
 	defer func() {
 		if err := db.Close(); err != nil {
-			logger.Default().Warn("close db failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("close db failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -186,7 +186,7 @@ func (a *App) ExecuteTableImport(
 	}
 	defer func() {
 		if err := conn.Close(); err != nil {
-			logger.Default().Warn("close db session failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("close db session failed", zap.Error(err))
 		}
 	}()
 
@@ -223,11 +223,11 @@ func (a *App) ExecuteSQLPaged(assetID int64, sqlText string, database string, pa
 	}
 	defer func() {
 		if err := db.Close(); err != nil {
-			logger.Default().Warn("close db failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("close db failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -263,11 +263,11 @@ func (a *App) ExecuteRedis(assetID int64, command string, db int) (string, error
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			logger.Default().Warn("close redis client failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("close redis client failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -303,11 +303,11 @@ func (a *App) TestMongoDBConnection(configJSON string, plainPassword string) err
 	}
 	defer func() {
 		if err := client.Disconnect(context.Background()); err != nil {
-			logger.Default().Warn("disconnect mongodb client failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("disconnect mongodb client failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -341,11 +341,11 @@ func (a *App) ExecuteMongo(assetID int64, operation, database, collection, query
 	}
 	defer func() {
 		if err := client.Disconnect(context.Background()); err != nil {
-			logger.Default().Warn("disconnect mongodb client failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("disconnect mongodb client failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -380,11 +380,11 @@ func (a *App) ListMongoDatabases(assetID int64) (string, error) {
 	}
 	defer func() {
 		if err := client.Disconnect(context.Background()); err != nil {
-			logger.Default().Warn("disconnect mongodb client failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("disconnect mongodb client failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -427,11 +427,11 @@ func (a *App) ListMongoCollections(assetID int64, database string) (string, erro
 	}
 	defer func() {
 		if err := client.Disconnect(context.Background()); err != nil {
-			logger.Default().Warn("disconnect mongodb client failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("disconnect mongodb client failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()
@@ -475,11 +475,11 @@ func (a *App) ExecuteRedisArgs(assetID int64, args []string, db int) (string, er
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			logger.Default().Warn("close redis client failed", zap.Error(err))
+			logger.Ctx(ctx).Warn("close redis client failed", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close tunnel failed", zap.Error(err))
+				logger.Ctx(ctx).Warn("close tunnel failed", zap.Error(err))
 			}
 		}
 	}()

--- a/internal/app/app_settings.go
+++ b/internal/app/app_settings.go
@@ -947,7 +947,7 @@ func (a *App) registerPlugin(home string) error {
 	cfg := pluginsConfig{Version: 2, Plugins: make(map[string][]pluginEntry)}
 	if data, err := os.ReadFile(pluginsFile); err == nil { //nolint:gosec // path from app data dir
 		if err := json.Unmarshal(data, &cfg); err != nil {
-			logger.Default().Warn("parse installed_plugins.json failed, will overwrite", zap.Error(err))
+			logger.Ctx(a.ctx).Warn("parse installed_plugins.json failed, will overwrite", zap.Error(err))
 			cfg = pluginsConfig{Version: 2, Plugins: make(map[string][]pluginEntry)}
 		}
 	}
@@ -1117,7 +1117,7 @@ func (a *App) InstallSkills() error {
 
 	// 在应用数据目录写一份各工具的插件结构，方便用户手动拷贝
 	if err := a.writePluginReference(); err != nil {
-		logger.Default().Warn("write plugin reference failed", zap.Error(err))
+		logger.Ctx(a.ctx).Warn("write plugin reference failed", zap.Error(err))
 	}
 
 	return nil
@@ -1239,13 +1239,13 @@ func (a *App) startAutoUpdateCheck() {
 
 		info, err := update_svc.CheckForUpdate(a.GetUpdateChannel(), a.GetDownloadMirror())
 		if err != nil {
-			logger.Default().Warn("auto check update failed", zap.Error(err))
+			logger.Ctx(a.ctx).Warn("auto check update failed", zap.Error(err))
 			return
 		}
 
 		cfg.LastUpdateCheck = now
 		if err := bootstrap.SaveConfig(cfg); err != nil {
-			logger.Default().Warn("save last update check time", zap.Error(err))
+			logger.Ctx(a.ctx).Warn("save last update check time", zap.Error(err))
 		}
 
 		if info.HasUpdate {

--- a/internal/app/app_sftp.go
+++ b/internal/app/app_sftp.go
@@ -296,7 +296,7 @@ func (a *App) ListLocalSSHKeys() ([]LocalSSHKeyInfo, error) {
 func (a *App) SelectSSHKeyFile() (*LocalSSHKeyInfo, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		logger.Default().Warn("get user home dir", zap.Error(err))
+		logger.Ctx(a.ctx).Warn("get user home dir", zap.Error(err))
 	}
 	defaultDir := filepath.Join(homeDir, ".ssh")
 

--- a/internal/app/forward_manager.go
+++ b/internal/app/forward_manager.go
@@ -114,7 +114,7 @@ func (m *ForwardManager) StartConfig(ctx context.Context, configID int64) error 
 		if startErr != nil {
 			rf.errMsg = startErr.Error()
 			cancel()
-			logger.Default().Error("rule failed", zap.Int64("ruleID", rule.ID), zap.Error(startErr))
+			logger.Ctx(ctx).Error("rule failed", zap.Int64("ruleID", rule.ID), zap.Error(startErr))
 		}
 		m.running[rule.ID] = rf
 		atomic.AddInt32(&fc.refs, 1)
@@ -274,7 +274,7 @@ func startLocalForward(ctx context.Context, client *ssh.Client, rule *forward_en
 	go func() {
 		<-ctx.Done()
 		if err := listener.Close(); err != nil {
-			logger.Default().Warn("close listener", zap.Error(err))
+			logger.Ctx(ctx).Warn("close listener", zap.Error(err))
 		}
 	}()
 
@@ -289,7 +289,7 @@ func startLocalForward(ctx context.Context, client *ssh.Client, rule *forward_en
 				rconn, err := client.Dial("tcp", remote)
 				if err != nil {
 					if closeErr := conn.Close(); closeErr != nil {
-						logger.Default().Warn("close conn", zap.Error(closeErr))
+						logger.Ctx(ctx).Warn("close conn", zap.Error(closeErr))
 					}
 					return
 				}
@@ -311,7 +311,7 @@ func startRemoteForward(ctx context.Context, client *ssh.Client, rule *forward_e
 	go func() {
 		<-ctx.Done()
 		if err := listener.Close(); err != nil {
-			logger.Default().Warn("close listener", zap.Error(err))
+			logger.Ctx(ctx).Warn("close listener", zap.Error(err))
 		}
 	}()
 
@@ -326,7 +326,7 @@ func startRemoteForward(ctx context.Context, client *ssh.Client, rule *forward_e
 				lconn, err := net.Dial("tcp", local)
 				if err != nil {
 					if closeErr := conn.Close(); closeErr != nil {
-						logger.Default().Warn("close conn", zap.Error(closeErr))
+						logger.Ctx(ctx).Warn("close conn", zap.Error(closeErr))
 					}
 					return
 				}
@@ -349,7 +349,7 @@ func startDynamicForward(ctx context.Context, client *ssh.Client, rule *forward_
 	go func() {
 		<-ctx.Done()
 		if err := listener.Close(); err != nil {
-			logger.Default().Warn("close listener", zap.Error(err))
+			logger.Ctx(ctx).Warn("close listener", zap.Error(err))
 		}
 	}()
 
@@ -533,7 +533,7 @@ func (a *App) UpdateForwardConfig(id int64, name string, assetID int64, rules []
 
 	if wasRunning {
 		if err := a.forwardManager.StartConfig(ctx, id); err != nil {
-			logger.Default().Error("restart forward config after update", zap.Int64("id", id), zap.Error(err))
+			logger.Ctx(ctx).Error("restart forward config after update", zap.Int64("id", id), zap.Error(err))
 		}
 	}
 
@@ -562,7 +562,7 @@ func (a *App) ListForwardConfigs() ([]ForwardConfigWithStatus, error) {
 	for _, c := range configs {
 		rules, err := forward_repo.Forward().ListRulesByConfigID(ctx, c.ID)
 		if err != nil {
-			logger.Default().Warn("list forward rules by config ID", zap.Error(err), zap.Int64("configID", c.ID))
+			logger.Ctx(ctx).Warn("list forward rules by config ID", zap.Error(err), zap.Int64("configID", c.ID))
 		}
 
 		// 获取资产名

--- a/internal/connpool/database.go
+++ b/internal/connpool/database.go
@@ -38,7 +38,7 @@ func DialDatabase(ctx context.Context, asset *asset_entity.Asset, cfg *asset_ent
 	if err != nil {
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close ssh tunnel", zap.Error(err))
+				logger.Ctx(ctx).Warn("close ssh tunnel", zap.Error(err))
 			}
 		}
 		return nil, nil, err
@@ -47,11 +47,11 @@ func DialDatabase(ctx context.Context, asset *asset_entity.Asset, cfg *asset_ent
 	// 测试连接（必须在 setReadOnly 之前，确保连接性检查受 ctx 超时保护）
 	if pingErr := db.PingContext(ctx); pingErr != nil {
 		if err := db.Close(); err != nil {
-			logger.Default().Warn("close db", zap.Error(err))
+			logger.Ctx(ctx).Warn("close db", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close ssh tunnel", zap.Error(err))
+				logger.Ctx(ctx).Warn("close ssh tunnel", zap.Error(err))
 			}
 		}
 		return nil, nil, fmt.Errorf("数据库连接失败: %w", pingErr)
@@ -61,11 +61,11 @@ func DialDatabase(ctx context.Context, asset *asset_entity.Asset, cfg *asset_ent
 	if cfg.ReadOnly {
 		if roErr := setReadOnly(ctx, db, cfg.Driver); roErr != nil {
 			if err := db.Close(); err != nil {
-				logger.Default().Warn("close db", zap.Error(err))
+				logger.Ctx(ctx).Warn("close db", zap.Error(err))
 			}
 			if tunnel != nil {
 				if err := tunnel.Close(); err != nil {
-					logger.Default().Warn("close ssh tunnel", zap.Error(err))
+					logger.Ctx(ctx).Warn("close ssh tunnel", zap.Error(err))
 				}
 			}
 			return nil, nil, fmt.Errorf("设置只读模式失败: %w", roErr)

--- a/internal/connpool/mongodb.go
+++ b/internal/connpool/mongodb.go
@@ -81,7 +81,7 @@ func DialMongoDB(ctx context.Context, asset *asset_entity.Asset, cfg *asset_enti
 	if err != nil {
 		if tunnel != nil {
 			if closeErr := tunnel.Close(); closeErr != nil {
-				logger.Default().Warn("close ssh tunnel", zap.Error(closeErr))
+				logger.Ctx(ctx).Warn("close ssh tunnel", zap.Error(closeErr))
 			}
 		}
 		return nil, nil, fmt.Errorf("MongoDB 连接失败: %w", err)
@@ -89,11 +89,11 @@ func DialMongoDB(ctx context.Context, asset *asset_entity.Asset, cfg *asset_enti
 
 	if pingErr := client.Ping(ctx, nil); pingErr != nil {
 		if disconnectErr := client.Disconnect(context.Background()); disconnectErr != nil {
-			logger.Default().Warn("disconnect mongodb client", zap.Error(disconnectErr))
+			logger.Ctx(ctx).Warn("disconnect mongodb client", zap.Error(disconnectErr))
 		}
 		if tunnel != nil {
 			if closeErr := tunnel.Close(); closeErr != nil {
-				logger.Default().Warn("close ssh tunnel", zap.Error(closeErr))
+				logger.Ctx(ctx).Warn("close ssh tunnel", zap.Error(closeErr))
 			}
 		}
 		return nil, nil, fmt.Errorf("MongoDB 连接失败: %w", pingErr)

--- a/internal/connpool/redis.go
+++ b/internal/connpool/redis.go
@@ -39,11 +39,11 @@ func DialRedis(ctx context.Context, asset *asset_entity.Asset, cfg *asset_entity
 	client := redis.NewClient(opts)
 	if pingErr := client.Ping(ctx).Err(); pingErr != nil {
 		if err := client.Close(); err != nil {
-			logger.Default().Warn("close redis client", zap.Error(err))
+			logger.Ctx(ctx).Warn("close redis client", zap.Error(err))
 		}
 		if tunnel != nil {
 			if err := tunnel.Close(); err != nil {
-				logger.Default().Warn("close ssh tunnel", zap.Error(err))
+				logger.Ctx(ctx).Warn("close ssh tunnel", zap.Error(err))
 			}
 		}
 		return nil, nil, fmt.Errorf("redis 连接失败: %w", pingErr)

--- a/internal/service/asset_svc/asset.go
+++ b/internal/service/asset_svc/asset.go
@@ -57,7 +57,7 @@ func (s *assetSvc) Create(ctx context.Context, asset *asset_entity.Asset) error 
 		if p, ok := policy.GetDefaultPolicyOf(asset.Type); ok {
 			data, err := json.Marshal(p)
 			if err != nil {
-				logger.Default().Error("marshal default policy", zap.Error(err))
+				logger.Ctx(ctx).Error("marshal default policy", zap.Error(err))
 			} else {
 				asset.CmdPolicy = string(data)
 			}

--- a/internal/service/backup_svc/export.go
+++ b/internal/service/backup_svc/export.go
@@ -242,7 +242,7 @@ func exportCredentials(ctx context.Context, assets []*asset_entity.Asset, crypto
 	for credID := range credIDs {
 		cred, err := credential_repo.Credential().Find(ctx, credID)
 		if err != nil {
-			logger.Default().Warn("credential not found during export", zap.Int64("id", credID), zap.Error(err))
+			logger.Ctx(ctx).Warn("credential not found during export", zap.Int64("id", credID), zap.Error(err))
 			continue
 		}
 		bc := &BackupCredential{Credential: *cred}

--- a/internal/service/backup_svc/import.go
+++ b/internal/service/backup_svc/import.go
@@ -151,7 +151,7 @@ func Import(ctx context.Context, data *BackupData, opts *ImportOptions, crypto C
 						if data.IncludesCredentials && cfg.Password != "" && crypto != nil {
 							encrypted, encErr := crypto.Encrypt(cfg.Password)
 							if encErr != nil {
-								logger.Default().Warn("re-encrypt ssh password", zap.Error(encErr))
+								logger.Ctx(ctx).Warn("re-encrypt ssh password", zap.Error(encErr))
 							} else {
 								cfg.Password = encrypted
 							}
@@ -160,13 +160,13 @@ func Import(ctx context.Context, data *BackupData, opts *ImportOptions, crypto C
 						if data.IncludesCredentials && cfg.Proxy != nil && cfg.Proxy.Password != "" && crypto != nil {
 							encrypted, encErr := crypto.Encrypt(cfg.Proxy.Password)
 							if encErr != nil {
-								logger.Default().Warn("re-encrypt proxy password", zap.Error(encErr))
+								logger.Ctx(ctx).Warn("re-encrypt proxy password", zap.Error(encErr))
 							} else {
 								cfg.Proxy.Password = encrypted
 							}
 						}
 						if err := a.SetSSHConfig(cfg); err != nil {
-							logger.Default().Warn("set ssh config in import", zap.Error(err))
+							logger.Ctx(ctx).Warn("set ssh config in import", zap.Error(err))
 						}
 					}
 				case a.IsDatabase() && a.Config != "":
@@ -179,13 +179,13 @@ func Import(ctx context.Context, data *BackupData, opts *ImportOptions, crypto C
 						if data.IncludesCredentials && cfg.Password != "" && crypto != nil {
 							encrypted, encErr := crypto.Encrypt(cfg.Password)
 							if encErr != nil {
-								logger.Default().Warn("re-encrypt db password", zap.Error(encErr))
+								logger.Ctx(ctx).Warn("re-encrypt db password", zap.Error(encErr))
 							} else {
 								cfg.Password = encrypted
 							}
 						}
 						if err := a.SetDatabaseConfig(cfg); err != nil {
-							logger.Default().Warn("set db config in import", zap.Error(err))
+							logger.Ctx(ctx).Warn("set db config in import", zap.Error(err))
 						}
 					}
 				case a.IsRedis() && a.Config != "":
@@ -198,13 +198,13 @@ func Import(ctx context.Context, data *BackupData, opts *ImportOptions, crypto C
 						if data.IncludesCredentials && cfg.Password != "" && crypto != nil {
 							encrypted, encErr := crypto.Encrypt(cfg.Password)
 							if encErr != nil {
-								logger.Default().Warn("re-encrypt redis password", zap.Error(encErr))
+								logger.Ctx(ctx).Warn("re-encrypt redis password", zap.Error(encErr))
 							} else {
 								cfg.Password = encrypted
 							}
 						}
 						if err := a.SetRedisConfig(cfg); err != nil {
-							logger.Default().Warn("set redis config in import", zap.Error(err))
+							logger.Ctx(ctx).Warn("set redis config in import", zap.Error(err))
 						}
 					}
 				}

--- a/internal/service/conversation_svc/conversation.go
+++ b/internal/service/conversation_svc/conversation.go
@@ -83,7 +83,7 @@ func (s *conversationSvc) Delete(ctx context.Context, id int64) error {
 
 	// 删除消息
 	if err := conversation_repo.Conversation().DeleteMessages(ctx, id); err != nil {
-		logger.Default().Warn("delete conversation messages", zap.Int64("id", id), zap.Error(err))
+		logger.Ctx(ctx).Warn("delete conversation messages", zap.Int64("id", id), zap.Error(err))
 	}
 
 	// 清理 saveLocks，避免删除后的 conversationID 继续占用 mutex。
@@ -92,7 +92,7 @@ func (s *conversationSvc) Delete(ctx context.Context, id int64) error {
 	// 清理工作目录
 	if conv.WorkDir != "" {
 		if err := os.RemoveAll(conv.WorkDir); err != nil {
-			logger.Default().Warn("remove conversation work dir", zap.String("dir", conv.WorkDir), zap.Error(err))
+			logger.Ctx(ctx).Warn("remove conversation work dir", zap.String("dir", conv.WorkDir), zap.Error(err))
 		}
 	}
 

--- a/internal/service/import_svc/sshconfig.go
+++ b/internal/service/import_svc/sshconfig.go
@@ -245,7 +245,7 @@ func ImportSSHConfigSelected(ctx context.Context, data []byte, selectedIndexes [
 			continue
 		}
 		if err := asset_svc.Asset().Update(ctx, asset); err != nil {
-			logger.Default().Warn("update asset jump host after ssh config import", zap.Int64("assetID", asset.ID), zap.Error(err))
+			logger.Ctx(ctx).Warn("update asset jump host after ssh config import", zap.Int64("assetID", asset.ID), zap.Error(err))
 		}
 	}
 

--- a/internal/service/import_svc/tabby.go
+++ b/internal/service/import_svc/tabby.go
@@ -412,7 +412,7 @@ func ImportTabbySelected(ctx context.Context, data []byte, selectedIndexes []int
 			continue
 		}
 		if err := asset_svc.Asset().Update(ctx, asset); err != nil {
-			logger.Default().Warn("update asset jump host after tabby import", zap.Int64("assetID", asset.ID), zap.Error(err))
+			logger.Ctx(ctx).Warn("update asset jump host after tabby import", zap.Int64("assetID", asset.ID), zap.Error(err))
 		}
 	}
 

--- a/internal/service/policy_group_svc/policy_group.go
+++ b/internal/service/policy_group_svc/policy_group.go
@@ -62,7 +62,7 @@ func (s *policyGroupSvc) List(ctx context.Context, policyType string) ([]*policy
 	}
 	if err != nil {
 		// DB 查询失败（如表未创建）不影响内置组返回
-		logger.Default().Warn("list user policy groups", zap.Error(err))
+		logger.Ctx(ctx).Warn("list user policy groups", zap.Error(err))
 		return items, nil
 	}
 	for _, pg := range userGroups {

--- a/internal/service/sftp_svc/sftp.go
+++ b/internal/service/sftp_svc/sftp.go
@@ -183,7 +183,7 @@ func (s *Service) Upload(ctx context.Context, transferID, sessionID, localPath, 
 	}
 	defer func() {
 		if err := localFile.Close(); err != nil {
-			logger.Default().Warn("close local file", zap.String("path", localPath), zap.Error(err))
+			logger.Ctx(ctx).Warn("close local file", zap.String("path", localPath), zap.Error(err))
 		}
 	}()
 
@@ -198,7 +198,7 @@ func (s *Service) Upload(ctx context.Context, transferID, sessionID, localPath, 
 	}
 	defer func() {
 		if err := remoteFile.Close(); err != nil {
-			logger.Default().Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
+			logger.Ctx(ctx).Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
 		}
 	}()
 
@@ -225,7 +225,7 @@ func (s *Service) Download(ctx context.Context, transferID, sessionID, remotePat
 	}
 	defer func() {
 		if err := remoteFile.Close(); err != nil {
-			logger.Default().Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
+			logger.Ctx(ctx).Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
 		}
 	}()
 
@@ -240,7 +240,7 @@ func (s *Service) Download(ctx context.Context, transferID, sessionID, remotePat
 	}
 	defer func() {
 		if err := localFile.Close(); err != nil {
-			logger.Default().Warn("close local file", zap.String("path", localPath), zap.Error(err))
+			logger.Ctx(ctx).Warn("close local file", zap.String("path", localPath), zap.Error(err))
 		}
 	}()
 
@@ -300,7 +300,7 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 
 		relPath, err := filepath.Rel(localDir, path)
 		if err != nil {
-			logger.Default().Warn("compute relative path", zap.String("base", localDir), zap.String("path", path), zap.Error(err))
+			logger.Ctx(ctx).Warn("compute relative path", zap.String("base", localDir), zap.String("path", path), zap.Error(err))
 			return err
 		}
 		remoteFull := remoteDir + "/" + filepath.ToSlash(relPath)
@@ -316,7 +316,7 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 		}
 		defer func() {
 			if err := localFile.Close(); err != nil {
-				logger.Default().Warn("close local file", zap.String("path", path), zap.Error(err))
+				logger.Ctx(ctx).Warn("close local file", zap.String("path", path), zap.Error(err))
 			}
 		}()
 
@@ -326,7 +326,7 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 		}
 		defer func() {
 			if err := remoteFile.Close(); err != nil {
-				logger.Default().Warn("close remote file", zap.String("path", remoteFull), zap.Error(err))
+				logger.Ctx(ctx).Warn("close remote file", zap.String("path", remoteFull), zap.Error(err))
 			}
 		}()
 
@@ -462,7 +462,7 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 		localFile, err := os.Create(localFull) //nolint:gosec // file path from user config
 		if err != nil {
 			if closeErr := remoteFile.Close(); closeErr != nil {
-				logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
+				logger.Ctx(ctx).Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
 			}
 			return err
 		}
@@ -471,10 +471,10 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 		for {
 			if ctx.Err() != nil {
 				if closeErr := localFile.Close(); closeErr != nil {
-					logger.Default().Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
+					logger.Ctx(ctx).Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
 				}
 				if closeErr := remoteFile.Close(); closeErr != nil {
-					logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
+					logger.Ctx(ctx).Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
 				}
 				return ctx.Err()
 			}
@@ -482,10 +482,10 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 			if n > 0 {
 				if _, writeErr := localFile.Write(buf[:n]); writeErr != nil {
 					if closeErr := localFile.Close(); closeErr != nil {
-						logger.Default().Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
+						logger.Ctx(ctx).Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
 					}
 					if closeErr := remoteFile.Close(); closeErr != nil {
-						logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
+						logger.Ctx(ctx).Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
 					}
 					return writeErr
 				}
@@ -515,20 +515,20 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 			}
 			if readErr != nil {
 				if closeErr := localFile.Close(); closeErr != nil {
-					logger.Default().Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
+					logger.Ctx(ctx).Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
 				}
 				if closeErr := remoteFile.Close(); closeErr != nil {
-					logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
+					logger.Ctx(ctx).Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
 				}
 				return readErr
 			}
 		}
 
 		if closeErr := localFile.Close(); closeErr != nil {
-			logger.Default().Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
+			logger.Ctx(ctx).Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
 		}
 		if closeErr := remoteFile.Close(); closeErr != nil {
-			logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
+			logger.Ctx(ctx).Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
 		}
 		filesCompleted++
 	}

--- a/internal/service/ssh_svc/host_key_verify.go
+++ b/internal/service/ssh_svc/host_key_verify.go
@@ -64,7 +64,7 @@ func MakeHostKeyCallback(host string, port int, verifyFn HostKeyVerifyFunc) ssh.
 				// 密钥匹配，更新 last_seen
 				stored.LastSeen = now
 				if err := host_key_repo.HostKey().Upsert(ctx, stored); err != nil {
-					logger.Default().Warn("upsert host key", zap.String("host", host), zap.Int("port", port), zap.Error(err))
+					logger.Ctx(ctx).Warn("upsert host key", zap.String("host", host), zap.Int("port", port), zap.Error(err))
 				}
 				return nil
 			}
@@ -86,7 +86,7 @@ func MakeHostKeyCallback(host string, port int, verifyFn HostKeyVerifyFunc) ssh.
 				stored.Fingerprint = fingerprint
 				stored.LastSeen = now
 				if err := host_key_repo.HostKey().Upsert(ctx, stored); err != nil {
-					logger.Default().Warn("upsert host key", zap.String("host", host), zap.Int("port", port), zap.Error(err))
+					logger.Ctx(ctx).Warn("upsert host key", zap.String("host", host), zap.Int("port", port), zap.Error(err))
 				}
 				return nil
 			case HostKeyAcceptOnce:
@@ -117,7 +117,7 @@ func MakeHostKeyCallback(host string, port int, verifyFn HostKeyVerifyFunc) ssh.
 				LastSeen:    now,
 			}
 			if err := host_key_repo.HostKey().Upsert(ctx, newKey); err != nil {
-				logger.Default().Warn("upsert new host key", zap.String("host", host), zap.Int("port", port), zap.Error(err))
+				logger.Ctx(ctx).Warn("upsert new host key", zap.String("host", host), zap.Int("port", port), zap.Error(err))
 			}
 			return nil
 		case HostKeyAcceptOnce:

--- a/internal/sshpool/pool.go
+++ b/internal/sshpool/pool.go
@@ -148,11 +148,11 @@ func (p *Pool) Get(ctx context.Context, assetID int64) (*ssh.Client, error) {
 		p.mu.Unlock()
 		// 关闭我们刚创建的，使用已存在的
 		if err := client.Close(); err != nil {
-			logger.Default().Warn("close duplicate ssh client", zap.Int64("assetID", assetID), zap.Error(err))
+			logger.Ctx(ctx).Warn("close duplicate ssh client", zap.Int64("assetID", assetID), zap.Error(err))
 		}
 		for _, c := range closers {
 			if err := c.Close(); err != nil {
-				logger.Default().Warn("close duplicate intermediate connection", zap.Int64("assetID", assetID), zap.Error(err))
+				logger.Ctx(ctx).Warn("close duplicate intermediate connection", zap.Int64("assetID", assetID), zap.Error(err))
 			}
 		}
 		if existing.isAlive() {

--- a/migrations/202603290001_policy_group_string_ids.go
+++ b/migrations/202603290001_policy_group_string_ids.go
@@ -64,7 +64,7 @@ func migratePolicyColumn(tx *gorm.DB, table, column string) error {
 		}
 		updateSQL := fmt.Sprintf("UPDATE %s SET %s = ? WHERE id = ?", table, column)
 		if err := tx.Exec(updateSQL, newPolicy, r.ID).Error; err != nil {
-			logger.Default().Warn("migration: update policy column",
+			logger.Ctx(tx.Statement.Context).Warn("migration: update policy column",
 				zap.String("table", table), zap.String("column", column),
 				zap.Int64("id", r.ID), zap.Error(err))
 			return err

--- a/pkg/extension/io_http.go
+++ b/pkg/extension/io_http.go
@@ -209,7 +209,7 @@ func (h *httpHandle) Close() error {
 	h.cancel()
 	if h.resp != nil {
 		if err := h.resp.Body.Close(); err != nil {
-			logger.Default().Warn("close HTTP response body", zap.Error(err))
+			logger.Ctx(h.ctx).Warn("close HTTP response body", zap.Error(err))
 		}
 	}
 	return nil

--- a/pkg/extension/manager.go
+++ b/pkg/extension/manager.go
@@ -173,7 +173,7 @@ func (m *Manager) Close(ctx context.Context) {
 	for _, ext := range exts {
 		if ext.Plugin != nil {
 			if err := ext.Plugin.Close(ctx); err != nil {
-				logger.Default().Warn("close extension plugin", zap.String("name", ext.Name), zap.Error(err))
+				logger.Ctx(ctx).Warn("close extension plugin", zap.String("name", ext.Name), zap.Error(err))
 			}
 		}
 	}
@@ -185,7 +185,7 @@ func (m *Manager) Shutdown(ctx context.Context) {
 	m.Close(ctx)
 	if m.wasmCache != nil {
 		if err := m.wasmCache.Close(ctx); err != nil {
-			logger.Default().Warn("close wasm compilation cache", zap.Error(err))
+			logger.Ctx(ctx).Warn("close wasm compilation cache", zap.Error(err))
 		}
 	}
 }
@@ -200,14 +200,14 @@ func (m *Manager) Watch(ctx context.Context, onChange func()) error {
 
 	if err := os.MkdirAll(m.dir, 0755); err != nil {
 		if closeErr := watcher.Close(); closeErr != nil {
-			logger.Default().Warn("close watcher after mkdir error", zap.Error(closeErr))
+			logger.Ctx(ctx).Warn("close watcher after mkdir error", zap.Error(closeErr))
 		}
 		return fmt.Errorf("create extensions dir: %w", err)
 	}
 
 	if err := watcher.Add(m.dir); err != nil {
 		if closeErr := watcher.Close(); closeErr != nil {
-			logger.Default().Warn("close watcher after add error", zap.Error(closeErr))
+			logger.Ctx(ctx).Warn("close watcher after add error", zap.Error(closeErr))
 		}
 		return fmt.Errorf("watch extensions dir: %w", err)
 	}
@@ -215,7 +215,7 @@ func (m *Manager) Watch(ctx context.Context, onChange func()) error {
 	go func() {
 		defer func() {
 			if err := watcher.Close(); err != nil {
-				logger.Default().Warn("close filesystem watcher", zap.Error(err))
+				logger.Ctx(ctx).Warn("close filesystem watcher", zap.Error(err))
 			}
 		}()
 		for {
@@ -380,7 +380,7 @@ func (m *Manager) Install(ctx context.Context, sourcePath string) (*Manifest, er
 		}
 		defer func() {
 			if err := os.RemoveAll(tmpDir); err != nil {
-				logger.Default().Warn("remove temp dir", zap.String("dir", tmpDir), zap.Error(err))
+				logger.Ctx(ctx).Warn("remove temp dir", zap.String("dir", tmpDir), zap.Error(err))
 			}
 		}()
 		if err := extractZip(sourcePath, tmpDir); err != nil {
@@ -426,7 +426,7 @@ func (m *Manager) Install(ctx context.Context, sourcePath string) (*Manifest, er
 	// Load the extension
 	if _, err := m.LoadExtension(ctx, destDir); err != nil {
 		if removeErr := os.RemoveAll(destDir); removeErr != nil {
-			logger.Default().Warn("remove extension dir after load failure", zap.String("dir", destDir), zap.Error(removeErr))
+			logger.Ctx(ctx).Warn("remove extension dir after load failure", zap.String("dir", destDir), zap.Error(removeErr))
 		}
 		return nil, fmt.Errorf("load extension: %w", err)
 	}

--- a/pkg/extension/runtime.go
+++ b/pkg/extension/runtime.go
@@ -42,7 +42,7 @@ func LoadPlugin(ctx context.Context, manifest *Manifest, wasmBytes []byte, host 
 	// Register host functions module
 	if err := registerHostModule(ctx, r, host); err != nil {
 		if closeErr := r.Close(ctx); closeErr != nil {
-			logger.Default().Warn("close wasm runtime after host module error", zap.Error(closeErr))
+			logger.Ctx(ctx).Warn("close wasm runtime after host module error", zap.Error(closeErr))
 		}
 		return nil, fmt.Errorf("register host functions: %w", err)
 	}
@@ -50,7 +50,7 @@ func LoadPlugin(ctx context.Context, manifest *Manifest, wasmBytes []byte, host 
 	compiled, err := r.CompileModule(ctx, wasmBytes)
 	if err != nil {
 		if closeErr := r.Close(ctx); closeErr != nil {
-			logger.Default().Warn("close wasm runtime after compile error", zap.Error(closeErr))
+			logger.Ctx(ctx).Warn("close wasm runtime after compile error", zap.Error(closeErr))
 		}
 		return nil, fmt.Errorf("compile wasm: %w", err)
 	}
@@ -205,7 +205,7 @@ func (p *Plugin) callLocked(ctx context.Context, fnName string, input []byte) (j
 	}
 	defer func() {
 		if err := mod.Close(callCtx); err != nil {
-			logger.Default().Warn("close wasm module", zap.Error(err))
+			logger.Ctx(ctx).Warn("close wasm module", zap.Error(err))
 		}
 	}()
 
@@ -289,7 +289,7 @@ func registerHostModule(ctx context.Context, r wazero.Runtime, host HostProvider
 	// host_io_close(handle_id)
 	b.NewFunctionBuilder().WithFunc(func(ctx context.Context, mod api.Module, handleID uint32) {
 		if err := host.IOClose(handleID); err != nil {
-			logger.Default().Warn("close IO handle from host", zap.Uint32("handleID", handleID), zap.Error(err))
+			logger.Ctx(ctx).Warn("close IO handle from host", zap.Uint32("handleID", handleID), zap.Error(err))
 		}
 	}).Export("host_io_close")
 
@@ -342,7 +342,7 @@ func registerHostModule(ctx context.Context, r wazero.Runtime, host HostProvider
 		key := readGuestString(mod, keyPtr, keyLen)
 		val := readGuestBytes(mod, valPtr, valLen)
 		if err := host.KVSet(key, val); err != nil {
-			logger.Default().Warn("host KV set", zap.String("key", key), zap.Error(err))
+			logger.Ctx(ctx).Warn("host KV set", zap.String("key", key), zap.Error(err))
 		}
 	}).Export("host_kv_set")
 
@@ -351,7 +351,7 @@ func registerHostModule(ctx context.Context, r wazero.Runtime, host HostProvider
 		eventType := readGuestString(mod, typePtr, typeLen)
 		data := readGuestBytes(mod, dataPtr, dataLen)
 		if err := host.ActionEvent(eventType, data); err != nil {
-			logger.Default().Warn("host action event", zap.String("eventType", eventType), zap.Error(err))
+			logger.Ctx(ctx).Warn("host action event", zap.String("eventType", eventType), zap.Error(err))
 		}
 	}).Export("host_action_event")
 


### PR DESCRIPTION
## Summary
- Preserve Anthropic adaptive thinking signatures across streaming, persistence, and subsequent tool-use turns.
- Treat malformed, interrupted, and provider error SSE streams as explicit errors instead of silently completing.
- Switch AI/connection/extension warning logs to context-aware loggers where a request context is available.

## Test Plan
- [x] `make test`
- [x] `cd frontend && pnpm test`
- [x] `make lint`
- [x] `cd frontend && pnpm lint` (passes; reports existing warnings only)