### PR TITLE
📄 为 README 添加介绍视频链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Currently supports SSH servers, MySQL/PostgreSQL databases, Redis, MongoDB, and 
 
 **If you find it useful, please give us a Star ⭐ — it means a lot!**
 
+## Intro Video
+
+https://github.com/user-attachments/assets/2af6e52e-637c-4398-9c8b-8b39b4238b12
+
 ## Demo
 
 https://github.com/user-attachments/assets/035fc0df-230c-456b-87bd-8a4a125feaec

--- a/README_zh.md
+++ b/README_zh.md
@@ -37,6 +37,10 @@ OpsKat
 
 **如果觉得有用，求个 Star ⭐ 这是对我们最大的支持！**
 
+## 介绍视频
+
+https://github.com/user-attachments/assets/5816f1b1-ba90-4a7c-a5a7-cf4c5d7bbb89
+
 ## 演示
 
 https://github.com/user-attachments/assets/035fc0df-230c-456b-87bd-8a4a125feaec


### PR DESCRIPTION
## 变更

- 在英文 README 的 Demo 区块上方新增 Intro Video。
- 在中文 README 的 演示 区块上方新增 介绍视频。
- 两处都使用 GitHub user-attachments 视频地址，不把视频文件提交进仓库。

## 验证

- 使用 g 确认中英文 README 都包含对应介绍视频地址，并且保留原有 Demo / 演示视频地址。
- 使用 git status --short --branch --untracked-files=all 确认变更范围只有两份 README。
