### PR TITLE
⚡️ AI 流式输出性能优化 + 组件拆分重构

### DIFF
--- a/frontend/src/__tests__/AIChatContent.test.tsx
+++ b/frontend/src/__tests__/AIChatContent.test.tsx
@@ -581,4 +581,79 @@ describe("AIChatContent", () => {
 
     expect(viewport!.scrollTop).toBe(30);
   });
+
+  it("re-enables outer viewport follow when the user sends a new idle message", async () => {
+    const user = userEvent.setup();
+    const onSendOverride = vi.fn().mockResolvedValue(undefined);
+
+    useAIStore.setState({
+      conversationMessages: {
+        94: [
+          { role: "user", content: "hi", blocks: [] },
+          { role: "assistant", content: "old answer", blocks: [{ type: "text", content: "old answer" }] },
+        ],
+      },
+      conversationStreaming: {
+        94: { sending: false, pendingQueue: [] },
+      },
+    });
+
+    const { container } = render(<AIChatContent conversationId={94} onSendOverride={onSendOverride} />);
+    const viewport = container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+    expect(viewport).toBeTruthy();
+    setupScrollableElement(viewport!, {
+      scrollHeight: 500,
+      clientHeight: 200,
+      scrollTop: 300,
+    });
+    dispatchScroll(viewport!);
+    viewport!.scrollTop = 120;
+    dispatchScroll(viewport!);
+
+    await user.type(screen.getByRole("textbox", { name: "mock-ai-input" }), "new question");
+    await user.click(screen.getByRole("button", { name: "mock-submit" }));
+
+    await waitFor(() => expect(onSendOverride).toHaveBeenCalledWith("new question"));
+    expect(viewport!.scrollTop).toBe(500);
+  });
+
+  it("keeps the user's scroll position when sending only queues during active output", async () => {
+    const user = userEvent.setup();
+    const onSendOverride = vi.fn().mockResolvedValue(undefined);
+
+    useAIStore.setState({
+      conversationMessages: {
+        95: [
+          { role: "user", content: "hi", blocks: [] },
+          {
+            role: "assistant",
+            content: "streaming answer",
+            blocks: [{ type: "text", content: "streaming answer" }],
+            streaming: true,
+          },
+        ],
+      },
+      conversationStreaming: {
+        95: { sending: true, pendingQueue: [] },
+      },
+    });
+
+    const { container } = render(<AIChatContent conversationId={95} onSendOverride={onSendOverride} />);
+    const viewport = container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+    expect(viewport).toBeTruthy();
+    setupScrollableElement(viewport!, {
+      scrollHeight: 500,
+      clientHeight: 200,
+      scrollTop: 300,
+    });
+    dispatchScroll(viewport!);
+    viewport!.scrollTop = 120;
+    dispatchScroll(viewport!);
+
+    await user.type(screen.getByRole("textbox", { name: "mock-ai-input" }), "queued question");
+    await user.click(screen.getByRole("button", { name: "mock-submit" }));
+
+    await waitFor(() => expect(onSendOverride).toHaveBeenCalledWith("queued question"));
+    expect(viewport!.scrollTop).toBe(120);
+  });
 });

--- a/frontend/src/__tests__/AIChatContent.test.tsx
+++ b/frontend/src/__tests__/AIChatContent.test.tsx
@@ -7,23 +7,13 @@ import { useAIStore } from "../stores/aiStore";
 import { useTabStore } from "../stores/tabStore";
 import { AIChatContent } from "../components/ai/AIChatContent";
 
-// 流式跟随滚动测试需要在 deferred markdown 异步 commit 时被通知，
-// 真实环境靠 ResizeObserver；happy-dom 没实现，这里桩一个能透出 callback 的版本。
-const resizeObserverCallbacks: ResizeObserverCallback[] = [];
-class MockResizeObserver {
-  callback: ResizeObserverCallback;
-  constructor(cb: ResizeObserverCallback) {
-    this.callback = cb;
-    resizeObserverCallbacks.push(cb);
-  }
-  observe() {}
-  unobserve() {}
-  disconnect() {
-    const idx = resizeObserverCallbacks.indexOf(this.callback);
-    if (idx >= 0) resizeObserverCallbacks.splice(idx, 1);
-  }
-}
-vi.stubGlobal("ResizeObserver", MockResizeObserver);
+const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+  callback(0);
+  return 1;
+});
+const cancelAnimationFrameMock = vi.fn();
+vi.stubGlobal("requestAnimationFrame", requestAnimationFrameMock);
+vi.stubGlobal("cancelAnimationFrame", cancelAnimationFrameMock);
 
 const mockInputSpies = vi.hoisted(() => ({
   loadDraft: vi.fn(),
@@ -43,6 +33,32 @@ const defaultAIActions = {
 const editButtonName = /ai\.editMessage|编辑消息|Edit message/i;
 const editingBannerName = /ai\.editingMessage|正在编辑消息|Editing message/i;
 const cancelEditName = /ai\.cancelEdit|取消编辑|Cancel edit/i;
+
+function setupScrollableElement(
+  element: HTMLElement,
+  geometry: { scrollHeight: number; clientHeight: number; scrollTop: number }
+) {
+  let scrollHeight = geometry.scrollHeight;
+  let clientHeight = geometry.clientHeight;
+  Object.defineProperty(element, "scrollHeight", { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(element, "clientHeight", { configurable: true, get: () => clientHeight });
+  element.scrollTop = geometry.scrollTop;
+
+  return {
+    setScrollHeight: (next: number) => {
+      scrollHeight = next;
+    },
+    setClientHeight: (next: number) => {
+      clientHeight = next;
+    },
+  };
+}
+
+function dispatchScroll(viewport: HTMLElement) {
+  act(() => {
+    viewport.dispatchEvent(new Event("scroll"));
+  });
+}
 
 vi.mock("@/components/ai/AIChatInput", () => ({
   AIChatInput: forwardRef(function MockAIChatInput(
@@ -103,7 +119,8 @@ describe("AIChatContent", () => {
     localStorage.setItem("language", "zh-CN");
     mockInputSpies.loadDraft.mockReset();
     mockInputSpies.clear.mockReset();
-    resizeObserverCallbacks.length = 0;
+    requestAnimationFrameMock.mockClear();
+    cancelAnimationFrameMock.mockClear();
 
     useTabStore.setState({ tabs: [], activeTabId: null });
     useAIStore.setState({
@@ -319,43 +336,101 @@ describe("AIChatContent", () => {
     expect(screen.queryByText("110")).not.toBeInTheDocument();
   });
 
-  it("streaming auto-follows scroll when deferred content grows scrollHeight", () => {
-    // 复现 useDeferredValue 异步 commit 的场景：
-    // store 已经推过新内容，messages effect 跑过一次按当时 scrollHeight 滚到底；
-    // 随后 markdown 异步 commit，把 scrollHeight 撑得更高——
-    // 此时既不再触发 messages effect 也不触发 scroll 事件，
-    // 唯有 ResizeObserver 能让视口继续跟到新底部。
+  it("auto-follows the bottom inside a streaming thinking block after its internal content overflows", () => {
     useAIStore.setState({
       conversationMessages: {
-        77: [
+        81: [
           { role: "user", content: "hi", blocks: [] },
           {
             role: "assistant",
-            content: "first",
-            blocks: [{ type: "text", content: "first" }],
+            content: "thinking",
+            blocks: [{ type: "thinking", content: "step 1", status: "running" }],
             streaming: true,
           },
         ],
       },
       conversationStreaming: {
-        77: { sending: true, pendingQueue: [] },
+        81: { sending: true, pendingQueue: [] },
       },
     });
 
-    const { container } = render(<AIChatContent conversationId={77} />);
-    const viewport = container.querySelector<HTMLDivElement>("[data-radix-scroll-area-viewport]");
-    expect(viewport).toBeTruthy();
-    expect(resizeObserverCallbacks.length).toBeGreaterThan(0);
+    const { container } = render(<AIChatContent conversationId={81} />);
+    const thinkingScroll = container.querySelector<HTMLElement>("[data-thinking-scroll]");
+    expect(thinkingScroll).toBeTruthy();
+    const { setScrollHeight } = setupScrollableElement(thinkingScroll!, {
+      scrollHeight: 240,
+      clientHeight: 100,
+      scrollTop: 140,
+    });
+    dispatchScroll(thinkingScroll!);
 
-    Object.defineProperty(viewport!, "scrollHeight", { configurable: true, get: () => 1200 });
-    Object.defineProperty(viewport!, "clientHeight", { configurable: true, get: () => 300 });
-
+    setScrollHeight(500);
     act(() => {
-      for (const cb of resizeObserverCallbacks) {
-        cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
-      }
+      useAIStore.setState({
+        conversationMessages: {
+          81: [
+            { role: "user", content: "hi", blocks: [] },
+            {
+              role: "assistant",
+              content: "thinking",
+              blocks: [{ type: "thinking", content: "step 1\nstep 2", status: "running" }],
+              streaming: true,
+            },
+          ],
+        },
+      });
     });
 
-    expect(viewport!.scrollTop).toBe(1200);
+    expect(thinkingScroll!.scrollTop).toBe(500);
+  });
+
+  it("does not auto-follow streaming thinking growth after the user scrolls up inside the thinking block", () => {
+    useAIStore.setState({
+      conversationMessages: {
+        82: [
+          { role: "user", content: "hi", blocks: [] },
+          {
+            role: "assistant",
+            content: "thinking",
+            blocks: [{ type: "thinking", content: "step 1", status: "running" }],
+            streaming: true,
+          },
+        ],
+      },
+      conversationStreaming: {
+        82: { sending: true, pendingQueue: [] },
+      },
+    });
+
+    const { container } = render(<AIChatContent conversationId={82} />);
+    const thinkingScroll = container.querySelector<HTMLElement>("[data-thinking-scroll]");
+    expect(thinkingScroll).toBeTruthy();
+    const { setScrollHeight } = setupScrollableElement(thinkingScroll!, {
+      scrollHeight: 240,
+      clientHeight: 100,
+      scrollTop: 140,
+    });
+    dispatchScroll(thinkingScroll!);
+    thinkingScroll!.scrollTop = 60;
+    dispatchScroll(thinkingScroll!);
+
+    setScrollHeight(500);
+    act(() => {
+      useAIStore.setState({
+        conversationMessages: {
+          82: [
+            { role: "user", content: "hi", blocks: [] },
+            {
+              role: "assistant",
+              content: "thinking",
+              blocks: [{ type: "thinking", content: "step 1\nstep 2", status: "running" }],
+              streaming: true,
+            },
+          ],
+        },
+      });
+    });
+
+    expect(thinkingScroll!.scrollTop).toBe(60);
   });
 });

--- a/frontend/src/__tests__/AIChatContent.test.tsx
+++ b/frontend/src/__tests__/AIChatContent.test.tsx
@@ -548,7 +548,8 @@ describe("AIChatContent", () => {
       triggerResizeObservers();
     });
 
-    expect(viewport!.scrollTop).toBe(500);
+    // 到底部的 scrollTop 上限是 scrollHeight - clientHeight = 500 - 200 = 300
+    expect(viewport!.scrollTop).toBe(300);
   });
 
   it("does not drop follow when content shrinks (e.g. ThinkingBlock collapses) and the browser clamps scrollTop", () => {
@@ -591,7 +592,8 @@ describe("AIChatContent", () => {
     act(() => {
       triggerResizeObservers();
     });
-    expect(viewport!.scrollTop).toBe(700);
+    // 到底部的 scrollTop 上限是 scrollHeight - clientHeight = 700 - 200 = 500
+    expect(viewport!.scrollTop).toBe(500);
   });
 
   it("does not pull the outer viewport back to bottom after the user scrolled up", () => {

--- a/frontend/src/__tests__/AIChatContent.test.tsx
+++ b/frontend/src/__tests__/AIChatContent.test.tsx
@@ -1,11 +1,29 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import i18n from "../i18n";
 import { useAIStore } from "../stores/aiStore";
 import { useTabStore } from "../stores/tabStore";
 import { AIChatContent } from "../components/ai/AIChatContent";
+
+// 流式跟随滚动测试需要在 deferred markdown 异步 commit 时被通知，
+// 真实环境靠 ResizeObserver；happy-dom 没实现，这里桩一个能透出 callback 的版本。
+const resizeObserverCallbacks: ResizeObserverCallback[] = [];
+class MockResizeObserver {
+  callback: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this.callback = cb;
+    resizeObserverCallbacks.push(cb);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    const idx = resizeObserverCallbacks.indexOf(this.callback);
+    if (idx >= 0) resizeObserverCallbacks.splice(idx, 1);
+  }
+}
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
 
 const mockInputSpies = vi.hoisted(() => ({
   loadDraft: vi.fn(),
@@ -85,6 +103,7 @@ describe("AIChatContent", () => {
     localStorage.setItem("language", "zh-CN");
     mockInputSpies.loadDraft.mockReset();
     mockInputSpies.clear.mockReset();
+    resizeObserverCallbacks.length = 0;
 
     useTabStore.setState({ tabs: [], activeTabId: null });
     useAIStore.setState({
@@ -269,5 +288,74 @@ describe("AIChatContent", () => {
     await user.click(await screen.findByRole("button", { name: /common\.confirm|确定|Confirm/i }));
 
     await waitFor(() => expect(regenerateConversation).toHaveBeenCalledWith(31, 0));
+  });
+
+  it("assistant usage badge shows uncached input rather than input plus cache", () => {
+    useAIStore.setState({
+      conversationMessages: {
+        41: [
+          {
+            role: "assistant",
+            content: "usage ready",
+            blocks: [],
+            tokenUsage: {
+              inputTokens: 80,
+              outputTokens: 5,
+              cacheCreationTokens: 10,
+              cacheReadTokens: 20,
+            },
+          },
+        ],
+      },
+      conversationStreaming: {
+        41: { sending: false, pendingQueue: [] },
+      },
+    });
+
+    render(<AIChatContent conversationId={41} />);
+
+    expect(screen.getByText("80")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.queryByText("110")).not.toBeInTheDocument();
+  });
+
+  it("streaming auto-follows scroll when deferred content grows scrollHeight", () => {
+    // 复现 useDeferredValue 异步 commit 的场景：
+    // store 已经推过新内容，messages effect 跑过一次按当时 scrollHeight 滚到底；
+    // 随后 markdown 异步 commit，把 scrollHeight 撑得更高——
+    // 此时既不再触发 messages effect 也不触发 scroll 事件，
+    // 唯有 ResizeObserver 能让视口继续跟到新底部。
+    useAIStore.setState({
+      conversationMessages: {
+        77: [
+          { role: "user", content: "hi", blocks: [] },
+          {
+            role: "assistant",
+            content: "first",
+            blocks: [{ type: "text", content: "first" }],
+            streaming: true,
+          },
+        ],
+      },
+      conversationStreaming: {
+        77: { sending: true, pendingQueue: [] },
+      },
+    });
+
+    const { container } = render(<AIChatContent conversationId={77} />);
+    const viewport = container.querySelector<HTMLDivElement>("[data-radix-scroll-area-viewport]");
+    expect(viewport).toBeTruthy();
+    expect(resizeObserverCallbacks.length).toBeGreaterThan(0);
+
+    Object.defineProperty(viewport!, "scrollHeight", { configurable: true, get: () => 1200 });
+    Object.defineProperty(viewport!, "clientHeight", { configurable: true, get: () => 300 });
+
+    act(() => {
+      for (const cb of resizeObserverCallbacks) {
+        cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+      }
+    });
+
+    expect(viewport!.scrollTop).toBe(1200);
   });
 });

--- a/frontend/src/__tests__/AIChatContent.test.tsx
+++ b/frontend/src/__tests__/AIChatContent.test.tsx
@@ -6,6 +6,12 @@ import i18n from "../i18n";
 import { useAIStore } from "../stores/aiStore";
 import { useTabStore } from "../stores/tabStore";
 import { AIChatContent } from "../components/ai/AIChatContent";
+import {
+  CreateConversation,
+  ListConversations,
+  SendAIMessage,
+  UpdateConversationTitle,
+} from "../../wailsjs/go/app/App";
 
 const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
   callback(0);
@@ -310,6 +316,52 @@ describe("AIChatContent", () => {
 
     await waitFor(() => expect(onSendOverride).toHaveBeenCalledWith("sidebar send"));
     expect(editAndResendConversation).not.toHaveBeenCalled();
+  });
+
+  it("side-tab first send reloads an empty draft after binding the conversation", async () => {
+    const user = userEvent.setup();
+    const sideTabId = "sidebar-901";
+    vi.mocked(CreateConversation).mockResolvedValue({
+      ID: 901,
+      Title: "新对话",
+      Updatetime: 0,
+    } as Awaited<ReturnType<typeof CreateConversation>>);
+    vi.mocked(UpdateConversationTitle).mockResolvedValue(
+      undefined as Awaited<ReturnType<typeof UpdateConversationTitle>>
+    );
+    vi.mocked(SendAIMessage).mockResolvedValue(undefined as Awaited<ReturnType<typeof SendAIMessage>>);
+    vi.mocked(ListConversations).mockResolvedValue([{ ID: 901, Title: "hello", Updatetime: 0 }] as Awaited<
+      ReturnType<typeof ListConversations>
+    >);
+    useAIStore.setState({
+      sidebarTabs: [
+        {
+          id: sideTabId,
+          conversationId: null,
+          title: "新对话",
+          createdAt: 1,
+          uiState: { inputDraft: { content: "hello" }, scrollTop: 24, editTarget: null },
+        },
+      ],
+      activeSidebarTabId: sideTabId,
+      conversationMessages: {},
+      conversationStreaming: {},
+    });
+
+    const onSendOverride = (content: string) => useAIStore.getState().sendFromSidebarTab(sideTabId, content);
+    const { rerender } = render(
+      <AIChatContent sideTabId={sideTabId} conversationId={null} onSendOverride={onSendOverride} />
+    );
+    await user.type(screen.getByRole("textbox", { name: "mock-ai-input" }), "hello");
+    mockInputSpies.loadDraft.mockClear();
+
+    await user.click(screen.getByRole("button", { name: "mock-submit" }));
+    await waitFor(() => expect(useAIStore.getState().sidebarTabs[0].conversationId).toBe(901));
+
+    rerender(<AIChatContent sideTabId={sideTabId} conversationId={901} onSendOverride={onSendOverride} />);
+
+    await waitFor(() => expect(mockInputSpies.loadDraft).toHaveBeenLastCalledWith({ content: "" }));
+    expect(screen.getByRole("textbox", { name: "mock-ai-input" })).toHaveValue("");
   });
 
   it("conversationId regenerate routes through direct mode", async () => {

--- a/frontend/src/__tests__/AIChatContent.test.tsx
+++ b/frontend/src/__tests__/AIChatContent.test.tsx
@@ -15,6 +15,32 @@ const cancelAnimationFrameMock = vi.fn();
 vi.stubGlobal("requestAnimationFrame", requestAnimationFrameMock);
 vi.stubGlobal("cancelAnimationFrame", cancelAnimationFrameMock);
 
+// happy-dom 不会因为状态变化自然触发 ResizeObserver，测试需要手动调用回调来模拟
+// "deferred markdown commit 撑高内容容器"这一拍，从而验证 AIChatContent 的滚动跟随行为。
+const resizeObservers: Array<{ cb: ResizeObserverCallback }> = [];
+class MockResizeObserver {
+  private entry: { cb: ResizeObserverCallback };
+  constructor(cb: ResizeObserverCallback) {
+    this.entry = { cb };
+    resizeObservers.push(this.entry);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    const idx = resizeObservers.indexOf(this.entry);
+    if (idx >= 0) resizeObservers.splice(idx, 1);
+  }
+}
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+function triggerResizeObservers() {
+  // 快照防止 callback 触发 disconnect 后迭代失效
+  const snapshot = [...resizeObservers];
+  for (const entry of snapshot) {
+    entry.cb([], {} as ResizeObserver);
+  }
+}
+
 const mockInputSpies = vi.hoisted(() => ({
   loadDraft: vi.fn(),
   clear: vi.fn(),
@@ -121,6 +147,7 @@ describe("AIChatContent", () => {
     mockInputSpies.clear.mockReset();
     requestAnimationFrameMock.mockClear();
     cancelAnimationFrameMock.mockClear();
+    resizeObservers.length = 0;
 
     useTabStore.setState({ tabs: [], activeTabId: null });
     useAIStore.setState({
@@ -432,5 +459,126 @@ describe("AIChatContent", () => {
     });
 
     expect(thinkingScroll!.scrollTop).toBe(60);
+  });
+
+  it("auto-follows the outer viewport when the messages container grows after a deferred markdown commit", () => {
+    useAIStore.setState({
+      conversationMessages: {
+        91: [
+          { role: "user", content: "hi", blocks: [] },
+          {
+            role: "assistant",
+            content: "first chunk",
+            blocks: [{ type: "text", content: "first chunk" }],
+            streaming: true,
+          },
+        ],
+      },
+      conversationStreaming: {
+        91: { sending: true, pendingQueue: [] },
+      },
+    });
+
+    const { container } = render(<AIChatContent conversationId={91} />);
+    const viewport = container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+    expect(viewport).toBeTruthy();
+    const { setScrollHeight } = setupScrollableElement(viewport!, {
+      scrollHeight: 300,
+      clientHeight: 200,
+      scrollTop: 100,
+    });
+    // 初始在底部：scrollHeight - scrollTop - clientHeight === 0
+    dispatchScroll(viewport!);
+
+    // 模拟 deferred markdown commit 撑高容器，由 ResizeObserver 把 viewport 拉到新底部
+    setScrollHeight(500);
+    act(() => {
+      triggerResizeObservers();
+    });
+
+    expect(viewport!.scrollTop).toBe(500);
+  });
+
+  it("does not drop follow when content shrinks (e.g. ThinkingBlock collapses) and the browser clamps scrollTop", () => {
+    useAIStore.setState({
+      conversationMessages: {
+        93: [
+          { role: "user", content: "hi", blocks: [] },
+          {
+            role: "assistant",
+            content: "x",
+            blocks: [{ type: "text", content: "x" }],
+            streaming: true,
+          },
+        ],
+      },
+      conversationStreaming: {
+        93: { sending: true, pendingQueue: [] },
+      },
+    });
+
+    const { container } = render(<AIChatContent conversationId={93} />);
+    const viewport = container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+    expect(viewport).toBeTruthy();
+    const { setScrollHeight } = setupScrollableElement(viewport!, {
+      scrollHeight: 600,
+      clientHeight: 200,
+      scrollTop: 400,
+    });
+    // 初始在底部，distance = 0
+    dispatchScroll(viewport!);
+
+    // 内容缩水（典型：ThinkingBlock 完成自动 collapse 把 max-h-64 展开内容收掉），
+    // 浏览器把 scrollTop 钳到新 max（这里手动模拟那一拍）
+    setScrollHeight(400);
+    viewport!.scrollTop = 200;
+    dispatchScroll(viewport!);
+
+    // 跟随不应该被关掉：scrollTop 减小是钳位结果，scrollHeight 同时缩了，不是用户上滑
+    setScrollHeight(700);
+    act(() => {
+      triggerResizeObservers();
+    });
+    expect(viewport!.scrollTop).toBe(700);
+  });
+
+  it("does not pull the outer viewport back to bottom after the user scrolled up", () => {
+    useAIStore.setState({
+      conversationMessages: {
+        92: [
+          { role: "user", content: "hi", blocks: [] },
+          {
+            role: "assistant",
+            content: "first chunk",
+            blocks: [{ type: "text", content: "first chunk" }],
+            streaming: true,
+          },
+        ],
+      },
+      conversationStreaming: {
+        92: { sending: true, pendingQueue: [] },
+      },
+    });
+
+    const { container } = render(<AIChatContent conversationId={92} />);
+    const viewport = container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+    expect(viewport).toBeTruthy();
+    const { setScrollHeight } = setupScrollableElement(viewport!, {
+      scrollHeight: 300,
+      clientHeight: 200,
+      scrollTop: 100,
+    });
+    // 初始进入 isAtBottom = true
+    dispatchScroll(viewport!);
+    // 用户上滑：scrollTop 减小触发 handler 把 isAtBottomRef 设为 false
+    viewport!.scrollTop = 30;
+    dispatchScroll(viewport!);
+
+    setScrollHeight(500);
+    act(() => {
+      triggerResizeObservers();
+    });
+
+    expect(viewport!.scrollTop).toBe(30);
   });
 });

--- a/frontend/src/__tests__/AIChatEditResend.test.tsx
+++ b/frontend/src/__tests__/AIChatEditResend.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AIChatContent } from "@/components/ai/AIChatContent";
-import { useAIStore, type ChatMessage } from "@/stores/aiStore";
+import { useAIStore, type ChatMessage, type PendingQueueItem } from "@/stores/aiStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { useTabStore } from "@/stores/tabStore";
 import { SendAIMessage, StopAIGeneration, SaveConversationMessages } from "../../wailsjs/go/app/App";
@@ -87,7 +87,7 @@ function setupConversationFixture({
   conversationId: number;
   messages: ChatMessage[];
   sending?: boolean;
-  pendingQueue?: Array<{ text: string }>;
+  pendingQueue?: PendingQueueItem[];
   tabId?: string;
 }) {
   useAIStore.setState({
@@ -244,7 +244,10 @@ describe("AIChat edit-and-resend regression", () => {
     setupConversationFixture({
       conversationId,
       sending: true,
-      pendingQueue: [{ text: "queued-1" }, { text: "queued-2" }],
+      pendingQueue: [
+        { id: "q1", text: "queued-1" },
+        { id: "q2", text: "queued-2" },
+      ],
       messages: [
         buildMessage("user", "root question"),
         buildMessage("assistant", "root answer"),

--- a/frontend/src/__tests__/AIChatInput.test.tsx
+++ b/frontend/src/__tests__/AIChatInput.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef } from "react";
 import { AIChatInput, type AIChatInputHandle } from "@/components/ai/AIChatInput";
@@ -30,6 +30,116 @@ describe("AIChatInput", () => {
     const [content] = onSubmit.mock.calls[0];
     expect(content).toBe("hello");
     expect(content).not.toContain("<mention");
+  });
+
+  it("提交后同步清空外部草稿和编辑器内容", async () => {
+    const onSubmit = vi.fn();
+    const onDraftChange = vi.fn();
+    const editorRef = { current: null as Editor | null };
+    const handleRef = createRef<AIChatInputHandle>();
+    render(
+      <AIChatInput
+        ref={handleRef}
+        onSubmit={onSubmit}
+        onDraftChange={onDraftChange}
+        sendOnEnter={true}
+        editorRef={editorRef}
+      />
+    );
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+
+    act(() => {
+      editorRef.current!.chain().focus().insertContent("hello").run();
+      handleRef.current!.submit();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith("hello");
+    expect(onDraftChange).toHaveBeenLastCalledWith({ content: "" });
+    await waitFor(() => expect(editorRef.current!.getText()).toBe(""));
+  });
+
+  it("提交时取消未刷新的草稿节流，避免旧内容尾随写回", async () => {
+    const onSubmit = vi.fn();
+    const onDraftChange = vi.fn();
+    const editorRef = { current: null as Editor | null };
+    const handleRef = createRef<AIChatInputHandle>();
+    render(
+      <AIChatInput
+        ref={handleRef}
+        onSubmit={onSubmit}
+        onDraftChange={onDraftChange}
+        sendOnEnter={true}
+        editorRef={editorRef}
+      />
+    );
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        editorRef.current!.chain().focus().insertContent("hello").run();
+        handleRef.current!.submit();
+      });
+      expect(onDraftChange).toHaveBeenLastCalledWith({ content: "" });
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(onSubmit).toHaveBeenCalledWith("hello");
+      expect(onDraftChange.mock.calls).not.toContainEqual([{ content: "hello" }]);
+      expect(onDraftChange).toHaveBeenLastCalledWith({ content: "" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("IME 组合输入期间 Enter 不触发发送", async () => {
+    const onSubmit = vi.fn();
+    const editorRef = { current: null as Editor | null };
+    render(<AIChatInput onSubmit={onSubmit} sendOnEnter={true} editorRef={editorRef} />);
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+    const editor = screen.getByRole("textbox");
+
+    act(() => {
+      editorRef.current!.chain().focus().insertContent("nihao").run();
+    });
+    fireEvent.compositionStart(editor);
+    fireEvent.keyDown(editor, { key: "Enter", code: "Enter", keyCode: 13 });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("keyCode 229 的 Enter 不触发发送", async () => {
+    const onSubmit = vi.fn();
+    const editorRef = { current: null as Editor | null };
+    render(<AIChatInput onSubmit={onSubmit} sendOnEnter={true} editorRef={editorRef} />);
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+    const editor = screen.getByRole("textbox");
+
+    act(() => {
+      editorRef.current!.chain().focus().insertContent("nihao").run();
+    });
+    fireEvent.keyDown(editor, { key: "Enter", code: "Enter", keyCode: 229 });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("IME 结束后普通 Enter 正常发送", async () => {
+    const onSubmit = vi.fn();
+    const editorRef = { current: null as Editor | null };
+    render(<AIChatInput onSubmit={onSubmit} sendOnEnter={true} editorRef={editorRef} />);
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+    const editor = screen.getByRole("textbox");
+
+    act(() => {
+      editorRef.current!.chain().focus().insertContent("你好").run();
+    });
+    fireEvent.compositionStart(editor);
+    fireEvent.compositionEnd(editor);
+    fireEvent.keyDown(editor, { key: "Enter", code: "Enter", keyCode: 13 });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith("你好"));
   });
 
   it("输入 @ 弹出 MentionList", async () => {

--- a/frontend/src/__tests__/AssistantMessageRetry.test.tsx
+++ b/frontend/src/__tests__/AssistantMessageRetry.test.tsx
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("../i18n", () => ({
+  default: { t: (key: string, fallback?: string) => fallback || key },
+}));
+
+import { AssistantMessage } from "../components/ai/AIChatContent";
+import type { ChatMessage } from "../stores/aiStore";
+
+// 回归 bug: cago 同步 retry 路径下 assistant 占位消息处于 streaming=true、blocks=[]、
+// content="" 状态，AssistantMessage 旧逻辑命中 dot loader 早返回分支，完全不渲染
+// RetryBanner。结果 cago 后端日志显示 retry 2 次，前端 UI 一秒都看不到"重试中"提示，
+// 最终只看到 ErrorBlock。修复:dot loader 分支也必须挂 RetryBanner。
+describe("AssistantMessage retry rendering", () => {
+  const noop = () => {};
+
+  it("streaming 中 + 空 blocks + 有 retryStatus → 渲染 RetryBanner（覆盖 dot loader 分支）", () => {
+    const msg: ChatMessage = {
+      id: "1",
+      role: "assistant",
+      content: "",
+      blocks: [],
+      streaming: true,
+      retryStatus: {
+        attempt: 1,
+        delayMs: 1000,
+        startedAt: Date.now(),
+        cause: "503 service unavailable",
+      },
+    };
+    render(<AssistantMessage msg={msg} index={0} sending={true} onRegenerate={noop} />);
+    // RetryBanner 的 ARIA role="status" 是稳定测试锚点；i18n 文本受 setup mock
+    // 影响（t() 返回 key 而非 fallback），用 role 而非 textContent 断言。
+    const banner = screen.getByRole("status");
+    expect(banner).toBeInTheDocument();
+    // 同时确认 banner 文本里至少包含 retry i18n key（"ai.retry.retrying"）。
+    expect(banner.textContent || "").toMatch(/retry/i);
+  });
+
+  it("有 blocks + retryStatus → hasBlocks 分支也渲染 RetryBanner", () => {
+    const msg: ChatMessage = {
+      id: "2",
+      role: "assistant",
+      content: "Hello",
+      blocks: [{ type: "text", content: "Hello" }],
+      streaming: true,
+      retryStatus: {
+        attempt: 2,
+        delayMs: 2000,
+        startedAt: Date.now(),
+        cause: "503",
+      },
+    };
+    render(<AssistantMessage msg={msg} index={0} sending={true} onRegenerate={noop} />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("RetryBanner 内显示 cause 原文 + classifyError 分类标题", () => {
+    const msg: ChatMessage = {
+      id: "4",
+      role: "assistant",
+      content: "",
+      blocks: [],
+      streaming: true,
+      retryStatus: {
+        attempt: 2,
+        delayMs: 2000,
+        startedAt: Date.now(),
+        cause: "error, status code: 503, status: 503 Service Unavailable, message: No available channel",
+      },
+    };
+    render(<AssistantMessage msg={msg} index={0} sending={true} onRegenerate={noop} />);
+    const banner = screen.getByRole("status");
+    // 原始 cause 必须出现在 banner 内（用户能看到 503 的真实文本和 request id）。
+    expect(banner.textContent).toContain("503 Service Unavailable");
+    expect(banner.textContent).toContain("No available channel");
+  });
+
+  it("无 retryStatus → 不渲染 RetryBanner", () => {
+    const msg: ChatMessage = {
+      id: "3",
+      role: "assistant",
+      content: "",
+      blocks: [],
+      streaming: true,
+    };
+    render(<AssistantMessage msg={msg} index={0} sending={true} onRegenerate={noop} />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/UserMessage.test.tsx
+++ b/frontend/src/__tests__/UserMessage.test.tsx
@@ -58,12 +58,13 @@ describe("UserMessage", () => {
       blocks: [],
     } as any;
 
-    render(<UserMessage msg={msg} onEdit={onEdit} />);
+    render(<UserMessage msg={msg} index={2} onEdit={onEdit} />);
 
     expect(screen.getByRole("button", { name: editButtonName })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: copyButtonName })).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: editButtonName }));
     expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onEdit).toHaveBeenCalledWith(2, msg);
   });
 });

--- a/frontend/src/__tests__/aiError.test.ts
+++ b/frontend/src/__tests__/aiError.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+
+// classifyError 内部读取 i18n.t 取友好标题；测试只关心 kind 分类，message 走 fallback。
+vi.mock("../i18n", () => ({
+  default: { t: (_key: string, fallback: string) => fallback },
+}));
+
+import { classifyError } from "../lib/aiError";
+
+describe("classifyError", () => {
+  it("命中 auth（401/403/api key/unauthorized）", () => {
+    expect(classifyError("401 unauthorized").kind).toBe("auth");
+    expect(classifyError("403 forbidden").kind).toBe("auth");
+    expect(classifyError("invalid_api_key").kind).toBe("auth");
+    expect(classifyError("authentication failed").kind).toBe("auth");
+  });
+
+  it("命中 rate_limit（429/too many/rate limit）", () => {
+    expect(classifyError("429 too many requests").kind).toBe("rate_limit");
+    expect(classifyError("rate_limit_exceeded").kind).toBe("rate_limit");
+  });
+
+  it("命中 network（timeout/EOF/connection reset/i/o timeout/tls handshake）", () => {
+    expect(classifyError("dial tcp: i/o timeout").kind).toBe("network");
+    expect(classifyError("read: connection reset by peer").kind).toBe("network");
+    expect(classifyError("EOF").kind).toBe("network");
+    expect(classifyError("tls handshake timeout").kind).toBe("network");
+  });
+
+  it("命中 server（5xx/service unavailable/bad gateway）", () => {
+    expect(classifyError("503 service unavailable").kind).toBe("server");
+    expect(classifyError("502 bad gateway").kind).toBe("server");
+    expect(classifyError("500 internal server error").kind).toBe("server");
+  });
+
+  it("auth 优先于 server（401 不被 5xx 误捞）", () => {
+    expect(classifyError("provider returned 401: api key unauthorized").kind).toBe("auth");
+  });
+
+  it("rate_limit 优先于 server（429 不被 5xx 误捞）", () => {
+    expect(classifyError("429 rate limit exceeded").kind).toBe("rate_limit");
+  });
+
+  it("空字符串与未知错误归类为 unknown", () => {
+    expect(classifyError("").kind).toBe("unknown");
+    expect(classifyError(null).kind).toBe("unknown");
+    expect(classifyError("some weird message").kind).toBe("unknown");
+  });
+
+  it("显式 kind 跳过正则匹配（用于 interrupted 路径）", () => {
+    expect(classifyError("401 unauthorized", "interrupted").kind).toBe("interrupted");
+    expect(classifyError("429 too many", "interrupted").kind).toBe("interrupted");
+  });
+
+  it("message 字段在所有 kind 上非空", () => {
+    const kinds = ["rate_limit", "server", "network", "auth", "interrupted", "unknown"] as const;
+    for (const k of kinds) {
+      const { message } = classifyError("any", k);
+      expect(message).toBeTruthy();
+    }
+  });
+});

--- a/frontend/src/__tests__/aiStore.mention.test.ts
+++ b/frontend/src/__tests__/aiStore.mention.test.ts
@@ -13,7 +13,7 @@ import { SendAIMessage, CreateConversation, QueueAIMessage } from "../../wailsjs
 // mention 信息现在以内联 <mention> XML 形式写在 content 里，前端不再维护独立的
 // mentions 数组，也不再把 MentionedAssets 塞进 AIContext。这些 case 校验：
 //   - content 原样进入消息体（已经在前端 AIChatInput 里 build 好）
-//   - 排队场景下 QueueAIMessage 只透传 content（标签解析交给后端 prompt builder）
+//   - 排队场景下 QueueAIMessage 透传队列 ID + content（标签解析交给后端 prompt builder）
 //   - AIContext 只包含 openTabs，不再有 mentionedAssets
 
 const mentionXml = '<mention asset-id="42" type="mysql" host="10.0.0.5" group="数据库">@prod-db</mention>';
@@ -74,7 +74,7 @@ describe("aiStore mentions (XML inline)", () => {
     expect(Array.isArray(ctx.openTabs)).toBe(true);
   });
 
-  it("生成中时 sendToTab 把 content 入队并调用 QueueAIMessage(convId, content)", () => {
+  it("生成中时 sendToTab 把 content 入队并调用 QueueAIMessage(convId, queueId, content)", () => {
     useAIStore.setState((s) => ({
       conversationStreaming: {
         ...s.conversationStreaming,
@@ -86,13 +86,15 @@ describe("aiStore mentions (XML inline)", () => {
 
     const q = useAIStore.getState().conversationStreaming[1].pendingQueue;
     expect(q).toHaveLength(1);
-    expect(q[0]).toEqual({ text: content });
+    expect(q[0]?.id).toMatch(/^queue-/);
+    expect(q[0]?.text).toBe(content);
 
     expect(QueueAIMessage).toHaveBeenCalledTimes(1);
     const args = vi.mocked(QueueAIMessage).mock.calls[0];
     expect(args[0]).toBe(1);
-    expect(args[1]).toBe(content);
-    // 旧实现有第三个 MentionedAsset[] 参数；现在签名只剩两个参数。
-    expect(args).toHaveLength(2);
+    expect(args[1]).toBe(q[0]?.id);
+    expect(args[2]).toBe(content);
+    // 旧实现有第三个 MentionedAsset[] 参数；现在第三个参数是 content。
+    expect(args).toHaveLength(3);
   });
 });

--- a/frontend/src/__tests__/aiStore.test.ts
+++ b/frontend/src/__tests__/aiStore.test.ts
@@ -1992,3 +1992,102 @@ describe("ChatMessage.id 稳定性", () => {
     expect(msgs[0].id).not.toBe(msgs[1].id);
   });
 });
+
+// AI 错误处理 & 自动重试：验证 cago EventRetry / EventError 翻译到前端后的状态机行为，
+// 以及 retryStatus → ErrorBlock 物化在退出路径的落盘。
+describe("retry/error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useTabStore.setState({ tabs: [], activeTabId: null });
+    useAIStore.setState({
+      tabStates: {},
+      conversations: [],
+      conversationMessages: {},
+      conversationStreaming: {},
+    });
+    vi.mocked(SendAIMessage).mockResolvedValue(undefined as any);
+    vi.mocked(SaveConversationMessages).mockResolvedValue(undefined as any);
+  });
+
+  async function startStreamingConv(convId: number) {
+    const callbacks: Array<(event: any) => void> = [];
+    vi.mocked(EventsOn).mockImplementation(((_n: string, h: (event: any) => void) => {
+      callbacks.push(h);
+      return () => {};
+    }) as any);
+    const tabId = `ai-${convId}`;
+    useTabStore.setState({
+      tabs: [{ id: tabId, type: "ai", label: "t", meta: { type: "ai", conversationId: convId, title: "t" } }],
+      activeTabId: tabId,
+    });
+    useAIStore.setState({
+      tabStates: { [tabId]: createTabState() },
+      conversationMessages: { [convId]: [] },
+      conversationStreaming: { [convId]: { sending: false, pendingQueue: [] } },
+    });
+    await useAIStore.getState().sendToTab(tabId, "hi");
+    return callbacks;
+  }
+
+  it("retry 事件把 attempt/delayMs/cause 写入 lastAssistant.retryStatus", async () => {
+    const cbs = await startStreamingConv(401);
+    cbs[0]?.({ type: "retry", content: "2", retryDelayMs: 3000, error: "timeout" });
+    const last = useAIStore.getState().conversationMessages[401].at(-1)!;
+    expect(last.role).toBe("assistant");
+    expect(last.retryStatus).toBeTruthy();
+    expect(last.retryStatus!.attempt).toBe(2);
+    expect(last.retryStatus!.delayMs).toBe(3000);
+    expect(last.retryStatus!.cause).toBe("timeout");
+  });
+
+  it("retry 之后到达 tool_start 等非 retry 事件会清掉 retryStatus", async () => {
+    const cbs = await startStreamingConv(402);
+    cbs[0]?.({ type: "retry", content: "1", retryDelayMs: 2000, error: "timeout" });
+    expect(useAIStore.getState().conversationMessages[402].at(-1)?.retryStatus).toBeTruthy();
+    cbs[0]?.({ type: "tool_start", tool_name: "bash", tool_input: "{}", tool_call_id: "t1" });
+    expect(useAIStore.getState().conversationMessages[402].at(-1)?.retryStatus).toBeUndefined();
+  });
+
+  it("error 事件 push 一个 ErrorBlock 并 classify 分类", async () => {
+    const cbs = await startStreamingConv(403);
+    cbs[0]?.({ type: "error", error: "401 unauthorized: invalid api key" });
+    const last = useAIStore.getState().conversationMessages[403].at(-1)!;
+    const err = last.blocks.find((b) => b.type === "error");
+    expect(err).toBeTruthy();
+    expect(err?.errorKind).toBe("auth");
+    expect(err?.errorDetail).toContain("401");
+    expect(last.streaming).toBe(false);
+    expect(useAIStore.getState().conversationStreaming[403]?.sending).toBe(false);
+  });
+
+  it("stopped 事件清 retryStatus 但不 push ErrorBlock", async () => {
+    const cbs = await startStreamingConv(404);
+    cbs[0]?.({ type: "retry", content: "1", retryDelayMs: 1000, error: "timeout" });
+    cbs[0]?.({ type: "stopped" });
+    const last = useAIStore.getState().conversationMessages[404].at(-1)!;
+    expect(last.retryStatus).toBeUndefined();
+    expect(last.blocks.some((b) => b.type === "error")).toBe(false);
+  });
+
+  it("includeStreaming 落盘时把 retryStatus 物化成 kind=interrupted 的 ErrorBlock", async () => {
+    const cbs = await startStreamingConv(405);
+    cbs[0]?.({ type: "retry", content: "2", retryDelayMs: 5000, error: "connection reset" });
+    // 模拟应用退出 / 关 tab：触发 flushAllConversationsAsync 调 SaveConversationMessages(toDisplayMessages(.., true))
+    vi.mocked(SaveConversationMessages).mockClear();
+    const ev = useAIStore.getState();
+    // 直接通过 conversationMessages 验证 toDisplayMessages 路径：调用一次关闭 tab 触发 persist
+    useTabStore.getState().closeTab("ai-405");
+    await waitForStoreCondition(() => vi.mocked(SaveConversationMessages).mock.calls.length > 0);
+    const calls = vi.mocked(SaveConversationMessages).mock.calls;
+    const lastSaved = calls.at(-1)![1] as any[];
+    const lastMsg = lastSaved.at(-1);
+    const errBlock = lastMsg.blocks.find((b: any) => b.type === "error");
+    expect(errBlock).toBeTruthy();
+    expect(errBlock.errorKind).toBe("interrupted");
+    expect(errBlock.errorDetail).toBe("connection reset");
+    // 序列化结果中不应该有 retryStatus（ConversationDisplayMessage 没有该字段）。
+    expect((lastMsg as any).retryStatus).toBeUndefined();
+    void ev;
+  });
+});

--- a/frontend/src/__tests__/aiStore.test.ts
+++ b/frontend/src/__tests__/aiStore.test.ts
@@ -17,6 +17,8 @@ import {
   StopAIGeneration,
   SaveConversationMessages,
   UpdateConversationTitle,
+  RemoveQueuedAIMessage,
+  ClearQueuedAIMessages,
 } from "../../wailsjs/go/app/App";
 import { EventsOn } from "../../wailsjs/runtime/runtime";
 
@@ -401,7 +403,7 @@ describe("aiStore", () => {
           ],
         },
         conversationStreaming: {
-          3: { sending: true, pendingQueue: [{ text: "queued-1" }] },
+          3: { sending: true, pendingQueue: [{ id: "q1", text: "queued-1" }] },
         },
       });
 
@@ -412,7 +414,7 @@ describe("aiStore", () => {
       expect(useAIStore.getState().conversationMessages[3][1].content).toBe("partial");
       expect(useAIStore.getState().conversationStreaming[3]).toEqual({
         sending: true,
-        pendingQueue: [{ text: "queued-1" }],
+        pendingQueue: [{ id: "q1", text: "queued-1" }],
       });
     });
   });
@@ -502,13 +504,84 @@ describe("conversationMessages (Phase 1)", () => {
   it("getStreamingByConversationId reflects streaming state", () => {
     useAIStore.setState({
       conversationStreaming: {
-        42: { sending: true, pendingQueue: [{ text: "q1" }, { text: "q2" }] },
+        42: {
+          sending: true,
+          pendingQueue: [
+            { id: "pq1", text: "q1" },
+            { id: "pq2", text: "q2" },
+          ],
+        },
       },
     });
     expect(useAIStore.getState().getStreamingByConversationId(42)).toEqual({
       sending: true,
-      pendingQueue: [{ text: "q1" }, { text: "q2" }],
+      pendingQueue: [
+        { id: "pq1", text: "q1" },
+        { id: "pq2", text: "q2" },
+      ],
     });
+  });
+
+  it("removeFromQueue removes only backend-confirmed pending steer", async () => {
+    vi.mocked(RemoveQueuedAIMessage).mockResolvedValueOnce(true as any);
+    useAIStore.setState({
+      conversationStreaming: {
+        42: {
+          sending: true,
+          pendingQueue: [
+            { id: "q1", text: "first" },
+            { id: "q2", text: "second" },
+          ],
+        },
+      },
+    });
+
+    await useAIStore.getState().removeFromQueue(42, 1);
+
+    expect(RemoveQueuedAIMessage).toHaveBeenCalledWith(42, "q2");
+    expect(useAIStore.getState().conversationStreaming[42].pendingQueue).toEqual([{ id: "q1", text: "first" }]);
+  });
+
+  it("removeFromQueue keeps local queue when backend says the steer was already consumed", async () => {
+    vi.mocked(RemoveQueuedAIMessage).mockResolvedValueOnce(false as any);
+    useAIStore.setState({
+      conversationStreaming: {
+        42: {
+          sending: true,
+          pendingQueue: [
+            { id: "q1", text: "first" },
+            { id: "q2", text: "second" },
+          ],
+        },
+      },
+    });
+
+    await useAIStore.getState().removeFromQueue(42, 1);
+
+    expect(useAIStore.getState().conversationStreaming[42].pendingQueue).toEqual([
+      { id: "q1", text: "first" },
+      { id: "q2", text: "second" },
+    ]);
+  });
+
+  it("clearQueue removes only ids confirmed by backend", async () => {
+    vi.mocked(ClearQueuedAIMessages).mockResolvedValueOnce(["q1"] as any);
+    useAIStore.setState({
+      conversationStreaming: {
+        42: {
+          sending: true,
+          pendingQueue: [
+            { id: "q1", text: "first" },
+            { id: "q2", text: "second" },
+          ],
+        },
+      },
+    });
+
+    await useAIStore.getState().clearQueue(42);
+
+    expect(ClearQueuedAIMessages).toHaveBeenCalledWith(42);
+    expect(useAIStore.getState().conversationStreaming[42].pendingQueue).toEqual([{ id: "q2", text: "second" }]);
   });
 
   it("sendToTab writes only to conversationMessages for an existing conversation", async () => {
@@ -941,7 +1014,15 @@ describe("editAndResendConversation", () => {
 
     await useAIStore.getState().sendFromSidebarTab("sidebar-55", "original");
     useAIStore.setState({
-      conversationStreaming: { 55: { sending: true, pendingQueue: [{ text: "queued-1" }, { text: "queued-2" }] } },
+      conversationStreaming: {
+        55: {
+          sending: true,
+          pendingQueue: [
+            { id: "q1", text: "queued-1" },
+            { id: "q2", text: "queued-2" },
+          ],
+        },
+      },
     });
     vi.mocked(StopAIGeneration).mockImplementation(async () => {
       callbacks[0]?.({ type: "stopped" });
@@ -1432,7 +1513,13 @@ describe("sidebar and main tab multi-host behavior", () => {
     await useAIStore.getState().sendFromSidebarTab("sidebar-live", "first");
     useAIStore.setState({
       conversationStreaming: {
-        60: { sending: true, pendingQueue: [{ text: "queued-1" }, { text: "queued-2" }] },
+        60: {
+          sending: true,
+          pendingQueue: [
+            { id: "q1", text: "queued-1" },
+            { id: "q2", text: "queued-2" },
+          ],
+        },
       },
     });
 
@@ -1447,7 +1534,10 @@ describe("sidebar and main tab multi-host behavior", () => {
 
     expect(useAIStore.getState().conversationStreaming[60]).toEqual({
       sending: false,
-      pendingQueue: [{ text: "queued-1" }, { text: "queued-2" }],
+      pendingQueue: [
+        { id: "q1", text: "queued-1" },
+        { id: "q2", text: "queued-2" },
+      ],
     });
     expect(vi.mocked(SendAIMessage)).toHaveBeenCalledTimes(1);
   });
@@ -1603,6 +1693,109 @@ describe("DeepSeek-v4 多轮 tool 调用历史展开", () => {
   });
 });
 
+describe("stream buffer batching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useTabStore.setState({ tabs: [], activeTabId: null });
+    useAIStore.setState({
+      tabStates: {},
+      conversations: [],
+      conversationMessages: {},
+      conversationStreaming: {},
+    });
+    vi.mocked(SendAIMessage).mockResolvedValue(undefined as any);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function startStreamingConversation(convId: number) {
+    const callbacks: Array<(event: any) => void> = [];
+    vi.mocked(EventsOn).mockImplementation(((_eventName: string, handler: (event: any) => void) => {
+      callbacks.push(handler);
+      return () => {};
+    }) as any);
+
+    const tabId = `ai-${convId}`;
+    useTabStore.setState({
+      tabs: [{ id: tabId, type: "ai", label: "t", meta: { type: "ai", conversationId: convId, title: "t" } }],
+      activeTabId: tabId,
+    });
+    useAIStore.setState({
+      tabStates: { [tabId]: createTabState() },
+      conversationMessages: { [convId]: [] },
+      conversationStreaming: { [convId]: { sending: false, pendingQueue: [] } },
+    });
+
+    await useAIStore.getState().sendToTab(tabId, "hi");
+    return callbacks;
+  }
+
+  it("content 事件在 50ms 窗口内合并成一次消息更新", async () => {
+    const callbacks = await startStreamingConversation(201);
+    let messageUpdates = 0;
+    const unsubscribe = useAIStore.subscribe((state, previous) => {
+      if (state.conversationMessages[201] !== previous.conversationMessages[201]) {
+        messageUpdates += 1;
+      }
+    });
+
+    callbacks[0]?.({ type: "content", content: "Hel" });
+    callbacks[0]?.({ type: "content", content: "lo " });
+    callbacks[0]?.({ type: "content", content: "world" });
+
+    expect(useAIStore.getState().conversationMessages[201].at(-1)?.content).toBe("");
+    expect(messageUpdates).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(49);
+    expect(useAIStore.getState().conversationMessages[201].at(-1)?.content).toBe("");
+    expect(messageUpdates).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    unsubscribe();
+
+    const assistant = useAIStore.getState().conversationMessages[201].at(-1)!;
+    expect(assistant.content).toBe("Hello world");
+    expect(assistant.blocks).toEqual([{ type: "text", content: "Hello world" }]);
+    expect(messageUpdates).toBe(1);
+  });
+
+  it("thinking 事件同样按窗口合并到 running thinking block", async () => {
+    const callbacks = await startStreamingConversation(202);
+
+    callbacks[0]?.({ type: "thinking", content: "step 1" });
+    callbacks[0]?.({ type: "thinking", content: "\nstep 2" });
+
+    expect(useAIStore.getState().conversationMessages[202].at(-1)?.blocks).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    const assistant = useAIStore.getState().conversationMessages[202].at(-1)!;
+    expect(assistant.content).toBe("");
+    expect(assistant.blocks).toEqual([{ type: "thinking", content: "step 1\nstep 2", status: "running" }]);
+  });
+
+  it("非流式事件会先 flush 缓冲并取消未触发 timer", async () => {
+    const callbacks = await startStreamingConversation(203);
+
+    callbacks[0]?.({ type: "content", content: "final text" });
+    callbacks[0]?.({ type: "done" });
+
+    let assistant = useAIStore.getState().conversationMessages[203].at(-1)!;
+    expect(assistant.content).toBe("final text");
+    expect(assistant.streaming).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    assistant = useAIStore.getState().conversationMessages[203].at(-1)!;
+    expect(assistant.content).toBe("final text");
+    expect(assistant.blocks).toEqual([{ type: "text", content: "final text" }]);
+  });
+});
+
 describe("queue_consumed handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1648,6 +1841,48 @@ describe("queue_consumed handler", () => {
     expect(msgs[4].streaming).toBe(true);
     expect(msgs[4].content).toBe("");
     expect(msgs[4].blocks).toEqual([]);
+  });
+
+  it("queue_consumed 带 queue_id 时按 id 移除本地 pendingQueue", async () => {
+    const callbacks: Array<(event: any) => void> = [];
+    vi.mocked(EventsOn).mockImplementation(((_eventName: string, handler: (event: any) => void) => {
+      callbacks.push(handler);
+      return () => {};
+    }) as any);
+
+    const tabId = "ai-102";
+    useTabStore.setState({
+      tabs: [{ id: tabId, type: "ai", label: "t", meta: { type: "ai", conversationId: 102, title: "t" } }],
+      activeTabId: tabId,
+    });
+    useAIStore.setState({
+      tabStates: { [tabId]: createTabState() },
+      conversationMessages: { 102: [] },
+      conversationStreaming: { 102: { sending: false, pendingQueue: [] } },
+    });
+
+    await useAIStore.getState().sendToTab(tabId, "hi");
+    useAIStore.setState({
+      conversationStreaming: {
+        102: {
+          sending: true,
+          pendingQueue: [
+            { id: "q1", text: "first" },
+            { id: "q2", text: "second" },
+          ],
+        },
+      },
+    });
+
+    callbacks[0]?.({ type: "queue_consumed", queue_id: "q2", content: "second" });
+
+    expect(useAIStore.getState().conversationStreaming[102].pendingQueue).toEqual([{ id: "q1", text: "first" }]);
+    const msgs = useAIStore.getState().conversationMessages[102];
+    expect(msgs.map((m) => [m.role, m.content])).toEqual([
+      ["user", "hi"],
+      ["user", "second"],
+      ["assistant", ""],
+    ]);
   });
 
   // 反向：LLM 已经写过内容的 assistant 必须保留（设 streaming:false），

--- a/frontend/src/__tests__/aiStore.test.ts
+++ b/frontend/src/__tests__/aiStore.test.ts
@@ -883,7 +883,16 @@ describe("sidebar state", () => {
       .mockResolvedValueOnce([{ ID: 89, Title: "sidebar first", Updatetime: 0 }] as any)
       .mockResolvedValue([{ ID: 89, Title: "sidebar first", Updatetime: 1 }] as any);
     useAIStore.setState({
-      sidebarTabs: [buildSidebarTab("sidebar-89", null)],
+      sidebarTabs: [
+        {
+          ...buildSidebarTab("sidebar-89", null),
+          uiState: {
+            inputDraft: { content: "stale draft" },
+            scrollTop: 120,
+            editTarget: null,
+          },
+        },
+      ],
       activeSidebarTabId: "sidebar-89",
     });
 
@@ -892,6 +901,11 @@ describe("sidebar state", () => {
     expect(UpdateConversationTitle).toHaveBeenCalledWith(89, "sidebar first");
     expect(useAIStore.getState().sidebarTabs[0].conversationId).toBe(89);
     expect(useAIStore.getState().sidebarTabs[0].title).toBe("sidebar first");
+    expect(useAIStore.getState().sidebarTabs[0].uiState).toEqual({
+      inputDraft: { content: "" },
+      scrollTop: 0,
+      editTarget: null,
+    });
     expect(vi.mocked(EventsOn).mock.calls.some((c) => c[0] === "ai:event:89")).toBe(true);
   });
 

--- a/frontend/src/__tests__/aiStore.test.ts
+++ b/frontend/src/__tests__/aiStore.test.ts
@@ -1175,7 +1175,7 @@ describe("editAndResendConversation", () => {
   });
 });
 
-describe("persistence debounce & streaming snapshot", () => {
+describe("AI conversation persistence", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
@@ -1196,7 +1196,7 @@ describe("persistence debounce & streaming snapshot", () => {
     vi.useRealTimers();
   });
 
-  it("persists user message immediately and debounces follow-up streaming snapshot", async () => {
+  it("persists user message immediately without scheduling an assistant placeholder snapshot", async () => {
     const tabId = "ai-100";
     useTabStore.setState({
       tabs: [{ id: tabId, type: "ai", label: "t", meta: { type: "ai", conversationId: 100, title: "t" } }],
@@ -1204,14 +1204,14 @@ describe("persistence debounce & streaming snapshot", () => {
     });
     useAIStore.setState({ tabStates: { [tabId]: createTabState() } });
 
-    // sendToTab 新行为：用户消息立即落盘一次（避免防抖窗口内崩溃丢失用户输入），
-    // 紧接着的 assistant placeholder 更新走 300ms 防抖。
+    // 用户消息立即落盘一次，紧接着的 assistant placeholder 只更新内存，
+    // 等后续关键事件或终态再落盘。
     await useAIStore.getState().sendToTab(tabId, "hi");
     expect(SaveConversationMessages).toHaveBeenCalledTimes(1);
     expect(vi.mocked(SaveConversationMessages).mock.calls[0][0]).toBe(100);
 
     await vi.advanceTimersByTimeAsync(300);
-    expect(SaveConversationMessages).toHaveBeenCalledTimes(2);
+    expect(SaveConversationMessages).toHaveBeenCalledTimes(1);
   });
 
   it("normalizes running/pending_confirm blocks when persisting a streaming snapshot", async () => {
@@ -1241,7 +1241,6 @@ describe("persistence debounce & streaming snapshot", () => {
     });
 
     await useAIStore.getState().sendToTab(tabId, "next");
-    await vi.advanceTimersByTimeAsync(300);
 
     expect(SaveConversationMessages).toHaveBeenCalled();
     const [, displayMsgs] = vi.mocked(SaveConversationMessages).mock.calls[0];
@@ -1250,7 +1249,7 @@ describe("persistence debounce & streaming snapshot", () => {
     expect(assistant.blocks.map((b: any) => b.status)).toEqual(["cancelled", "cancelled", "completed"]);
   });
 
-  it("clears pending persist timer when closing the AI tab", async () => {
+  it("flushes a final snapshot when closing the AI tab", async () => {
     const tabId = "ai-102";
     useTabStore.setState({
       tabs: [{ id: tabId, type: "ai", label: "t", meta: { type: "ai", conversationId: 102, title: "t" } }],
@@ -1258,15 +1257,14 @@ describe("persistence debounce & streaming snapshot", () => {
     });
     useAIStore.setState({ tabStates: { [tabId]: createTabState() } });
 
-    // sendToTab 会立即落盘一次（用户消息），后续 assistant placeholder 走 300ms 防抖。
     await useAIStore.getState().sendToTab(tabId, "hi");
     expect(SaveConversationMessages).toHaveBeenCalledTimes(1);
 
-    // 关闭标签要取消待定的防抖定时器，并同步 flush 一次最终快照。
+    // 关闭标签同步 flush 一次最终快照。
     useTabStore.getState().closeTab(tabId);
     expect(SaveConversationMessages).toHaveBeenCalledTimes(2);
 
-    // 定时器已被清理，300ms 后不应再产生额外保存。
+    // 没有会话消息定时落盘，300ms 后不应再产生额外保存。
     await vi.advanceTimersByTimeAsync(300);
     expect(SaveConversationMessages).toHaveBeenCalledTimes(2);
   });

--- a/frontend/src/__tests__/aiStore.test.ts
+++ b/frontend/src/__tests__/aiStore.test.ts
@@ -1933,3 +1933,62 @@ describe("queue_consumed handler", () => {
     expect(msgs[3].blocks).toEqual([]);
   });
 });
+
+describe("ChatMessage.id 稳定性", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useTabStore.setState({ tabs: [], activeTabId: null });
+    vi.mocked(SendAIMessage).mockResolvedValue(undefined as any);
+  });
+
+  // 回归 Copilot review：index 作 key 时，edit&resend / queue_consumed 截断重插会让
+  // React 复用错误 fiber，ToolBlock/ThinkingBlock 的 expanded 等本地 state 串到别的消息。
+  // 修复方式是给 ChatMessage 分配稳定 id，且新插消息 id 必须与旧消息不同。
+  it("send + queue_consumed 写入的消息都有唯一 id", async () => {
+    const callbacks: Array<(event: any) => void> = [];
+    vi.mocked(EventsOn).mockImplementation(((_eventName: string, handler: (event: any) => void) => {
+      callbacks.push(handler);
+      return () => {};
+    }) as any);
+
+    const tabId = "ai-200";
+    useTabStore.setState({
+      tabs: [{ id: tabId, type: "ai", label: "t", meta: { type: "ai", conversationId: 200, title: "t" } }],
+      activeTabId: tabId,
+    });
+    useAIStore.setState({
+      tabStates: { [tabId]: createTabState() },
+      conversationMessages: { 200: [] },
+      conversationStreaming: { 200: { sending: false, pendingQueue: [] } },
+    });
+
+    await useAIStore.getState().sendToTab(tabId, "hi");
+    callbacks[0]?.({ type: "content", content: "answer" });
+    callbacks[0]?.({ type: "queue_consumed", content: "next" });
+
+    const msgs = useAIStore.getState().conversationMessages[200];
+    const ids = msgs.map((m) => m.id);
+    expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("convertDisplayMessages 给从后端加载的每条消息分配 id", async () => {
+    vi.mocked(LoadConversationMessages).mockResolvedValue([
+      { role: "user", content: "a", blocks: [] },
+      { role: "assistant", content: "b", blocks: [] },
+    ] as any);
+    useAIStore.setState({
+      conversationMessages: {},
+      conversationStreaming: {},
+    });
+
+    await useAIStore.getState().openConversationTab(300);
+    await waitForStoreCondition(() => (useAIStore.getState().conversationMessages[300] || []).length === 2);
+
+    const msgs = useAIStore.getState().conversationMessages[300];
+    expect(msgs[0].id).toBeTruthy();
+    expect(msgs[1].id).toBeTruthy();
+    expect(msgs[0].id).not.toBe(msgs[1].id);
+  });
+});

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -200,9 +200,6 @@ export function AIChatContent({
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<AIChatInputHandle>(null);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
-  // 观察消息容器尺寸，useDeferredValue 让 markdown 异步 commit 撑高 scrollHeight 时，
-  // 这里是仅存的回调入口——没有它，messages effect 永远拿不到 deferred commit 后的真实高度。
-  const contentRef = useRef<HTMLDivElement>(null);
   // Radix ScrollArea 的 viewport 是内部 div，原先每个 effect 都 querySelector 一次；
   // 流式时 messages effect 按帧触发，querySelector 累积成本不小。这里把首次查找结果缓存，
   // 同时用 isConnected 兜底 Radix 重建子树的边角场景。
@@ -248,22 +245,6 @@ export function AIChatContent({
       bottomRef.current?.scrollIntoView({ behavior: "auto" });
     }
   }, [messages, getViewport]);
-
-  useEffect(() => {
-    // useDeferredValue 让 markdown 异步 commit：messages effect 跑完后 scrollHeight 还在增长，
-    // 没有 scroll 事件、没有下一段 chunk 来兜底——只有内容容器的 resize 回调能把视图重新拉到底。
-    const viewport = getViewport();
-    const content = contentRef.current;
-    if (!viewport || !content || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(() => {
-      if (!isAtBottomRef.current) return;
-      if (viewport.scrollTop !== viewport.scrollHeight) {
-        viewport.scrollTop = viewport.scrollHeight;
-      }
-    });
-    ro.observe(content);
-    return () => ro.disconnect();
-  }, [getViewport]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -460,7 +441,7 @@ export function AIChatContent({
       <div className="flex h-full flex-col" data-compact={compact}>
         {/* Messages */}
         <ScrollArea ref={scrollAreaRef} className="flex-1 min-h-0 overflow-hidden">
-          <div ref={contentRef} className="max-w-3xl mx-auto p-4 space-y-6">
+          <div className="max-w-3xl mx-auto p-4 space-y-6">
             {messages.length === 0 && (
               <p className="text-sm text-muted-foreground text-center mt-16">{t("ai.placeholder")}</p>
             )}

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, useMemo, memo, useCallback } from "react";
+import { useState, useRef, useEffect, useMemo, memo, useCallback, useDeferredValue } from "react";
+import { useShallow } from "zustand/shallow";
 import {
   Loader2,
   CornerDownLeft,
@@ -54,6 +55,21 @@ import { CompactContext, useCompact } from "@/components/ai/AIChatContentContext
 // 常量化 Markdown 插件数组，避免每次渲染创建新引用导致 Markdown 重解析
 const mdRemarkPlugins = [remarkGfm];
 const mdRehypePlugins = [rehypeSanitize];
+
+// 流式输出时整段 markdown 会按 RAF 频率重新塞进 <Markdown>。
+// react-markdown 是同步主线程解析，长文本下会直接卡住键盘 IME。
+// 这里加两层保护：
+//   1. memo 让"内容没变"的历史 block 一次也不重渲染（参数 content 是稳定字符串引用）。
+//   2. useDeferredValue 让正在增长的最后一个 block 在主线程有更高优先级任务（按键）时
+//      自动让位，等空闲帧再渲染——React 19 并发渲染会自然兜住延迟。
+const MarkdownContent = memo(function MarkdownContent({ content }: { content: string }) {
+  const deferred = useDeferredValue(content);
+  return (
+    <Markdown remarkPlugins={mdRemarkPlugins} rehypePlugins={mdRehypePlugins}>
+      {deferred}
+    </Markdown>
+  );
+});
 // 统一助手消息选中态样式，避免不同气泡的选区反馈不一致。
 const messageSelectionClass = "select-text selection:bg-primary/25 selection:text-foreground";
 
@@ -113,8 +129,11 @@ export function AIChatContent({
   onStopOverride,
 }: AIChatContentProps) {
   const { t } = useTranslation();
+  // 只订阅必要的标量字段：之前 `useAIStore()` 整体解构会让本组件订阅整张 store，
+  // 任何其它会话的流式 chunk、conversation list 增删、sidebar tab 抖动都会触发重渲染。
+  const configured = useAIStore((s) => s.configured);
+  // Actions 在 store 初始化后引用稳定；useShallow 让对象级浅比较恒为 true，永不触发重渲染。
   const {
-    configured,
     sendToTab,
     stopGeneration,
     regenerate,
@@ -125,7 +144,20 @@ export function AIChatContent({
     setSidebarTabInputDraft,
     setSidebarTabEditTarget,
     setSidebarTabScrollTop,
-  } = useAIStore();
+  } = useAIStore(
+    useShallow((s) => ({
+      sendToTab: s.sendToTab,
+      stopGeneration: s.stopGeneration,
+      regenerate: s.regenerate,
+      regenerateConversation: s.regenerateConversation,
+      removeFromQueue: s.removeFromQueue,
+      clearQueue: s.clearQueue,
+      editAndResendConversation: s.editAndResendConversation,
+      setSidebarTabInputDraft: s.setSidebarTabInputDraft,
+      setSidebarTabEditTarget: s.setSidebarTabEditTarget,
+      setSidebarTabScrollTop: s.setSidebarTabScrollTop,
+    }))
+  );
   const derivedConvId = useTabStore((s) => {
     if (!tabId) return null;
     const tab = s.tabs.find((x) => x.id === tabId);
@@ -146,17 +178,21 @@ export function AIChatContent({
     conversationId != null ? s.conversationStreaming[conversationId] || DEFAULT_STREAMING : DEFAULT_STREAMING
   );
   const { sending, pendingQueue } = streaming;
-  // 从最新到最旧收集非空用户消息，用 useMemo 避免无关渲染也构造新数组。
-  const userMessageHistory = useMemo(() => {
-    const history: string[] = [];
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.role === "user" && msg.content.trim()) {
-        history.push(msg.content);
+  // 直接走 zustand 选择器 + 浅比较：流式只改最后一条 assistant 消息时，
+  // 用户消息序列保持引用稳定，AIChatInput 不会因为父组件每帧重渲染而被波及。
+  const userMessageHistory = useAIStore(
+    useShallow((s) => {
+      const msgs = conversationId != null ? s.conversationMessages[conversationId] || EMPTY_MESSAGES : EMPTY_MESSAGES;
+      const history: string[] = [];
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        const msg = msgs[i];
+        if (msg.role === "user" && msg.content.trim()) {
+          history.push(msg.content);
+        }
       }
-    }
-    return history;
-  }, [messages]);
+      return history;
+    })
+  );
 
   const [regenerateTarget, setRegenerateTarget] = useState<number | null>(null);
   const [localEditTarget, setLocalEditTarget] = useState<EditTarget | null>(null);
@@ -164,12 +200,70 @@ export function AIChatContent({
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<AIChatInputHandle>(null);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
+  // 观察消息容器尺寸，useDeferredValue 让 markdown 异步 commit 撑高 scrollHeight 时，
+  // 这里是仅存的回调入口——没有它，messages effect 永远拿不到 deferred commit 后的真实高度。
+  const contentRef = useRef<HTMLDivElement>(null);
+  // Radix ScrollArea 的 viewport 是内部 div，原先每个 effect 都 querySelector 一次；
+  // 流式时 messages effect 按帧触发，querySelector 累积成本不小。这里把首次查找结果缓存，
+  // 同时用 isConnected 兜底 Radix 重建子树的边角场景。
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const getViewport = useCallback((): HTMLDivElement | null => {
+    if (viewportRef.current?.isConnected) return viewportRef.current;
+    const v = scrollAreaRef.current?.querySelector("[data-radix-scroll-area-viewport]") as HTMLDivElement | null;
+    viewportRef.current = v;
+    return v;
+  }, []);
   const previousConversationIdRef = useRef<number | null | undefined>(conversationId);
+  // 跟随滚动开关:用户在(接近)底部时为 true,流式追加内容会自动滚到底;
+  // 用户主动向上滚动后变为 false,后续消息不再打断阅读位置。重新滚到底部即恢复跟随。
+  const isAtBottomRef = useRef(true);
+  // 已经因为出现而自动滚动过的 approval confirmId 集合,避免对同一个审批反复抢回视图。
+  const seenApprovalIdsRef = useRef<Set<string>>(new Set());
   const editTarget = sideTabId ? sidebarEditTarget : localEditTarget;
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+    seenApprovalIdsRef.current = new Set();
+  }, [conversationId]);
+
+  useEffect(() => {
+    // 新出现待确认的审批一定要把视图拉回底部,审批是阻塞动作,用户必须看到。
+    let hasNewApproval = false;
+    for (const msg of messages) {
+      if (!msg.blocks) continue;
+      for (const block of msg.blocks) {
+        if (block.type !== "approval" || block.status !== "pending_confirm" || !block.confirmId) continue;
+        if (!seenApprovalIdsRef.current.has(block.confirmId)) {
+          seenApprovalIdsRef.current.add(block.confirmId);
+          hasNewApproval = true;
+        }
+      }
+    }
+    if (!hasNewApproval && !isAtBottomRef.current) return;
+    const viewport = getViewport();
+    if (viewport) {
+      // 流式过程中用 instant 滚动避免和持续增长的 scrollHeight 互相追赶导致跟随判定抖动。
+      viewport.scrollTop = viewport.scrollHeight;
+      isAtBottomRef.current = true;
+    } else {
+      bottomRef.current?.scrollIntoView({ behavior: "auto" });
+    }
+  }, [messages, getViewport]);
+
+  useEffect(() => {
+    // useDeferredValue 让 markdown 异步 commit：messages effect 跑完后 scrollHeight 还在增长，
+    // 没有 scroll 事件、没有下一段 chunk 来兜底——只有内容容器的 resize 回调能把视图重新拉到底。
+    const viewport = getViewport();
+    const content = contentRef.current;
+    if (!viewport || !content || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => {
+      if (!isAtBottomRef.current) return;
+      if (viewport.scrollTop !== viewport.scrollHeight) {
+        viewport.scrollTop = viewport.scrollHeight;
+      }
+    });
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [getViewport]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -227,17 +321,35 @@ export function AIChatContent({
   }, [conversationId, editTarget, messages, resetEditMode]);
 
   useEffect(() => {
-    if (!sideTabId) return;
-    const viewport = scrollAreaRef.current?.querySelector("[data-radix-scroll-area-viewport]") as HTMLDivElement | null;
+    const viewport = getViewport();
     if (!viewport) return;
-    const handleScroll = () => {
-      setSidebarTabScrollTop(sideTabId, viewport.scrollTop);
-    };
     // 滚动位置同样按宿主维度恢复，保证多个侧边 tab 来回切换时各自停在原来的阅读位置。
-    viewport.scrollTop = useAIStore.getState().sidebarTabs.find((tab) => tab.id === sideTabId)?.uiState.scrollTop ?? 0;
+    if (sideTabId) {
+      viewport.scrollTop =
+        useAIStore.getState().sidebarTabs.find((tab) => tab.id === sideTabId)?.uiState.scrollTop ?? 0;
+    }
+    let lastScrollTop = viewport.scrollTop;
+    // 初始按几何判定一次：短内容/刚加载都视为在底部、开启跟随。
+    isAtBottomRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 50;
+    const handleScroll = () => {
+      const currentTop = viewport.scrollTop;
+      // 关键：只有 scrollTop "向上"移动才视为用户主动离开底部、关掉跟随。
+      // 向下方向（程序 scrollTop = scrollHeight、或用户滑回底部）只用来恢复跟随，永不主动关。
+      // 这样 useDeferredValue 让 markdown 异步撑高 scrollHeight 时，
+      // 后到的 scroll 事件即便看到"几何上不在底部"，也不会把跟随误关。50px 余量容忍 sub-pixel/边距差异。
+      if (currentTop < lastScrollTop) {
+        isAtBottomRef.current = false;
+      } else if (viewport.scrollHeight - currentTop - viewport.clientHeight <= 50) {
+        isAtBottomRef.current = true;
+      }
+      lastScrollTop = currentTop;
+      if (sideTabId) {
+        setSidebarTabScrollTop(sideTabId, currentTop);
+      }
+    };
     viewport.addEventListener("scroll", handleScroll, { passive: true });
     return () => viewport.removeEventListener("scroll", handleScroll);
-  }, [conversationId, setSidebarTabScrollTop, sideTabId]);
+  }, [conversationId, getViewport, setSidebarTabScrollTop, sideTabId]);
 
   const handleSend = useCallback(
     (content: string) => {
@@ -313,6 +425,17 @@ export function AIChatContent({
     [conversationId, setSidebarTabEditTarget, sideTabId]
   );
 
+  // 草稿写回侧边态。useCallback 提供稳定引用，否则 AIChatInput memo 失效，
+  // 父组件每次流式重渲染都会让输入框跟着重渲染。
+  const handleDraftChange = useCallback(
+    (draft: AIChatInputDraft) => {
+      if (sideTabId) {
+        setSidebarTabInputDraft(sideTabId, draft);
+      }
+    },
+    [setSidebarTabInputDraft, sideTabId]
+  );
+
   const confirmRegenerate = () => {
     if (regenerateTarget !== null) {
       if (tabId) {
@@ -337,7 +460,7 @@ export function AIChatContent({
       <div className="flex h-full flex-col" data-compact={compact}>
         {/* Messages */}
         <ScrollArea ref={scrollAreaRef} className="flex-1 min-h-0 overflow-hidden">
-          <div className="max-w-3xl mx-auto p-4 space-y-6">
+          <div ref={contentRef} className="max-w-3xl mx-auto p-4 space-y-6">
             {messages.length === 0 && (
               <p className="text-sm text-muted-foreground text-center mt-16">{t("ai.placeholder")}</p>
             )}
@@ -350,7 +473,7 @@ export function AIChatContent({
               return (
                 <div key={i} className="text-sm" style={cvStyle}>
                   {msg.role === "user" ? (
-                    <UserMessage msg={msg} onEdit={() => handleEditMessage(i, msg)} />
+                    <UserMessage msg={msg} index={i} onEdit={handleEditMessage} />
                   ) : (
                     <AssistantMessage msg={msg} index={i} sending={sending} onRegenerate={handleRegenerate} />
                   )}
@@ -429,11 +552,7 @@ export function AIChatContent({
                 ref={inputRef}
                 onSubmit={handleSend}
                 onEmptyChange={setEmpty}
-                onDraftChange={(draft) => {
-                  if (sideTabId) {
-                    setSidebarTabInputDraft(sideTabId, draft);
-                  }
-                }}
+                onDraftChange={handleDraftChange}
                 sendOnEnter={sendOnEnter}
                 userMessageHistory={userMessageHistory}
                 placeholder={t("ai.sendPlaceholder")}
@@ -515,9 +634,7 @@ const TokenUsageBadge = memo(function TokenUsageBadge({ usage }: { usage: TokenU
   const output = usage.outputTokens || 0;
   const cacheWrite = usage.cacheCreationTokens || 0;
   const cacheRead = usage.cacheReadTokens || 0;
-  // 合计输入包含 cache write / read，让使用者一眼看到本轮实际消耗的 prompt 规模
-  const totalInput = input + cacheWrite + cacheRead;
-  if (totalInput === 0 && output === 0) return null;
+  if (input === 0 && output === 0 && cacheWrite === 0 && cacheRead === 0) return null;
   const hasCache = cacheRead > 0 || cacheWrite > 0;
 
   return (
@@ -527,7 +644,7 @@ const TokenUsageBadge = memo(function TokenUsageBadge({ usage }: { usage: TokenU
           <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70 tabular-nums select-none cursor-default">
             <span className="inline-flex items-center gap-0.5">
               <ArrowUp className="h-3 w-3" />
-              {formatTokenCount(totalInput)}
+              {formatTokenCount(input)}
             </span>
             <span className="inline-flex items-center gap-0.5">
               <ArrowDown className="h-3 w-3" />
@@ -578,7 +695,9 @@ const AssistantToolbar = memo(function AssistantToolbar({
 }) {
   const { t } = useTranslation();
   const showActions = !sending && !msg.streaming;
-  const copyText = extractAssistantText(msg);
+  // 复制按钮即使不显示也会读 msg；流式时上层 toolbar 会因为 showActions=false 提前 return，
+  // 不真正用到这里的结果。useMemo 让 toolbar 重渲染时不重做拼接，msg.blocks 引用稳定就直接命中。
+  const copyText = useMemo(() => extractAssistantText(msg), [msg]);
 
   const handleCopy = useCallback(async () => {
     if (!copyText) return;
@@ -648,6 +767,10 @@ const AssistantMessage = memo(function AssistantMessage({
 }) {
   const hasBlocks = msg.blocks && msg.blocks.length > 0;
   const isEmpty = !hasBlocks && msg.content === "";
+  // Hooks 规则要求在条件分支之前调用：用空数组占位，下方按 hasBlocks 决定要不要取用。
+  // 流式时 msg.blocks 引用每帧改变会重算，但 splitBlocksByApproval 本身是 O(blocks.length) 的纯遍历，
+  // useMemo 至少避免 toolbar / 其他渲染触发的二次执行。
+  const segments = useMemo(() => splitBlocksByApproval(msg.blocks ?? []), [msg.blocks]);
 
   if (msg.streaming && isEmpty) {
     return (
@@ -674,7 +797,6 @@ const AssistantMessage = memo(function AssistantMessage({
   }
 
   if (hasBlocks) {
-    const segments = splitBlocksByApproval(msg.blocks);
     return (
       <div className="flex flex-col items-start gap-1.5 group/assistant">
         <span className="text-xs font-semibold text-primary tracking-wide">Assistant</span>
@@ -698,9 +820,7 @@ const AssistantMessage = memo(function AssistantMessage({
       <div
         className={`rounded-xl rounded-bl-sm bg-muted px-3.5 py-2.5 max-w-[95%] min-w-0 overflow-hidden break-words prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-pre:my-1 prose-pre:overflow-x-auto shadow-sm ${messageSelectionClass}`}
       >
-        <Markdown remarkPlugins={mdRemarkPlugins} rehypePlugins={mdRehypePlugins}>
-          {msg.content}
-        </Markdown>
+        <MarkdownContent content={msg.content} />
         {msg.streaming && <Loader2 className="h-3 w-3 animate-spin inline-block ml-1" />}
       </div>
       <AssistantToolbar msg={msg} index={index} sending={sending} onRegenerate={onRegenerate} />
@@ -727,9 +847,7 @@ const BubbleSegment = memo(function BubbleSegment({
             key={idx}
             className="prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-pre:my-1 overflow-x-auto break-words"
           >
-            <Markdown remarkPlugins={mdRemarkPlugins} rehypePlugins={mdRehypePlugins}>
-              {block.content}
-            </Markdown>
+            <MarkdownContent content={block.content} />
           </div>
         ) : block.type === "thinking" ? (
           <ThinkingBlock key={idx} block={block} />

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -220,6 +220,16 @@ export function AIChatContent({
   const seenApprovalIdsRef = useRef<Set<string>>(new Set());
   const editTarget = sideTabId ? sidebarEditTarget : localEditTarget;
 
+  const enableScrollFollow = useCallback(() => {
+    isAtBottomRef.current = true;
+    const viewport = getViewport();
+    if (viewport) {
+      viewport.scrollTop = viewport.scrollHeight;
+    } else {
+      bottomRef.current?.scrollIntoView({ behavior: "auto" });
+    }
+  }, [getViewport]);
+
   useEffect(() => {
     seenApprovalIdsRef.current = new Set();
   }, [conversationId]);
@@ -365,6 +375,7 @@ export function AIChatContent({
       if (!content.trim()) return;
       if (editTarget && conversationId != null) {
         const activeTarget = editTarget;
+        enableScrollFollow();
         // 编辑模式改走 conversation 级 replay，提交成功后只在目标仍未变化时退出编辑态。
         void editAndResendConversation(conversationId, activeTarget.messageIndex, content).then(() => {
           if (sideTabId) {
@@ -389,6 +400,11 @@ export function AIChatContent({
         });
         return;
       }
+      // 普通发送在当前会话空闲时会立即开启新一轮输出，视图应重新进入底部跟随。
+      // 若 sending=true，本次提交只会进入 pending queue，保留用户当前阅读位置。
+      if (!sending) {
+        enableScrollFollow();
+      }
       if (onSendOverride) {
         void onSendOverride(content);
       } else if (tabId) {
@@ -399,10 +415,12 @@ export function AIChatContent({
       conversationId,
       editAndResendConversation,
       editTarget,
+      enableScrollFollow,
       onSendOverride,
       sendToTab,
       setSidebarTabEditTarget,
       sideTabId,
+      sending,
       tabId,
     ]
   );
@@ -447,6 +465,7 @@ export function AIChatContent({
 
   const confirmRegenerate = () => {
     if (regenerateTarget !== null) {
+      enableScrollFollow();
       if (tabId) {
         regenerate(tabId, regenerateTarget);
       } else if (conversationId != null) {

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -200,6 +200,8 @@ export function AIChatContent({
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<AIChatInputHandle>(null);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
+  // 内层 messages 容器：ResizeObserver 挂在这里，捕获 useDeferredValue commit 撑高的那一帧。
+  const contentRef = useRef<HTMLDivElement>(null);
   // Radix ScrollArea 的 viewport 是内部 div，原先每个 effect 都 querySelector 一次；
   // 流式时 messages effect 按帧触发，querySelector 累积成本不小。这里把首次查找结果缓存，
   // 同时用 isConnected 兜底 Radix 重建子树的边角场景。
@@ -238,13 +240,35 @@ export function AIChatContent({
     if (!hasNewApproval && !isAtBottomRef.current) return;
     const viewport = getViewport();
     if (viewport) {
-      // 流式过程中用 instant 滚动避免和持续增长的 scrollHeight 互相追赶导致跟随判定抖动。
+      // 这里读到的 scrollHeight 可能还是 useDeferredValue commit 之前的旧值（MarkdownContent
+      // 内部把 markdown 渲染挂到了低优先级 transition），所以这次滚到底只对齐到"旧底部"；
+      // 下面那条 ResizeObserver effect 会在内容容器真正撑高的那一帧再把视图二次对齐到新底部。
       viewport.scrollTop = viewport.scrollHeight;
       isAtBottomRef.current = true;
     } else {
       bottomRef.current?.scrollIntoView({ behavior: "auto" });
     }
   }, [messages, getViewport]);
+
+  useEffect(() => {
+    // MarkdownContent 用 useDeferredValue 让长 markdown 走低优先级 commit，
+    // 上面那条 messages effect 跑的时候 deferred 还没 commit、scrollHeight 是旧值；
+    // 而 deferred 真正 commit 时既没有 scroll 事件、也不会改变 messages 引用，
+    // 没有任何同步信号能把视图重新拉到底——只剩内容容器尺寸变化这个回调入口。
+    // ResizeObserver 在内层 messages 容器尺寸变化时（包括每次 deferred commit 撑高）
+    // 触发一次，加上 isAtBottomRef 闸门，保证用户上滑后跟随会被关掉，不与 scroll 处理器抢镜。
+    const viewport = getViewport();
+    const content = contentRef.current;
+    if (!viewport || !content || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => {
+      if (!isAtBottomRef.current) return;
+      if (viewport.scrollTop !== viewport.scrollHeight) {
+        viewport.scrollTop = viewport.scrollHeight;
+      }
+    });
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [getViewport]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -310,20 +334,24 @@ export function AIChatContent({
         useAIStore.getState().sidebarTabs.find((tab) => tab.id === sideTabId)?.uiState.scrollTop ?? 0;
     }
     let lastScrollTop = viewport.scrollTop;
+    let lastScrollHeight = viewport.scrollHeight;
     // 初始按几何判定一次：短内容/刚加载都视为在底部、开启跟随。
     isAtBottomRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 50;
     const handleScroll = () => {
       const currentTop = viewport.scrollTop;
-      // 关键：只有 scrollTop "向上"移动才视为用户主动离开底部、关掉跟随。
-      // 向下方向（程序 scrollTop = scrollHeight、或用户滑回底部）只用来恢复跟随，永不主动关。
-      // 这样 useDeferredValue 让 markdown 异步撑高 scrollHeight 时，
-      // 后到的 scroll 事件即便看到"几何上不在底部"，也不会把跟随误关。50px 余量容忍 sub-pixel/边距差异。
-      if (currentTop < lastScrollTop) {
+      const currentScrollHeight = viewport.scrollHeight;
+      // 真正的"用户上滑"必须同时满足：scrollTop 减小 AND scrollHeight 没缩。
+      // 内容收缩场景（典型：ThinkingBlock 从 running 完成时自动 collapse，max-h-64 展开内容消失）
+      // 浏览器会把 scrollTop 钳到新 max → 看起来 scrollTop 减小但用户没动，
+      // 误判会把跟随关掉、整段后续流式都无法回到底。
+      const userScrolledUp = currentTop < lastScrollTop && currentScrollHeight >= lastScrollHeight;
+      if (userScrolledUp) {
         isAtBottomRef.current = false;
-      } else if (viewport.scrollHeight - currentTop - viewport.clientHeight <= 50) {
+      } else if (currentScrollHeight - currentTop - viewport.clientHeight <= 50) {
         isAtBottomRef.current = true;
       }
       lastScrollTop = currentTop;
+      lastScrollHeight = currentScrollHeight;
       if (sideTabId) {
         setSidebarTabScrollTop(sideTabId, currentTop);
       }
@@ -441,7 +469,7 @@ export function AIChatContent({
       <div className="flex h-full flex-col" data-compact={compact}>
         {/* Messages */}
         <ScrollArea ref={scrollAreaRef} className="flex-1 min-h-0 overflow-hidden">
-          <div className="max-w-3xl mx-auto p-4 space-y-6">
+          <div ref={contentRef} className="max-w-3xl mx-auto p-4 space-y-6">
             {messages.length === 0 && (
               <p className="text-sm text-muted-foreground text-center mt-16">{t("ai.placeholder")}</p>
             )}

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -48,6 +48,8 @@ import { formatModKey } from "@/stores/shortcutStore";
 import { ToolBlock } from "@/components/ai/ToolBlock";
 import { ThinkingBlock } from "@/components/ai/ThinkingBlock";
 import { AgentBlock } from "@/components/ai/AgentBlock";
+import { ErrorBlock as ErrorBlockView } from "@/components/ai/ErrorBlock";
+import { RetryBanner } from "@/components/ai/RetryBanner";
 import { ApprovalBlock } from "@/components/approval/ApprovalBlock";
 import { AISetupWizard } from "@/components/ai/AISetupWizard";
 import { CompactContext, useCompact } from "@/components/ai/AIChatContentContext";
@@ -789,7 +791,7 @@ const AssistantToolbar = memo(function AssistantToolbar({
   );
 });
 
-const AssistantMessage = memo(function AssistantMessage({
+export const AssistantMessage = memo(function AssistantMessage({
   msg,
   index,
   sending,
@@ -811,6 +813,10 @@ const AssistantMessage = memo(function AssistantMessage({
     return (
       <div className="flex flex-col items-start gap-1.5">
         <span className="text-xs font-semibold text-primary tracking-wide">Assistant</span>
+        {/* 503 等错误在 cago 同步路径下 retry，此时 assistant 占位 blocks 为空 +
+            content="" → 命中本分支。RetryBanner 必须在这里也渲染，否则 retry 期间
+            (1s/2s/4s 倒计时) UI 看不到任何"重试中"提示，最终只看到 ErrorBlock。 */}
+        {msg.retryStatus && <RetryBanner status={msg.retryStatus} />}
         <div className="rounded-xl rounded-bl-sm bg-muted px-3.5 py-2.5 max-w-[95%] shadow-sm">
           <div className="flex items-center gap-1 py-1">
             <span
@@ -835,6 +841,7 @@ const AssistantMessage = memo(function AssistantMessage({
     return (
       <div className="flex flex-col items-start gap-1.5 group/assistant">
         <span className="text-xs font-semibold text-primary tracking-wide">Assistant</span>
+        {msg.retryStatus && <RetryBanner status={msg.retryStatus} />}
         {segments.map((seg, si) =>
           seg.type === "approval" ? (
             <div key={si} className="w-full max-w-[95%]">
@@ -852,6 +859,7 @@ const AssistantMessage = memo(function AssistantMessage({
   return (
     <div className="flex flex-col items-start gap-1.5 group/assistant">
       <span className="text-xs font-semibold text-primary tracking-wide">Assistant</span>
+      {msg.retryStatus && <RetryBanner status={msg.retryStatus} />}
       <div
         className={`rounded-xl rounded-bl-sm bg-muted px-3.5 py-2.5 max-w-[95%] min-w-0 overflow-hidden break-words prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-pre:my-1 prose-pre:overflow-x-auto shadow-sm ${messageSelectionClass}`}
       >
@@ -888,6 +896,8 @@ const BubbleSegment = memo(function BubbleSegment({
           <ThinkingBlock key={idx} block={block} />
         ) : block.type === "agent" ? (
           <AgentBlock key={idx} block={block} />
+        ) : block.type === "error" ? (
+          <ErrorBlockView key={idx} block={block} />
         ) : (
           <ToolBlock key={idx} block={block} />
         )

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -272,8 +272,11 @@ export function AIChatContent({
     if (!viewport || !content || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver(() => {
       if (!isAtBottomRef.current) return;
-      if (viewport.scrollTop !== viewport.scrollHeight) {
-        viewport.scrollTop = viewport.scrollHeight;
+      // scrollTop 的最大值是 scrollHeight - clientHeight，不是 scrollHeight；
+      // 用 maxScrollTop 比较，避免每次尺寸变化都无效重写 scrollTop。
+      const maxScrollTop = viewport.scrollHeight - viewport.clientHeight;
+      if (viewport.scrollTop < maxScrollTop) {
+        viewport.scrollTop = maxScrollTop;
       }
     });
     ro.observe(content);
@@ -498,8 +501,12 @@ export function AIChatContent({
               const cvStyle: React.CSSProperties | undefined = isLast
                 ? undefined
                 : { contentVisibility: "auto", containIntrinsicSize: "auto 120px" };
+              // 必须用稳定的 msg.id 作 key：edit&resend / queue_consumed 会截断重插消息，
+              // 用 index 作 key 时 React 会复用错误节点，ToolBlock/ThinkingBlock 的 expanded
+              // 等本地 state 会串到别的消息。源头创建处均分配 id；测试 fixture 走 fallback。
+              const key = msg.id ?? `idx-${i}-${msg.role}`;
               return (
-                <div key={i} className="text-sm" style={cvStyle}>
+                <div key={key} className="text-sm" style={cvStyle}>
                   {msg.role === "user" ? (
                     <UserMessage msg={msg} index={i} onEdit={handleEditMessage} />
                   ) : (

--- a/frontend/src/components/ai/AIChatInput.tsx
+++ b/frontend/src/components/ai/AIChatInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useImperativeHandle, forwardRef, type MutableRefObject } from "react";
+import { memo, useEffect, useMemo, useRef, useImperativeHandle, forwardRef, type MutableRefObject } from "react";
 import { EditorContent, useEditor, ReactRenderer, type Editor } from "@tiptap/react";
 import { Extension } from "@tiptap/core";
 import Document from "@tiptap/extension-document";
@@ -389,7 +389,11 @@ function applyInputHistoryMessage(editor: Editor, nextMessage: string | AIChatIn
   editor.commands.focus("end");
 }
 
-export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(function AIChatInput(
+// onDraftChange 节流间隔：输入是高频事件，每键击都写 store/localStorage 会让流式期间叠加卡顿；
+// 100ms 节流足够保证草稿在 tab 切换/崩溃时不丢失，又不会阻塞键盘事件。
+const DRAFT_CHANGE_THROTTLE_MS = 120;
+
+const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(function AIChatInput(
   { onSubmit, onEmptyChange, onDraftChange, sendOnEnter, userMessageHistory = [], placeholder, disabled, editorRef },
   ref
 ) {
@@ -400,6 +404,11 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
   const historyRef = useRef(userMessageHistory);
   const historyIndexRef = useRef(-1);
   const applyingHistoryRef = useRef(false);
+  // onDraftChange 节流状态：尾随触发，确保用户停下后最终值一定写入 store。
+  const draftPendingRef = useRef<string | null>(null);
+  const draftFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const draftLastSentRef = useRef<string>("");
+  const lastIsEmptyRef = useRef<boolean | null>(null);
 
   useEffect(() => {
     submitRef.current = onSubmit;
@@ -555,9 +564,27 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
       } else {
         historyIndexRef.current = -1;
       }
-      onEmptyChangeRef.current?.(ed.isEmpty);
-      const content = extractContentXml(ed.state.doc as unknown as ProseMirrorLikeNode);
-      onDraftChangeRef.current?.({ content });
+      // 仅在 empty 状态翻转时通知，避免每个按键都触发父组件 setState 引发的级联重渲染。
+      const isEmpty = ed.isEmpty;
+      if (lastIsEmptyRef.current !== isEmpty) {
+        lastIsEmptyRef.current = isEmpty;
+        onEmptyChangeRef.current?.(isEmpty);
+      }
+      // 草稿抽取走节流通道：节流期内仅记录"有待处理"标志，下次 timer 到点时直接从 editor 读最新 doc。
+      // 这避免了流式输出 + 用户输入时，每个按键都触发 extractContentXml + zustand 写入。
+      if (!onDraftChangeRef.current) return;
+      draftPendingRef.current = "PENDING";
+      if (draftFlushTimerRef.current != null) return;
+      const flushDraft = () => {
+        draftFlushTimerRef.current = null;
+        if (draftPendingRef.current == null) return;
+        draftPendingRef.current = null;
+        const content = extractContentXml(ed.state.doc as unknown as ProseMirrorLikeNode);
+        if (content === draftLastSentRef.current) return;
+        draftLastSentRef.current = content;
+        onDraftChangeRef.current?.({ content });
+      };
+      draftFlushTimerRef.current = setTimeout(flushDraft, DRAFT_CHANGE_THROTTLE_MS);
     },
     editable: !disabled,
   });
@@ -578,12 +605,29 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
       const content = extractContentXml(editor.state.doc as unknown as ProseMirrorLikeNode);
       if (!content.trim()) return;
       historyIndexRef.current = -1;
+      // 抢在 clearContent 之前把节流中的草稿吞掉，避免提交后还有一次"旧 doc → 写空草稿"的尾随回调。
+      if (draftFlushTimerRef.current != null) {
+        clearTimeout(draftFlushTimerRef.current);
+        draftFlushTimerRef.current = null;
+      }
+      draftPendingRef.current = null;
       submitRef.current(content);
       // emitUpdate=true：默认 false 时 onUpdate 不会触发，外部 inputDraft 仍保留旧内容；
       // 侧边助手随后创建会话、conversationId 变化时会按草稿把刚发送的消息回填到输入框。
       editor.commands.clearContent(true);
+      draftLastSentRef.current = "";
     };
   }, [editor]);
+
+  // 卸载时清掉未触发的草稿节流定时器，避免在已销毁的 editor 上回调。
+  useEffect(() => {
+    return () => {
+      if (draftFlushTimerRef.current != null) {
+        clearTimeout(draftFlushTimerRef.current);
+        draftFlushTimerRef.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     editor?.setEditable(!disabled);
@@ -610,3 +654,8 @@ export const AIChatInput = forwardRef<AIChatInputHandle, AIChatInputProps>(funct
 
   return <EditorContent editor={editor} />;
 });
+
+// 父组件（AIChatContent）在流式输出期间会被 store 每帧重渲染。
+// 通过 memo 把 AIChatInput 的输入流和外部消息流解耦——只要传入 props 引用没变，
+// 输入框的 React 子树就跳过整段重渲染，按键和 IME 组合不再被流式打断。
+export const AIChatInput = memo(AIChatInputComponent) as typeof AIChatInputComponent;

--- a/frontend/src/components/ai/AIChatInput.tsx
+++ b/frontend/src/components/ai/AIChatInput.tsx
@@ -1,37 +1,22 @@
-import { memo, useEffect, useMemo, useRef, useImperativeHandle, forwardRef, type MutableRefObject } from "react";
-import { EditorContent, useEditor, ReactRenderer, type Editor } from "@tiptap/react";
-import { Extension } from "@tiptap/core";
+import { memo, useEffect, useImperativeHandle, useMemo, useRef, forwardRef, type MutableRefObject } from "react";
+import { EditorContent, useEditor, type Editor } from "@tiptap/react";
 import Document from "@tiptap/extension-document";
 import Paragraph from "@tiptap/extension-paragraph";
-import Text from "@tiptap/extension-text";
 import Placeholder from "@tiptap/extension-placeholder";
-import Mention from "@tiptap/extension-mention";
-import Suggestion, { type SuggestionProps, type SuggestionKeyDownProps } from "@tiptap/suggestion";
-import tippy, { type Instance } from "tippy.js";
-import { MentionList, type MentionListRef, type MentionItem } from "./MentionList";
+import Text from "@tiptap/extension-text";
+import { extractContentXml } from "./input/content";
+import { createMentionExtension, createSnippetSuggestionExtension } from "./input/extensions";
 import {
-  SnippetSuggestionList,
-  type SnippetSuggestionItem,
-  type SnippetSuggestionListRef,
-} from "./SnippetSuggestionList";
-import { useAssetStore } from "@/stores/assetStore";
-import { useSnippetStore } from "@/stores/snippetStore";
-import { buildGroupPathMap } from "@/lib/groupPath";
-import { buildMentionXml, escapeXmlText, parseMentionContent } from "@/lib/mentionXml";
-import { ListSnippets } from "../../../wailsjs/go/app/App";
-import { snippet_svc } from "../../../wailsjs/go/models";
+  applyInputHistoryMessage,
+  getInputHistoryNavigationState,
+  shouldContinueInputHistory,
+  shouldIgnoreEditorShortcut,
+  shouldStartInputHistory,
+} from "./input/keyboard";
+import { useInputDraftSync } from "./input/useInputDraft";
+import type { AIChatInputDraft, AIChatInputHandle, ProseMirrorLikeNode } from "./input/types";
 
-export interface AIChatInputDraft {
-  content: string;
-}
-
-export interface AIChatInputHandle {
-  focus: () => void;
-  clear: () => void;
-  isEmpty: () => boolean;
-  submit: () => void;
-  loadDraft: (draft: string | AIChatInputDraft) => void;
-}
+export type { AIChatInputDraft, AIChatInputHandle } from "./input/types";
 
 export interface AIChatInputProps {
   onSubmit: (content: string) => void;
@@ -45,354 +30,6 @@ export interface AIChatInputProps {
   editorRef?: MutableRefObject<Editor | null>;
 }
 
-interface ProseMirrorLikeNode {
-  type: { name: string };
-  text?: string;
-  attrs: Record<string, unknown>;
-  descendants: (fn: (node: ProseMirrorLikeNode) => boolean | void) => void;
-}
-
-interface TipTapTextNode {
-  type: "text";
-  text: string;
-}
-
-interface TipTapMentionNode {
-  type: "mention";
-  attrs: {
-    id: string;
-    label: string;
-  };
-}
-
-interface TipTapParagraphNode {
-  type: "paragraph";
-  content?: Array<TipTapTextNode | TipTapMentionNode>;
-}
-
-interface TipTapDocNode {
-  type: "doc";
-  content: TipTapParagraphNode[];
-}
-
-type InputHistoryDirection = "up" | "down";
-
-interface InputHistoryNavigationOptions {
-  direction: InputHistoryDirection;
-  currentText: string;
-  historyIndex: number;
-  userMessageHistory: string[];
-  canStartHistory: boolean;
-  canContinueHistory: boolean;
-}
-
-// 从 TipTap doc 直接抽出"含内联 <mention> 标签"的 content。
-// mention 节点会通过 assetStore 反查 type/host/groupPath，未命中（资产已删除）的降级为只带 asset-id + name。
-function extractContentXml(doc: ProseMirrorLikeNode): string {
-  const assetStore = useAssetStore.getState();
-  const groupPathMap = buildGroupPathMap(assetStore.groups);
-  const lookupAsset = (id: number) => assetStore.assets.find((a) => a.ID === id);
-  const hostFromConfig = (cfg: string | undefined) => {
-    if (!cfg) return undefined;
-    try {
-      const parsed = JSON.parse(cfg) as { host?: string };
-      return parsed.host || undefined;
-    } catch {
-      return undefined;
-    }
-  };
-
-  let out = "";
-  doc.descendants((node) => {
-    if (node.type.name === "text") {
-      out += escapeXmlText(node.text ?? "");
-    } else if (node.type.name === "mention") {
-      const id = Number(node.attrs.id);
-      const label = String(node.attrs.label ?? "");
-      const asset = Number.isFinite(id) ? lookupAsset(id) : undefined;
-      out += buildMentionXml({
-        assetId: id,
-        name: label,
-        type: asset?.Type,
-        host: asset ? hostFromConfig(asset.Config) : undefined,
-        groupPath: asset?.GroupID ? groupPathMap.get(asset.GroupID) : undefined,
-      });
-    } else if (node.type.name === "paragraph" && out.length > 0) {
-      out += "\n";
-    }
-    return true;
-  });
-  return out.replace(/\n+$/g, "");
-}
-
-function normalizeDraftMessage(draft: string | AIChatInputDraft): AIChatInputDraft {
-  if (typeof draft === "string") {
-    return { content: draft };
-  }
-  return { content: draft.content ?? "" };
-}
-
-function appendTextToParagraphs(
-  paragraphs: TipTapParagraphNode[],
-  text: string,
-  currentParagraphContent: Array<TipTapTextNode | TipTapMentionNode>
-) {
-  const segments = text.split("\n");
-  for (let index = 0; index < segments.length; index += 1) {
-    const segment = segments[index];
-    if (segment.length > 0) {
-      currentParagraphContent.push({ type: "text", text: segment });
-    }
-    if (index < segments.length - 1) {
-      paragraphs.push(
-        currentParagraphContent.length > 0
-          ? { type: "paragraph", content: currentParagraphContent }
-          : { type: "paragraph" }
-      );
-      currentParagraphContent = [];
-    }
-  }
-  return currentParagraphContent;
-}
-
-// 把持久化 user message（含内联 <mention> XML 的 content）重建为 TipTap 文档，
-// 供历史浏览与外部 draft 预填共用，避免两套回填逻辑出现偏差。
-function buildEditorDocFromMessage(message: string | AIChatInputDraft): TipTapDocNode {
-  const { content } = normalizeDraftMessage(message);
-  const segments = parseMentionContent(content);
-  const paragraphs: TipTapParagraphNode[] = [];
-  let currentParagraphContent: Array<TipTapTextNode | TipTapMentionNode> = [];
-
-  for (const seg of segments) {
-    if (seg.type === "text") {
-      currentParagraphContent = appendTextToParagraphs(paragraphs, seg.text, currentParagraphContent);
-    } else {
-      currentParagraphContent.push({
-        type: "mention",
-        attrs: {
-          id: String(seg.attrs.assetId),
-          label: seg.attrs.name,
-        },
-      });
-    }
-  }
-
-  paragraphs.push(
-    currentParagraphContent.length > 0 ? { type: "paragraph", content: currentParagraphContent } : { type: "paragraph" }
-  );
-
-  return {
-    type: "doc",
-    content: paragraphs,
-  };
-}
-
-/** First non-empty line of snippet content, used as the popup preview line. */
-function firstLine(s: string): string {
-  const i = s.indexOf("\n");
-  return i === -1 ? s.trim() : s.slice(0, i).trim();
-}
-
-function createClientRect(left: number, top: number, right: number, bottom: number): DOMRect {
-  const width = Math.max(0, right - left);
-  const height = Math.max(0, bottom - top);
-  return {
-    x: left,
-    y: top,
-    width,
-    height,
-    left,
-    top,
-    right,
-    bottom,
-    toJSON: () => ({ x: left, y: top, width, height, left, top, right, bottom }),
-  } as DOMRect;
-}
-
-function fallbackSuggestionClientRect(props: SuggestionProps<unknown>): DOMRect {
-  const docSize = props.editor.state.doc.content.size;
-  const from = Math.max(0, Math.min(props.range.from, docSize));
-  const to = Math.max(from, Math.min(props.range.to, docSize));
-
-  try {
-    const start = props.editor.view.coordsAtPos(from);
-    const end = props.editor.view.coordsAtPos(to);
-    return createClientRect(
-      Math.min(start.left, end.left),
-      Math.min(start.top, end.top),
-      Math.max(start.right, end.right),
-      Math.max(start.bottom, end.bottom)
-    );
-  } catch {
-    return createClientRect(0, 0, 0, 0);
-  }
-}
-
-function suggestionReferenceClientRect<TItem>(props: SuggestionProps<TItem>) {
-  return () => props.clientRect?.() ?? fallbackSuggestionClientRect(props as SuggestionProps<unknown>);
-}
-
-function createSuggestionPopup<TItem>(props: SuggestionProps<TItem>, content: Element): Instance[] {
-  return tippy("body", {
-    getReferenceClientRect: suggestionReferenceClientRect(props),
-    appendTo: () => document.body,
-    content,
-    showOnCreate: true,
-    interactive: true,
-    trigger: "manual",
-    placement: "bottom-start",
-  });
-}
-
-/**
- * Build a ProseMirror plugin that triggers on `/` and inserts the picked snippet
- * as PLAIN TEXT (not a Mention node) — prompt snippets are just template text.
- *
- * The factory takes the component-local `activeRef` so the editor's Enter-handler
- * can yield to the popup (mirroring how the `@` mention suggestion works).
- */
-function createSnippetSuggestionExtension(activeRef: MutableRefObject<boolean>) {
-  return Extension.create({
-    name: "snippetSuggestion",
-    addProseMirrorPlugins() {
-      // Shared closure: items() writes the unfiltered count here, render() reads
-      // it when building props so the list can distinguish "filter zeroed out"
-      // from "no prompt snippets at all". Avoids a separate fetch AND the earlier
-      // item-stamping hack where an empty `items` array lost the total.
-      let lastTotal = 0;
-      return [
-        Suggestion<SnippetSuggestionItem>({
-          editor: this.editor,
-          char: "/",
-          // Rely on TipTap's default `allowedPrefixes: [" "]` — it already
-          // enforces "doc-start or after whitespace" (that's why `http:/`
-          // doesn't trigger — `:` is not in allowedPrefixes). A custom `allow`
-          // here had an off-by-one and blocked legitimate "after space" cases
-          // like `hello /`.
-          command: ({ editor, range, props }) => {
-            editor.chain().focus().deleteRange(range).insertContent(props.content).run();
-            useSnippetStore.getState().recordUse(props.id);
-          },
-          items: async ({ query }) => {
-            try {
-              // NOTE: keyword is intentionally left blank and filtering is done client-side
-              // so we can keep the unfiltered `lastTotal` — SnippetSuggestionList needs it to
-              // tell "no prompts exist" (CTA) apart from "filter zeroed out" (no-match state).
-              const req = new snippet_svc.ListReq({
-                categories: ["prompt"],
-                keyword: "",
-                limit: 0,
-                offset: 0,
-                orderBy: "",
-              });
-              const all = await ListSnippets(req);
-              const list: SnippetSuggestionItem[] = (all ?? []).map((s) => ({
-                id: s.ID,
-                name: s.Name,
-                preview: firstLine(s.Content ?? "").slice(0, 80),
-                content: s.Content ?? "",
-                readOnly: (s.Source ?? "").startsWith("ext:"),
-              }));
-              lastTotal = list.length;
-              const q = query.toLowerCase();
-              const filtered = q
-                ? list.filter((i) => i.name.toLowerCase().includes(q) || i.preview.toLowerCase().includes(q))
-                : list;
-              return filtered.slice(0, 20);
-            } catch {
-              return [];
-            }
-          },
-          render: () => {
-            let component: ReactRenderer<SnippetSuggestionListRef> | null = null;
-            let popup: Instance[] = [];
-            const buildProps = (p: SuggestionProps<SnippetSuggestionItem>) => ({
-              items: p.items,
-              totalAvailable: lastTotal,
-              command: p.command,
-            });
-            return {
-              onStart: (props) => {
-                activeRef.current = true;
-                component = new ReactRenderer(SnippetSuggestionList, {
-                  props: buildProps(props),
-                  editor: props.editor,
-                });
-                popup = createSuggestionPopup(props, component.element);
-              },
-              onUpdate: (props) => {
-                component?.updateProps(buildProps(props));
-                if (popup[0]) {
-                  popup[0].setProps({ getReferenceClientRect: suggestionReferenceClientRect(props) });
-                } else if (component) {
-                  popup = createSuggestionPopup(props, component.element);
-                }
-              },
-              onKeyDown: (props: SuggestionKeyDownProps) => {
-                if (props.event.key === "Escape") {
-                  popup[0]?.hide();
-                  return true;
-                }
-                return component?.ref?.onKeyDown(props) || false;
-              },
-              onExit: () => {
-                activeRef.current = false;
-                popup[0]?.destroy();
-                component?.destroy();
-              },
-            };
-          },
-        }),
-      ];
-    },
-  });
-}
-
-// 仅在首行首字符接管向上历史，避免影响富文本输入的原生光标移动。
-function shouldStartInputHistory(editor: Editor) {
-  const { selection } = editor.state;
-  return selection.empty && selection.from === 1;
-}
-
-// 进入历史浏览后，只要还是折叠光标就允许继续用上下键切换。
-function shouldContinueInputHistory(editor: Editor) {
-  return editor.state.selection.empty;
-}
-
-// 统一计算上下键历史切换的目标内容，避免把判断分散在按键处理中。
-function getInputHistoryNavigationState({
-  direction,
-  currentText,
-  historyIndex,
-  userMessageHistory,
-  canStartHistory,
-  canContinueHistory,
-}: InputHistoryNavigationOptions) {
-  const currentHistoryMessage = historyIndex >= 0 ? userMessageHistory[historyIndex] : null;
-  const isBrowsingHistory = currentHistoryMessage != null && currentText === currentHistoryMessage;
-  const canNavigate = isBrowsingHistory ? canContinueHistory : canStartHistory;
-
-  if (!canNavigate) return null;
-  if (direction === "up" && userMessageHistory.length === 0) return null;
-  if (direction === "down" && (!isBrowsingHistory || historyIndex < 0)) return null;
-
-  const nextHistoryIndex =
-    direction === "up" ? Math.min(historyIndex + 1, userMessageHistory.length - 1) : historyIndex - 1;
-  const nextMessage = nextHistoryIndex >= 0 ? userMessageHistory[nextHistoryIndex] : "";
-
-  return { nextHistoryIndex, nextMessage };
-}
-
-// 把历史消息写回编辑器，并把光标定位到末尾，保证连续切换时体验稳定。
-function applyInputHistoryMessage(editor: Editor, nextMessage: string | AIChatInputDraft) {
-  editor.commands.setContent(buildEditorDocFromMessage(nextMessage));
-  editor.commands.focus("end");
-}
-
-// onDraftChange 节流间隔：输入是高频事件，每键击都写 store/localStorage 会让流式期间叠加卡顿；
-// 100ms 节流足够保证草稿在 tab 切换/崩溃时不丢失，又不会阻塞键盘事件。
-const DRAFT_CHANGE_THROTTLE_MS = 120;
-
 const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(function AIChatInput(
   { onSubmit, onEmptyChange, onDraftChange, sendOnEnter, userMessageHistory = [], placeholder, disabled, editorRef },
   ref
@@ -404,42 +41,38 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
   const historyRef = useRef(userMessageHistory);
   const historyIndexRef = useRef(-1);
   const applyingHistoryRef = useRef(false);
-  // onDraftChange 节流状态：尾随触发，确保用户停下后最终值一定写入 store。
-  const draftPendingRef = useRef<string | null>(null);
-  const draftFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const draftLastSentRef = useRef<string>("");
   const lastIsEmptyRef = useRef<boolean | null>(null);
+  const triggerSubmitRef = useRef<() => void>(() => {});
+  const mentionActiveRef = useRef(false);
+  const snippetSuggestionActiveRef = useRef(false);
+  // The extension factory stores the ref for later suggestion callbacks; it does not read current during render.
+  // eslint-disable-next-line react-hooks/refs
+  const mentionExtension = useMemo(() => createMentionExtension(mentionActiveRef), []);
+  // The extension factory stores the ref for later suggestion callbacks; it does not read current during render.
+  // eslint-disable-next-line react-hooks/refs
+  const snippetSuggestionExtension = useMemo(() => createSnippetSuggestionExtension(snippetSuggestionActiveRef), []);
+  const { scheduleDraftFlush, clearDraftImmediately } = useInputDraftSync(onDraftChangeRef);
 
   useEffect(() => {
     submitRef.current = onSubmit;
   }, [onSubmit]);
+
   useEffect(() => {
     sendOnEnterRef.current = sendOnEnter;
   }, [sendOnEnter]);
+
   useEffect(() => {
     onEmptyChangeRef.current = onEmptyChange;
   }, [onEmptyChange]);
+
   useEffect(() => {
     onDraftChangeRef.current = onDraftChange;
   }, [onDraftChange]);
+
   useEffect(() => {
-    // 历史列表变化（切换会话、新消息到达等）时复位浏览游标，避免旧 index 落到错位条目。
     historyRef.current = userMessageHistory;
     historyIndexRef.current = -1;
   }, [userMessageHistory]);
-
-  const triggerSubmitRef = useRef<() => void>(() => {});
-  // @ 提及弹窗是否处于激活状态。ProseMirror 会先调用 editorProps.handleKeyDown
-  // 再分发给插件，所以需要在此处主动让路，避免 Enter 直接触发发送。
-  const mentionActiveRef = useRef(false);
-  // `/` 片段弹窗的激活态；语义同 mentionActiveRef，两者互不冲突（不同插件）。
-  const snippetSuggestionActiveRef = useRef(false);
-  // Stable extension instance — `useMemo([])` ensures the plugin (and its tippy
-  // lifecycle state) is created exactly once per mount, not rebuilt on each render.
-  // The ref is only *stored* by the extension (mutated/read later in suggestion
-  // callbacks), never read during render; the rule can't detect that.
-  // eslint-disable-next-line react-hooks/refs
-  const snippetSuggestionExtension = useMemo(() => createSnippetSuggestionExtension(snippetSuggestionActiveRef), []);
 
   const editor = useEditor({
     extensions: [
@@ -447,58 +80,7 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
       Paragraph,
       Text,
       Placeholder.configure({ placeholder: placeholder || "" }),
-      Mention.configure({
-        HTMLAttributes: {
-          class:
-            "ai-mention inline-flex items-center rounded bg-primary/10 text-primary px-1 py-0.5 text-xs font-medium",
-        },
-        renderLabel: ({ node }) => `@${node.attrs.label}`,
-        suggestion: {
-          items: () => [] as MentionItem[],
-          render: () => {
-            let component: ReactRenderer<MentionListRef> | null = null;
-            let popup: Instance[] = [];
-            const makeProps = (p: SuggestionProps<MentionItem>) => ({
-              query: p.query,
-              command: (item: MentionItem) => {
-                // TipTap Mention 节点属性类型是 { id: string; label: string }，
-                // 这里将资产 ID 转为字符串以对齐扩展类型约束。
-                p.command({ id: String(item.id), label: item.label } as unknown as MentionItem);
-              },
-            });
-            return {
-              onStart: (props: SuggestionProps<MentionItem>) => {
-                mentionActiveRef.current = true;
-                component = new ReactRenderer(MentionList, {
-                  props: makeProps(props),
-                  editor: props.editor,
-                });
-                popup = createSuggestionPopup(props, component.element);
-              },
-              onUpdate: (props: SuggestionProps<MentionItem>) => {
-                component?.updateProps(makeProps(props));
-                if (popup[0]) {
-                  popup[0].setProps({ getReferenceClientRect: suggestionReferenceClientRect(props) });
-                } else if (component) {
-                  popup = createSuggestionPopup(props, component.element);
-                }
-              },
-              onKeyDown: (props: SuggestionKeyDownProps) => {
-                if (props.event.key === "Escape") {
-                  popup[0]?.hide();
-                  return true;
-                }
-                return component?.ref?.onKeyDown(props) || false;
-              },
-              onExit: () => {
-                mentionActiveRef.current = false;
-                popup[0]?.destroy();
-                component?.destroy();
-              },
-            };
-          },
-        },
-      }),
+      mentionExtension,
       snippetSuggestionExtension,
     ],
     editorProps: {
@@ -506,14 +88,14 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
         class: "ProseMirror min-h-[3rem] max-h-[25vh] overflow-y-auto px-3 pt-3 pb-1 text-sm outline-none resize-none",
         role: "textbox",
       },
-      handleKeyDown: (_view, event) => {
+      handleKeyDown: (view, event) => {
         if (!editor) return false;
+        if (shouldIgnoreEditorShortcut(view, event)) return false;
 
         const shouldSendOnEnter = sendOnEnterRef.current;
         const isEnter = event.key === "Enter";
         const mod = event.ctrlKey || event.metaKey;
 
-        // 在允许的光标位置接管上下键，统一处理用户消息历史切换。
         if (
           (event.key === "ArrowUp" || event.key === "ArrowDown") &&
           !event.altKey &&
@@ -540,7 +122,6 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
           }
         }
 
-        // 提及 / 片段弹窗激活时，把 Enter 让给 suggestion 插件用于选中候选项
         const suggestionActive = mentionActiveRef.current || snippetSuggestionActiveRef.current;
         if (isEnter && suggestionActive) {
           return false;
@@ -564,32 +145,18 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
       } else {
         historyIndexRef.current = -1;
       }
-      // 仅在 empty 状态翻转时通知，避免每个按键都触发父组件 setState 引发的级联重渲染。
+
       const isEmpty = ed.isEmpty;
       if (lastIsEmptyRef.current !== isEmpty) {
         lastIsEmptyRef.current = isEmpty;
         onEmptyChangeRef.current?.(isEmpty);
       }
-      // 草稿抽取走节流通道：节流期内仅记录"有待处理"标志，下次 timer 到点时直接从 editor 读最新 doc。
-      // 这避免了流式输出 + 用户输入时，每个按键都触发 extractContentXml + zustand 写入。
-      if (!onDraftChangeRef.current) return;
-      draftPendingRef.current = "PENDING";
-      if (draftFlushTimerRef.current != null) return;
-      const flushDraft = () => {
-        draftFlushTimerRef.current = null;
-        if (draftPendingRef.current == null) return;
-        draftPendingRef.current = null;
-        const content = extractContentXml(ed.state.doc as unknown as ProseMirrorLikeNode);
-        if (content === draftLastSentRef.current) return;
-        draftLastSentRef.current = content;
-        onDraftChangeRef.current?.({ content });
-      };
-      draftFlushTimerRef.current = setTimeout(flushDraft, DRAFT_CHANGE_THROTTLE_MS);
+
+      scheduleDraftFlush(ed);
     },
     editable: !disabled,
   });
 
-  // 在 effect 中更新可选的外部 editor 引用，避免在渲染期间写入 ref。
   useEffect(() => {
     if (editorRef) editorRef.current = editor ?? null;
     return () => {
@@ -597,37 +164,18 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
     };
   }, [editor, editorRef]);
 
-  // 把 triggerSubmit 放到 effect 中以便捕获最新 editor 引用。
   useEffect(() => {
     triggerSubmitRef.current = () => {
-      if (!editor) return;
-      if (editor.isEmpty) return;
+      if (!editor || disabled || editor.view.composing || editor.isEmpty) return;
       const content = extractContentXml(editor.state.doc as unknown as ProseMirrorLikeNode);
       if (!content.trim()) return;
-      historyIndexRef.current = -1;
-      // 抢在 clearContent 之前把节流中的草稿吞掉，避免提交后还有一次"旧 doc → 写空草稿"的尾随回调。
-      if (draftFlushTimerRef.current != null) {
-        clearTimeout(draftFlushTimerRef.current);
-        draftFlushTimerRef.current = null;
-      }
-      draftPendingRef.current = null;
-      submitRef.current(content);
-      // emitUpdate=true：默认 false 时 onUpdate 不会触发，外部 inputDraft 仍保留旧内容；
-      // 侧边助手随后创建会话、conversationId 变化时会按草稿把刚发送的消息回填到输入框。
-      editor.commands.clearContent(true);
-      draftLastSentRef.current = "";
-    };
-  }, [editor]);
 
-  // 卸载时清掉未触发的草稿节流定时器，避免在已销毁的 editor 上回调。
-  useEffect(() => {
-    return () => {
-      if (draftFlushTimerRef.current != null) {
-        clearTimeout(draftFlushTimerRef.current);
-        draftFlushTimerRef.current = null;
-      }
+      historyIndexRef.current = -1;
+      clearDraftImmediately();
+      submitRef.current(content);
+      editor.commands.clearContent(true);
     };
-  }, []);
+  }, [clearDraftImmediately, disabled, editor]);
 
   useEffect(() => {
     editor?.setEditable(!disabled);
@@ -639,7 +187,8 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
       focus: () => editor?.commands.focus(),
       clear: () => {
         historyIndexRef.current = -1;
-        editor?.commands.clearContent();
+        clearDraftImmediately();
+        editor?.commands.clearContent(true);
       },
       isEmpty: () => editor?.isEmpty ?? true,
       submit: () => triggerSubmitRef.current(),
@@ -649,13 +198,10 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
         applyInputHistoryMessage(editor, draft);
       },
     }),
-    [editor]
+    [clearDraftImmediately, editor]
   );
 
   return <EditorContent editor={editor} />;
 });
 
-// 父组件（AIChatContent）在流式输出期间会被 store 每帧重渲染。
-// 通过 memo 把 AIChatInput 的输入流和外部消息流解耦——只要传入 props 引用没变，
-// 输入框的 React 子树就跳过整段重渲染，按键和 IME 组合不再被流式打断。
 export const AIChatInput = memo(AIChatInputComponent) as typeof AIChatInputComponent;

--- a/frontend/src/components/ai/AgentBlock.tsx
+++ b/frontend/src/components/ai/AgentBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import { Bot, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import { ToolBlock } from "./ToolBlock";
 import type { ContentBlock } from "@/stores/aiStore";
@@ -7,7 +7,7 @@ interface AgentBlockProps {
   block: ContentBlock;
 }
 
-export function AgentBlock({ block }: AgentBlockProps) {
+export const AgentBlock = memo(function AgentBlock({ block }: AgentBlockProps) {
   const [expanded, setExpanded] = useState(block.status === "running");
 
   const isRunning = block.status === "running";
@@ -45,4 +45,4 @@ export function AgentBlock({ block }: AgentBlockProps) {
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/ai/ErrorBlock.tsx
+++ b/frontend/src/components/ai/ErrorBlock.tsx
@@ -1,0 +1,48 @@
+import { memo } from "react";
+import { useTranslation } from "react-i18next";
+import { AlertTriangle } from "lucide-react";
+import type { ContentBlock } from "@/stores/aiStore";
+import type { ErrorKind } from "@/lib/aiError";
+
+// ErrorBlock —— 持久化的对话级错误块。
+//
+// 由两条路径生成：
+//   1) EventError 命中后由 aiStore handleEvent 的 "error" case 推入；
+//   2) 重试中被关闭 tab / 切会话 / 应用退出时，由 materializeRetryStatusAsError
+//      把 retryStatus 物化为 kind="interrupted"。
+//
+// 用户明确要求该块纯展示 —— 不带"重试"/"复制"/"已达上限"等按钮。
+// 用户如需重试，可走顶部 AssistantToolbar 的"重新生成"按钮（统一入口）。
+const TITLE_FALLBACK_BY_KIND: Record<ErrorKind, string> = {
+  rate_limit: "请求过于频繁，稍后再试",
+  server: "服务暂时不可用",
+  network: "网络连接不稳定",
+  auth: "鉴权失败，请检查 API Key",
+  interrupted: "对话被中断",
+  unknown: "对话出错",
+};
+
+export const ErrorBlock = memo(function ErrorBlock({ block }: { block: ContentBlock }) {
+  const { t } = useTranslation();
+  const kind = (block.errorKind as ErrorKind | undefined) ?? "unknown";
+  // 优先用 block.content（落盘时已经是 classifyError 后的友好标题），
+  // 缺失时回落到按 kind 取 i18n。两层兜底避免老数据没 content 字段时空标题。
+  const title = block.content || t(`ai.error.${kind}`, TITLE_FALLBACK_BY_KIND[kind]);
+  const detail = block.errorDetail || "";
+
+  return (
+    <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="font-medium text-destructive">{title}</div>
+          {detail && (
+            <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground font-mono leading-relaxed m-0">
+              {detail}
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/ai/RetryBanner.tsx
+++ b/frontend/src/components/ai/RetryBanner.tsx
@@ -1,0 +1,66 @@
+import { memo, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { RotateCcw } from "lucide-react";
+import type { ChatMessageRetryStatus } from "@/stores/aiStore";
+import { classifyError } from "@/lib/aiError";
+
+// RetryBanner —— assistant 气泡顶部的"重试中"提示条。
+//
+// 仅当 ChatMessage.retryStatus 非空时挂载；retryStatus 在任何非 retry 流式事件
+// 到达时被 aiStore handleStreamEvent 清掉（见 clearRetryStatusOnLastAssistant），
+// 因此重试一旦成功，banner 自然卸载，无须组件内部判定。
+//
+// 倒计时基于 startedAt + delayMs，避免 setInterval 累积误差：每秒重算剩余秒数；
+// 归零后改显示"正在重试..."直到下一帧事件到达卸载该组件。
+function computeRemaining(status: ChatMessageRetryStatus): number {
+  const target = status.startedAt + status.delayMs;
+  return Math.max(0, Math.ceil((target - Date.now()) / 1000));
+}
+
+export const RetryBanner = memo(function RetryBanner({ status }: { status: ChatMessageRetryStatus }) {
+  const { t } = useTranslation();
+  const [remaining, setRemaining] = useState(() => computeRemaining(status));
+
+  useEffect(() => {
+    setRemaining(computeRemaining(status));
+    if (status.delayMs <= 0) return;
+    const id = window.setInterval(() => {
+      const next = computeRemaining(status);
+      setRemaining(next);
+      if (next <= 0) window.clearInterval(id);
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [status]);
+
+  const attemptLabel = status.attempt > 0 ? t("ai.retry.attempt", "第 {{n}} 次", { n: status.attempt }) : "";
+  const countdownLabel =
+    remaining > 0 ? t("ai.retry.countdown_seconds", "{{n}}s", { n: remaining }) : t("ai.retry.now", "正在重试...");
+  // 错误归因 + 原始错误：用户在 retry 期间想知道为什么在重试（503 / 网络 / 鉴权 …）。
+  // 友好标题走 classifyError(走和 ErrorBlock 同一份分类规则)，原始 cause 紧随其后以
+  // monospace 小字呈现，方便复制 request id。
+  const classified = status.cause ? classifyError(status.cause) : null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col gap-0.5 rounded-md border border-amber-400/40 bg-amber-50 dark:bg-amber-950/40 px-2.5 py-1 text-xs text-amber-700 dark:text-amber-300"
+    >
+      <div className="flex items-center gap-1.5">
+        <RotateCcw className="h-3 w-3 animate-spin-slow" aria-hidden="true" />
+        <span className="font-medium">{t("ai.retry.retrying", "重试中")}</span>
+        {attemptLabel && <span className="opacity-70">·</span>}
+        {attemptLabel && <span>{attemptLabel}</span>}
+        <span className="opacity-70">·</span>
+        <span>{countdownLabel}</span>
+        {classified && <span className="opacity-70">·</span>}
+        {classified && <span className="font-medium">{classified.message}</span>}
+      </div>
+      {status.cause && (
+        <pre className="whitespace-pre-wrap break-words text-[11px] font-mono leading-relaxed m-0 opacity-80">
+          {status.cause}
+        </pre>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/components/ai/ThinkingBlock.tsx
+++ b/frontend/src/components/ai/ThinkingBlock.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { Brain, ChevronRight, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { ContentBlock } from "@/stores/aiStore";
@@ -7,7 +7,7 @@ interface ThinkingBlockProps {
   block: ContentBlock;
 }
 
-export function ThinkingBlock({ block }: ThinkingBlockProps) {
+export const ThinkingBlock = memo(function ThinkingBlock({ block }: ThinkingBlockProps) {
   const { t } = useTranslation();
   const isRunning = block.status === "running";
   const [expanded, setExpanded] = useState(isRunning);
@@ -52,4 +52,4 @@ export function ThinkingBlock({ block }: ThinkingBlockProps) {
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/ai/ThinkingBlock.tsx
+++ b/frontend/src/components/ai/ThinkingBlock.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useEffect } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Brain, ChevronRight, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { ContentBlock } from "@/stores/aiStore";
@@ -7,10 +7,40 @@ interface ThinkingBlockProps {
   block: ContentBlock;
 }
 
+const BOTTOM_THRESHOLD = 24;
+
+function isNearBottom(element: HTMLDivElement) {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_THRESHOLD;
+}
+
 export const ThinkingBlock = memo(function ThinkingBlock({ block }: ThinkingBlockProps) {
   const { t } = useTranslation();
   const isRunning = block.status === "running";
   const [expanded, setExpanded] = useState(isRunning);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const followBottomRef = useRef(true);
+  const lastScrollTopRef = useRef(0);
+  const scrollRafRef = useRef<number | null>(null);
+
+  const scrollToThinkingBottom = useCallback((options?: { force?: boolean }) => {
+    const force = options?.force === true;
+    if (!force && !followBottomRef.current) return;
+
+    if (scrollRafRef.current !== null) {
+      cancelAnimationFrame(scrollRafRef.current);
+    }
+
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+      const content = contentRef.current;
+      if (!content) return;
+      if (!force && !followBottomRef.current) return;
+
+      content.scrollTop = content.scrollHeight;
+      lastScrollTopRef.current = content.scrollTop;
+      followBottomRef.current = true;
+    });
+  }, []);
 
   // Auto-collapse when thinking completes
   useEffect(() => {
@@ -18,6 +48,39 @@ export const ThinkingBlock = memo(function ThinkingBlock({ block }: ThinkingBloc
       setExpanded(false);
     }
   }, [isRunning]);
+
+  useEffect(() => {
+    return () => {
+      if (scrollRafRef.current !== null) {
+        cancelAnimationFrame(scrollRafRef.current);
+        scrollRafRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!expanded || !isRunning) return;
+    followBottomRef.current = true;
+    scrollToThinkingBottom({ force: true });
+  }, [expanded, isRunning, scrollToThinkingBottom]);
+
+  useLayoutEffect(() => {
+    if (!expanded || !isRunning || !block.content) return;
+    scrollToThinkingBottom();
+  }, [block.content, expanded, isRunning, scrollToThinkingBottom]);
+
+  const handleContentScroll = useCallback(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const currentTop = content.scrollTop;
+    if (currentTop < lastScrollTopRef.current) {
+      followBottomRef.current = false;
+    } else if (isNearBottom(content)) {
+      followBottomRef.current = true;
+    }
+    lastScrollTopRef.current = currentTop;
+  }, []);
 
   const charCount = block.content.length;
   const summary = isRunning
@@ -44,7 +107,12 @@ export const ThinkingBlock = memo(function ThinkingBlock({ block }: ThinkingBloc
       </button>
 
       {expanded && block.content && (
-        <div className="border-t border-purple-500/15 px-3 py-2 max-h-64 overflow-auto">
+        <div
+          ref={contentRef}
+          data-thinking-scroll
+          className="border-t border-purple-500/15 px-3 py-2 max-h-64 overflow-auto"
+          onScroll={handleContentScroll}
+        >
           <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground/80 leading-relaxed italic">
             {block.content}
           </pre>

--- a/frontend/src/components/ai/ToolBlock.tsx
+++ b/frontend/src/components/ai/ToolBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import {
   Terminal,
   FileText,
@@ -38,7 +38,7 @@ function formatToolInput(input?: string): string {
   }
 }
 
-export function ToolBlock({ block }: ToolBlockProps) {
+export const ToolBlock = memo(function ToolBlock({ block }: ToolBlockProps) {
   const [expanded, setExpanded] = useState(false);
   const Icon = toolIcons[block.toolName || ""] || Terminal;
   const isRunning = block.status === "running";
@@ -108,4 +108,4 @@ export function ToolBlock({ block }: ToolBlockProps) {
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/ai/UserMessage.tsx
+++ b/frontend/src/components/ai/UserMessage.tsx
@@ -24,10 +24,13 @@ async function copyUserMessageText(text: string, copiedText: string, failedText:
 
 interface UserMessageProps {
   msg: ChatMessage;
-  onEdit?: () => void;
+  // 显式传 index 而非闭包，让父组件的 onEdit 可以保持稳定引用，
+  // 流式时 UserMessage 的 memo 才能真正跳过重渲染。
+  index?: number;
+  onEdit?: (index: number, msg: ChatMessage) => void;
 }
 
-export const UserMessage = memo(function UserMessage({ msg, onEdit }: UserMessageProps) {
+export const UserMessage = memo(function UserMessage({ msg, index, onEdit }: UserMessageProps) {
   const compact = useCompact();
   const maxWidthClass = compact ? "max-w-[95%]" : "max-w-[85%]";
   const segments = parseMentionContent(msg.content);
@@ -45,9 +48,10 @@ export const UserMessage = memo(function UserMessage({ msg, onEdit }: UserMessag
     void copyUserMessageText(copyText, t("ai.copied", "已复制到剪贴板"), t("ai.copyFailed", "复制失败"));
   }, [msg.content, t]);
 
+  const canEdit = !!onEdit && index != null;
   const handleEdit = useCallback(() => {
-    onEdit?.();
-  }, [onEdit]);
+    if (onEdit && index != null) onEdit(index, msg);
+  }, [onEdit, index, msg]);
 
   return (
     <div className="flex flex-col items-end gap-1.5 group/user">
@@ -74,12 +78,12 @@ export const UserMessage = memo(function UserMessage({ msg, onEdit }: UserMessag
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
-          {onEdit && <ContextMenuItem onClick={handleEdit}>{t("ai.editMessage", "编辑消息")}</ContextMenuItem>}
+          {canEdit && <ContextMenuItem onClick={handleEdit}>{t("ai.editMessage", "编辑消息")}</ContextMenuItem>}
           <ContextMenuItem onClick={handleContextCopy}>{t("action.copy", "复制")}</ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
       <div className="flex items-center gap-2 min-h-[18px] pr-0.5">
-        {onEdit && (
+        {canEdit && (
           <button
             type="button"
             className="opacity-0 group-hover/user:opacity-100 transition-opacity text-muted-foreground/50 hover:text-primary"

--- a/frontend/src/components/ai/input/content.ts
+++ b/frontend/src/components/ai/input/content.ts
@@ -1,0 +1,108 @@
+import { buildGroupPathMap } from "@/lib/groupPath";
+import { buildMentionXml, escapeXmlText, parseMentionContent } from "@/lib/mentionXml";
+import { useAssetStore } from "@/stores/assetStore";
+import type {
+  AIChatInputDraft,
+  ProseMirrorLikeNode,
+  TipTapDocNode,
+  TipTapMentionNode,
+  TipTapParagraphNode,
+  TipTapTextNode,
+} from "./types";
+
+export function extractContentXml(doc: ProseMirrorLikeNode): string {
+  const assetStore = useAssetStore.getState();
+  const groupPathMap = buildGroupPathMap(assetStore.groups);
+  const lookupAsset = (id: number) => assetStore.assets.find((asset) => asset.ID === id);
+  const hostFromConfig = (cfg: string | undefined) => {
+    if (!cfg) return undefined;
+    try {
+      const parsed = JSON.parse(cfg) as { host?: string };
+      return parsed.host || undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  let out = "";
+  doc.descendants((node) => {
+    if (node.type.name === "text") {
+      out += escapeXmlText(node.text ?? "");
+    } else if (node.type.name === "mention") {
+      const id = Number(node.attrs.id);
+      const label = String(node.attrs.label ?? "");
+      const asset = Number.isFinite(id) ? lookupAsset(id) : undefined;
+      out += buildMentionXml({
+        assetId: id,
+        name: label,
+        type: asset?.Type,
+        host: asset ? hostFromConfig(asset.Config) : undefined,
+        groupPath: asset?.GroupID ? groupPathMap.get(asset.GroupID) : undefined,
+      });
+    } else if (node.type.name === "paragraph" && out.length > 0) {
+      out += "\n";
+    }
+    return true;
+  });
+  return out.replace(/\n+$/g, "");
+}
+
+function normalizeDraftMessage(draft: string | AIChatInputDraft): AIChatInputDraft {
+  if (typeof draft === "string") {
+    return { content: draft };
+  }
+  return { content: draft.content ?? "" };
+}
+
+function appendTextToParagraphs(
+  paragraphs: TipTapParagraphNode[],
+  text: string,
+  currentParagraphContent: Array<TipTapTextNode | TipTapMentionNode>
+) {
+  const segments = text.split("\n");
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    if (segment.length > 0) {
+      currentParagraphContent.push({ type: "text", text: segment });
+    }
+    if (index < segments.length - 1) {
+      paragraphs.push(
+        currentParagraphContent.length > 0
+          ? { type: "paragraph", content: currentParagraphContent }
+          : { type: "paragraph" }
+      );
+      currentParagraphContent = [];
+    }
+  }
+  return currentParagraphContent;
+}
+
+export function buildEditorDocFromMessage(message: string | AIChatInputDraft): TipTapDocNode {
+  const { content } = normalizeDraftMessage(message);
+  const segments = parseMentionContent(content);
+  const paragraphs: TipTapParagraphNode[] = [];
+  let currentParagraphContent: Array<TipTapTextNode | TipTapMentionNode> = [];
+
+  for (const seg of segments) {
+    if (seg.type === "text") {
+      currentParagraphContent = appendTextToParagraphs(paragraphs, seg.text, currentParagraphContent);
+    } else {
+      currentParagraphContent.push({
+        type: "mention",
+        attrs: {
+          id: String(seg.attrs.assetId),
+          label: seg.attrs.name,
+        },
+      });
+    }
+  }
+
+  paragraphs.push(
+    currentParagraphContent.length > 0 ? { type: "paragraph", content: currentParagraphContent } : { type: "paragraph" }
+  );
+
+  return {
+    type: "doc",
+    content: paragraphs,
+  };
+}

--- a/frontend/src/components/ai/input/extensions.ts
+++ b/frontend/src/components/ai/input/extensions.ts
@@ -1,0 +1,208 @@
+import type { MutableRefObject } from "react";
+import { Extension } from "@tiptap/core";
+import Mention from "@tiptap/extension-mention";
+import { ReactRenderer } from "@tiptap/react";
+import Suggestion, { type SuggestionKeyDownProps, type SuggestionProps } from "@tiptap/suggestion";
+import tippy, { type Instance } from "tippy.js";
+import { useSnippetStore } from "@/stores/snippetStore";
+import { ListSnippets } from "../../../../wailsjs/go/app/App";
+import { snippet_svc } from "../../../../wailsjs/go/models";
+import { MentionList, type MentionItem, type MentionListRef } from "../MentionList";
+import {
+  SnippetSuggestionList,
+  type SnippetSuggestionItem,
+  type SnippetSuggestionListRef,
+} from "../SnippetSuggestionList";
+
+function firstLine(s: string): string {
+  const index = s.indexOf("\n");
+  return index === -1 ? s.trim() : s.slice(0, index).trim();
+}
+
+function createClientRect(left: number, top: number, right: number, bottom: number): DOMRect {
+  const width = Math.max(0, right - left);
+  const height = Math.max(0, bottom - top);
+  return {
+    x: left,
+    y: top,
+    width,
+    height,
+    left,
+    top,
+    right,
+    bottom,
+    toJSON: () => ({ x: left, y: top, width, height, left, top, right, bottom }),
+  } as DOMRect;
+}
+
+function fallbackSuggestionClientRect(props: SuggestionProps<unknown>): DOMRect {
+  const docSize = props.editor.state.doc.content.size;
+  const from = Math.max(0, Math.min(props.range.from, docSize));
+  const to = Math.max(from, Math.min(props.range.to, docSize));
+
+  try {
+    const start = props.editor.view.coordsAtPos(from);
+    const end = props.editor.view.coordsAtPos(to);
+    return createClientRect(
+      Math.min(start.left, end.left),
+      Math.min(start.top, end.top),
+      Math.max(start.right, end.right),
+      Math.max(start.bottom, end.bottom)
+    );
+  } catch {
+    return createClientRect(0, 0, 0, 0);
+  }
+}
+
+function suggestionReferenceClientRect<TItem>(props: SuggestionProps<TItem>) {
+  return () => props.clientRect?.() ?? fallbackSuggestionClientRect(props as SuggestionProps<unknown>);
+}
+
+function createSuggestionPopup<TItem>(props: SuggestionProps<TItem>, content: Element): Instance[] {
+  return tippy("body", {
+    getReferenceClientRect: suggestionReferenceClientRect(props),
+    appendTo: () => document.body,
+    content,
+    showOnCreate: true,
+    interactive: true,
+    trigger: "manual",
+    placement: "bottom-start",
+  });
+}
+
+export function createMentionExtension(activeRef: MutableRefObject<boolean>) {
+  return Mention.configure({
+    HTMLAttributes: {
+      class: "ai-mention inline-flex items-center rounded bg-primary/10 text-primary px-1 py-0.5 text-xs font-medium",
+    },
+    renderLabel: ({ node }) => `@${node.attrs.label}`,
+    suggestion: {
+      items: () => [] as MentionItem[],
+      render: () => {
+        let component: ReactRenderer<MentionListRef> | null = null;
+        let popup: Instance[] = [];
+        const makeProps = (props: SuggestionProps<MentionItem>) => ({
+          query: props.query,
+          command: (item: MentionItem) => {
+            props.command({ id: String(item.id), label: item.label } as unknown as MentionItem);
+          },
+        });
+        return {
+          onStart: (props: SuggestionProps<MentionItem>) => {
+            activeRef.current = true;
+            component = new ReactRenderer(MentionList, {
+              props: makeProps(props),
+              editor: props.editor,
+            });
+            popup = createSuggestionPopup(props, component.element);
+          },
+          onUpdate: (props: SuggestionProps<MentionItem>) => {
+            component?.updateProps(makeProps(props));
+            if (popup[0]) {
+              popup[0].setProps({ getReferenceClientRect: suggestionReferenceClientRect(props) });
+            } else if (component) {
+              popup = createSuggestionPopup(props, component.element);
+            }
+          },
+          onKeyDown: (props: SuggestionKeyDownProps) => {
+            if (props.event.key === "Escape") {
+              popup[0]?.hide();
+              return true;
+            }
+            return component?.ref?.onKeyDown(props) || false;
+          },
+          onExit: () => {
+            activeRef.current = false;
+            popup[0]?.destroy();
+            component?.destroy();
+          },
+        };
+      },
+    },
+  });
+}
+
+export function createSnippetSuggestionExtension(activeRef: MutableRefObject<boolean>) {
+  return Extension.create({
+    name: "snippetSuggestion",
+    addProseMirrorPlugins() {
+      let lastTotal = 0;
+      return [
+        Suggestion<SnippetSuggestionItem>({
+          editor: this.editor,
+          char: "/",
+          command: ({ editor, range, props }) => {
+            editor.chain().focus().deleteRange(range).insertContent(props.content).run();
+            useSnippetStore.getState().recordUse(props.id);
+          },
+          items: async ({ query }) => {
+            try {
+              const req = new snippet_svc.ListReq({
+                categories: ["prompt"],
+                keyword: "",
+                limit: 0,
+                offset: 0,
+                orderBy: "",
+              });
+              const all = await ListSnippets(req);
+              const list: SnippetSuggestionItem[] = (all ?? []).map((snippet) => ({
+                id: snippet.ID,
+                name: snippet.Name,
+                preview: firstLine(snippet.Content ?? "").slice(0, 80),
+                content: snippet.Content ?? "",
+                readOnly: (snippet.Source ?? "").startsWith("ext:"),
+              }));
+              lastTotal = list.length;
+              const q = query.toLowerCase();
+              const filtered = q
+                ? list.filter((item) => item.name.toLowerCase().includes(q) || item.preview.toLowerCase().includes(q))
+                : list;
+              return filtered.slice(0, 20);
+            } catch {
+              return [];
+            }
+          },
+          render: () => {
+            let component: ReactRenderer<SnippetSuggestionListRef> | null = null;
+            let popup: Instance[] = [];
+            const buildProps = (props: SuggestionProps<SnippetSuggestionItem>) => ({
+              items: props.items,
+              totalAvailable: lastTotal,
+              command: props.command,
+            });
+            return {
+              onStart: (props) => {
+                activeRef.current = true;
+                component = new ReactRenderer(SnippetSuggestionList, {
+                  props: buildProps(props),
+                  editor: props.editor,
+                });
+                popup = createSuggestionPopup(props, component.element);
+              },
+              onUpdate: (props) => {
+                component?.updateProps(buildProps(props));
+                if (popup[0]) {
+                  popup[0].setProps({ getReferenceClientRect: suggestionReferenceClientRect(props) });
+                } else if (component) {
+                  popup = createSuggestionPopup(props, component.element);
+                }
+              },
+              onKeyDown: (props: SuggestionKeyDownProps) => {
+                if (props.event.key === "Escape") {
+                  popup[0]?.hide();
+                  return true;
+                }
+                return component?.ref?.onKeyDown(props) || false;
+              },
+              onExit: () => {
+                activeRef.current = false;
+                popup[0]?.destroy();
+                component?.destroy();
+              },
+            };
+          },
+        }),
+      ];
+    },
+  });
+}

--- a/frontend/src/components/ai/input/keyboard.ts
+++ b/frontend/src/components/ai/input/keyboard.ts
@@ -1,0 +1,45 @@
+import type { Editor } from "@tiptap/react";
+import type { EditorView } from "@tiptap/pm/view";
+import { buildEditorDocFromMessage } from "./content";
+import type { AIChatInputDraft, InputHistoryNavigationOptions } from "./types";
+
+export function shouldIgnoreEditorShortcut(view: EditorView, event: KeyboardEvent): boolean {
+  return view.composing || event.isComposing || event.keyCode === 229;
+}
+
+export function shouldStartInputHistory(editor: Editor) {
+  const { selection } = editor.state;
+  return selection.empty && selection.from === 1;
+}
+
+export function shouldContinueInputHistory(editor: Editor) {
+  return editor.state.selection.empty;
+}
+
+export function getInputHistoryNavigationState({
+  direction,
+  currentText,
+  historyIndex,
+  userMessageHistory,
+  canStartHistory,
+  canContinueHistory,
+}: InputHistoryNavigationOptions) {
+  const currentHistoryMessage = historyIndex >= 0 ? userMessageHistory[historyIndex] : null;
+  const isBrowsingHistory = currentHistoryMessage != null && currentText === currentHistoryMessage;
+  const canNavigate = isBrowsingHistory ? canContinueHistory : canStartHistory;
+
+  if (!canNavigate) return null;
+  if (direction === "up" && userMessageHistory.length === 0) return null;
+  if (direction === "down" && (!isBrowsingHistory || historyIndex < 0)) return null;
+
+  const nextHistoryIndex =
+    direction === "up" ? Math.min(historyIndex + 1, userMessageHistory.length - 1) : historyIndex - 1;
+  const nextMessage = nextHistoryIndex >= 0 ? userMessageHistory[nextHistoryIndex] : "";
+
+  return { nextHistoryIndex, nextMessage };
+}
+
+export function applyInputHistoryMessage(editor: Editor, nextMessage: string | AIChatInputDraft) {
+  editor.commands.setContent(buildEditorDocFromMessage(nextMessage));
+  editor.commands.focus("end");
+}

--- a/frontend/src/components/ai/input/types.ts
+++ b/frontend/src/components/ai/input/types.ts
@@ -1,0 +1,56 @@
+import type { Editor } from "@tiptap/react";
+
+export interface AIChatInputDraft {
+  content: string;
+}
+
+export interface AIChatInputHandle {
+  focus: () => void;
+  clear: () => void;
+  isEmpty: () => boolean;
+  submit: () => void;
+  loadDraft: (draft: string | AIChatInputDraft) => void;
+}
+
+export interface ProseMirrorLikeNode {
+  type: { name: string };
+  text?: string;
+  attrs: Record<string, unknown>;
+  descendants: (fn: (node: ProseMirrorLikeNode) => boolean | void) => void;
+}
+
+export interface TipTapTextNode {
+  type: "text";
+  text: string;
+}
+
+export interface TipTapMentionNode {
+  type: "mention";
+  attrs: {
+    id: string;
+    label: string;
+  };
+}
+
+export interface TipTapParagraphNode {
+  type: "paragraph";
+  content?: Array<TipTapTextNode | TipTapMentionNode>;
+}
+
+export interface TipTapDocNode {
+  type: "doc";
+  content: TipTapParagraphNode[];
+}
+
+export type InputHistoryDirection = "up" | "down";
+
+export interface InputHistoryNavigationOptions {
+  direction: InputHistoryDirection;
+  currentText: string;
+  historyIndex: number;
+  userMessageHistory: string[];
+  canStartHistory: boolean;
+  canContinueHistory: boolean;
+}
+
+export type TipTapEditor = Editor;

--- a/frontend/src/components/ai/input/useInputDraft.ts
+++ b/frontend/src/components/ai/input/useInputDraft.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, type MutableRefObject } from "react";
+import type { Editor } from "@tiptap/react";
+import { extractContentXml } from "./content";
+import type { AIChatInputDraft, ProseMirrorLikeNode } from "./types";
+
+const DRAFT_CHANGE_THROTTLE_MS = 120;
+
+export function useInputDraftSync(onDraftChangeRef: MutableRefObject<((draft: AIChatInputDraft) => void) | undefined>) {
+  const pendingEditorRef = useRef<Editor | null>(null);
+  const draftPendingRef = useRef(false);
+  const draftFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastDraftContentRef = useRef("");
+
+  const cancelPendingDraft = useCallback(() => {
+    if (draftFlushTimerRef.current != null) {
+      clearTimeout(draftFlushTimerRef.current);
+      draftFlushTimerRef.current = null;
+    }
+    draftPendingRef.current = false;
+    pendingEditorRef.current = null;
+  }, []);
+
+  const scheduleDraftFlush = useCallback(
+    (editor: Editor) => {
+      if (!onDraftChangeRef.current) return;
+      pendingEditorRef.current = editor;
+      draftPendingRef.current = true;
+      if (draftFlushTimerRef.current != null) return;
+
+      draftFlushTimerRef.current = setTimeout(() => {
+        draftFlushTimerRef.current = null;
+        if (!draftPendingRef.current) return;
+        draftPendingRef.current = false;
+
+        const pendingEditor = pendingEditorRef.current;
+        pendingEditorRef.current = null;
+        if (!pendingEditor) return;
+
+        const content = extractContentXml(pendingEditor.state.doc as unknown as ProseMirrorLikeNode);
+        if (content === lastDraftContentRef.current) return;
+        lastDraftContentRef.current = content;
+        onDraftChangeRef.current?.({ content });
+      }, DRAFT_CHANGE_THROTTLE_MS);
+    },
+    [onDraftChangeRef]
+  );
+
+  const clearDraftImmediately = useCallback(() => {
+    cancelPendingDraft();
+    lastDraftContentRef.current = "";
+    onDraftChangeRef.current?.({ content: "" });
+  }, [cancelPendingDraft, onDraftChangeRef]);
+
+  useEffect(() => cancelPendingDraft, [cancelPendingDraft]);
+
+  return {
+    scheduleDraftFlush,
+    clearDraftImmediately,
+    cancelPendingDraft,
+  };
+}

--- a/frontend/src/components/approval/ApprovalBlock.tsx
+++ b/frontend/src/components/approval/ApprovalBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ShieldAlert, Terminal, Database, Server, Globe, FolderOpen, FileEdit, FilePlus } from "lucide-react";
 import { Button, Input, Textarea } from "@opskat/ui";
@@ -10,7 +10,7 @@ interface ApprovalBlockProps {
   block: ContentBlock;
 }
 
-export function ApprovalBlock({ block }: ApprovalBlockProps) {
+export const ApprovalBlock = memo(function ApprovalBlock({ block }: ApprovalBlockProps) {
   const { t } = useTranslation();
   const isPending = block.status === "pending_confirm";
   const items = block.approvalItems || [];
@@ -261,7 +261,7 @@ export function ApprovalBlock({ block }: ApprovalBlockProps) {
       </div>
     </div>
   );
-}
+});
 
 function TypeBadge({ type, compact }: { type: string; compact?: boolean }) {
   const icons: Record<string, typeof Terminal> = {

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -822,6 +822,20 @@
       "tooltip": "Token usage for this reply"
     },
     "retrying": "Retrying",
+    "retry": {
+      "retrying": "Retrying",
+      "attempt": "Attempt {{n}}",
+      "countdown_seconds": "{{n}}s",
+      "now": "Retrying now..."
+    },
+    "error": {
+      "rate_limit": "Too many requests, please wait",
+      "server": "Service temporarily unavailable",
+      "network": "Unstable network connection",
+      "auth": "Authentication failed, please check API Key",
+      "interrupted": "Conversation interrupted",
+      "unknown": "Conversation failed"
+    },
     "newConversation": "New conversation",
     "sidebar": {
       "title": "AI Assistant",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -807,6 +807,20 @@
       "tooltip": "本次回复 token 使用量"
     },
     "retrying": "重试中",
+    "retry": {
+      "retrying": "重试中",
+      "attempt": "第 {{n}} 次",
+      "countdown_seconds": "{{n}}s",
+      "now": "正在重试..."
+    },
+    "error": {
+      "rate_limit": "请求过于频繁，稍后再试",
+      "server": "服务暂时不可用",
+      "network": "网络连接不稳定",
+      "auth": "鉴权失败，请检查 API Key",
+      "interrupted": "对话被中断",
+      "unknown": "对话出错"
+    },
     "newConversation": "新对话",
     "sidebar": {
       "title": "AI 助手",

--- a/frontend/src/lib/aiError.ts
+++ b/frontend/src/lib/aiError.ts
@@ -1,0 +1,60 @@
+import i18n from "../i18n";
+
+// ErrorKind: AI 对话错误分类。
+// rate_limit  — 429 / 限流
+// server      — 5xx / 服务暂不可用
+// network     — 连接抖动、超时、TLS 握手失败、EOF
+// auth        — 401/403 / API Key 无效（cago 默认不重试，UI 直接呈现）
+// interrupted — 重试进行中被用户关闭 tab / 切会话 / 应用退出 时落盘的中断标记
+// unknown     — 未命中任何模式，按原文展示
+export type ErrorKind = "rate_limit" | "server" | "network" | "auth" | "interrupted" | "unknown";
+
+const I18N_KEY_BY_KIND: Record<ErrorKind, string> = {
+  rate_limit: "ai.error.rate_limit",
+  server: "ai.error.server",
+  network: "ai.error.network",
+  auth: "ai.error.auth",
+  interrupted: "ai.error.interrupted",
+  unknown: "ai.error.unknown",
+};
+
+const FALLBACK_LABEL_BY_KIND: Record<ErrorKind, string> = {
+  rate_limit: "请求过于频繁，稍后再试",
+  server: "服务暂时不可用",
+  network: "网络连接不稳定",
+  auth: "鉴权失败，请检查 API Key",
+  interrupted: "对话被中断",
+  unknown: "对话出错",
+};
+
+// 匹配优先级遵循 README 的从高到低顺序：
+// auth 优先于 rate_limit/server（避免 401 被 5xx 关键字误捞），
+// rate_limit/network 优先于 server（429/timeout 在响应里有时也带 5xx 串）。
+const PATTERNS: Array<{ kind: ErrorKind; re: RegExp }> = [
+  { kind: "auth", re: /\b(401|403)\b|api[\s._-]?key|invalid_api|authentication|unauthorized/i },
+  { kind: "rate_limit", re: /\b429\b|too many|rate[\s._-]?limit/i },
+  { kind: "network", re: /timeout|EOF|connection reset|broken pipe|i\/o timeout|tls handshake/i },
+  { kind: "server", re: /\b5\d{2}\b|service unavailable|bad gateway|gateway timeout|server error/i },
+];
+
+export interface ClassifiedError {
+  kind: ErrorKind;
+  message: string;
+}
+
+// classifyError 把原始 error 文本归类成 ErrorKind + 友好标题。
+// 显式传入 kind 时跳过正则（用于 interrupted 路径），message 仍走 i18n。
+export function classifyError(raw: string | undefined | null, explicitKind?: ErrorKind): ClassifiedError {
+  const text = (raw ?? "").trim();
+  let kind: ErrorKind = explicitKind ?? "unknown";
+  if (!explicitKind) {
+    for (const { kind: k, re } of PATTERNS) {
+      if (re.test(text)) {
+        kind = k;
+        break;
+      }
+    }
+  }
+  const message = i18n.t(I18N_KEY_BY_KIND[kind], FALLBACK_LABEL_BY_KIND[kind]);
+  return { kind, message };
+}

--- a/frontend/src/lib/groupPath.ts
+++ b/frontend/src/lib/groupPath.ts
@@ -45,16 +45,31 @@ export function resolveGroupPath(
   return resolveGroupPathFromLookup(buildGroupLookup(groups), groupId, separator);
 }
 
+// 按 (groups 引用, separator) 缓存路径映射。
+// 高频调用点（如 AI 输入框 onUpdate）会在每次按键时调用本函数；assetStore.groups 引用稳定时直接命中缓存，
+// 避免 O(N²) 的重复路径回溯让输入产生肉眼可见的卡顿。
+const groupPathMapCache = new WeakMap<group_entity.Group[], Map<string, Map<number, string>>>();
+
 /** 把 group 列表解析为 groupId -> "父/子/孙" 路径映射。异常 parent 环会在当前视角截断，避免缓存污染。 */
 export function buildGroupPathMap(
   groups: group_entity.Group[],
   { separator = DEFAULT_SEPARATOR }: GroupPathOptions = {}
 ): Map<number, string> {
+  let bySeparator = groupPathMapCache.get(groups);
+  if (bySeparator) {
+    const cached = bySeparator.get(separator);
+    if (cached) return cached;
+  }
   const byId = buildGroupLookup(groups);
   const map = new Map<number, string>();
   for (const group of groups) {
     map.set(group.ID, resolveGroupPathFromLookup(byId, group.ID, separator));
   }
+  if (!bySeparator) {
+    bySeparator = new Map();
+    groupPathMapCache.set(groups, bySeparator);
+  }
+  bySeparator.set(separator, map);
   return map;
 }
 

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -59,6 +59,10 @@ export interface TokenUsage {
 }
 
 export interface ChatMessage {
+  // 前端会话内稳定 ID（仅前端使用，不随后端持久化往返）。
+  // 用作 React list key，避免编辑重发 / queue_consumed 截断重插时按 index 复用错误的子组件实例
+  // （ToolBlock / ThinkingBlock 的 expanded 等本地 state 串到别的消息）。
+  id?: string;
   role: "user" | "assistant" | "tool";
   content: string;
   blocks: ContentBlock[];
@@ -509,6 +513,7 @@ function toDisplayMessages(msgs: ChatMessage[], includeStreaming = false): app.C
 
 function convertDisplayMessages(displayMsgs: app.ConversationDisplayMessage[]): ChatMessage[] {
   return (displayMsgs || []).map((dm: app.ConversationDisplayMessage) => ({
+    id: crypto.randomUUID(),
     role: dm.role as "user" | "assistant" | "tool",
     content: dm.content,
     blocks: (dm.blocks || []).map((b: conversation_entity.ContentBlock) => ({
@@ -854,6 +859,7 @@ function drainQueue(convId: number) {
   const newMsgs = [...currentMsgs];
   for (const item of queue) {
     newMsgs.push({
+      id: crypto.randomUUID(),
       role: "user" as const,
       content: item.text,
       blocks: [],
@@ -1159,12 +1165,14 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
         }
       }
       nextMsgs.push({
+        id: crypto.randomUUID(),
         role: "user" as const,
         content: event.content || "",
         blocks: [],
         streaming: false,
       });
       nextMsgs.push({
+        id: crypto.randomUUID(),
         role: "assistant" as const,
         content: "",
         blocks: [],
@@ -1421,6 +1429,7 @@ async function _sendForConversation(convId: number, content: string) {
     updateConversation(convId, { sending: true });
   } else {
     newMessages.push({
+      id: crypto.randomUUID(),
       role: "user",
       content,
       blocks: [],
@@ -1432,6 +1441,7 @@ async function _sendForConversation(convId: number, content: string) {
   }
 
   const assistantMsg: ChatMessage = {
+    id: crypto.randomUUID(),
     role: "assistant",
     content: "",
     blocks: [],

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -4,6 +4,8 @@ import {
   SendAIMessage,
   StopAIGeneration,
   QueueAIMessage,
+  RemoveQueuedAIMessage,
+  ClearQueuedAIMessages,
   GetActiveAIProvider,
   CreateConversation,
   ListConversations,
@@ -65,12 +67,14 @@ export interface ChatMessage {
 }
 
 export interface PendingQueueItem {
+  id: string;
   text: string;
 }
 
 interface StreamEventData {
   type: string;
   content?: string;
+  queue_id?: string;
   tool_name?: string;
   tool_input?: string;
   tool_call_id?: string;
@@ -177,6 +181,12 @@ function getDefaultSidebarTitle() {
 
 function createSidebarTabId() {
   return `sidebar-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createPendingQueueId() {
+  const randomUUID = globalThis.crypto?.randomUUID?.bind(globalThis.crypto);
+  if (randomUUID) return `queue-${randomUUID()}`;
+  return `queue-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 function createSidebarTab(overrides?: Partial<SidebarAITab>): SidebarAITab {
@@ -364,14 +374,16 @@ function persistNow(convId: number, includeStreaming = false) {
   persistConversationSnapshot(convId, includeStreaming);
 }
 
-// === 流式事件缓冲（性能优化：合并高频 content/thinking 事件，按帧刷新）===
+// === 流式事件缓冲（性能优化：合并高频 content/thinking 事件，降低主线程刷新压力）===
 
-const streamBuffers = new Map<number, { content: string; thinking: string; raf: number | null }>();
+const STREAM_FLUSH_INTERVAL_MS = 50;
+type StreamBuffer = { content: string; thinking: string; timer: ReturnType<typeof setTimeout> | null };
+const streamBuffers = new Map<number, StreamBuffer>();
 
 function getOrCreateStreamBuffer(convId: number) {
   let buf = streamBuffers.get(convId);
   if (!buf) {
-    buf = { content: "", thinking: "", raf: null };
+    buf = { content: "", thinking: "", timer: null };
     streamBuffers.set(convId, buf);
   }
   return buf;
@@ -380,9 +392,9 @@ function getOrCreateStreamBuffer(convId: number) {
 function flushStreamBuffer(convId: number) {
   const buf = streamBuffers.get(convId);
   if (!buf) return;
-  if (buf.raf !== null) {
-    cancelAnimationFrame(buf.raf);
-    buf.raf = null;
+  if (buf.timer !== null) {
+    clearTimeout(buf.timer);
+    buf.timer = null;
   }
   const cd = buf.content;
   const td = buf.thinking;
@@ -419,9 +431,19 @@ function flushStreamBuffer(convId: number) {
   });
 }
 
+function scheduleStreamBufferFlush(convId: number) {
+  const buf = getOrCreateStreamBuffer(convId);
+  if (buf.timer !== null) return;
+  buf.timer = setTimeout(() => {
+    const b = streamBuffers.get(convId);
+    if (b) b.timer = null;
+    flushStreamBuffer(convId);
+  }, STREAM_FLUSH_INTERVAL_MS);
+}
+
 function cleanupStreamBuffer(convId: number) {
   const buf = streamBuffers.get(convId);
-  if (buf?.raf != null) cancelAnimationFrame(buf.raf);
+  if (buf?.timer != null) clearTimeout(buf.timer);
   streamBuffers.delete(convId);
 }
 
@@ -882,7 +904,7 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
   const currentMsgs = useAIStore.getState().conversationMessages[convId] || [];
   if (!currentMsgs) return;
 
-  // 高频事件缓冲：content/thinking 通过 RAF 合并，每帧最多一次状态更新
+  // 高频事件缓冲：content/thinking 通过固定时间窗合并，避免每帧重解析 Markdown 抢占输入。
   if (event.type === "content" || event.type === "thinking") {
     const buf = getOrCreateStreamBuffer(convId);
     if (event.type === "content") {
@@ -890,13 +912,7 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
     } else {
       buf.thinking += event.content || "";
     }
-    if (buf.raf === null) {
-      buf.raf = requestAnimationFrame(() => {
-        const b = streamBuffers.get(convId);
-        if (b) b.raf = null;
-        flushStreamBuffer(convId);
-      });
-    }
+    scheduleStreamBufferFlush(convId);
     return;
   }
 
@@ -1154,7 +1170,11 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
         blocks: [],
         streaming: true,
       });
-      const newQueue = curQueue.length > 0 ? curQueue.slice(1) : [];
+      const newQueue = event.queue_id
+        ? curQueue.filter((item) => item.id !== event.queue_id)
+        : curQueue.length > 0
+          ? curQueue.slice(1)
+          : [];
       updateConversation(convId, { messages: nextMsgs, pendingQueue: newQueue });
       // 排队消息被消费（插入新 user + 开启新 assistant）属于低频关键事件，立即落盘。
       persistNow(convId, true);
@@ -1374,11 +1394,19 @@ async function _sendForConversation(convId: number, content: string) {
 
   // 生成中时排队：推送到后端 runner 队列 + 本地队列（用于 UI 显示）
   if (streaming.sending) {
-    if (content.trim()) {
+    const text = content.trim();
+    if (text) {
+      const queueID = createPendingQueueId();
       updateConversation(convId, {
-        pendingQueue: [...streaming.pendingQueue, { text: content.trim() }],
+        pendingQueue: [...streaming.pendingQueue, { id: queueID, text }],
       });
-      QueueAIMessage(convId, content.trim()).catch(() => {});
+      QueueAIMessage(convId, queueID, text).catch(() => {
+        const current = useAIStore.getState().conversationStreaming[convId];
+        if (!current?.pendingQueue.some((item) => item.id === queueID)) return;
+        updateConversation(convId, {
+          pendingQueue: current.pendingQueue.filter((item) => item.id !== queueID),
+        });
+      });
     }
     return;
   }
@@ -1496,8 +1524,8 @@ interface AIState {
   stopGeneration: (tabId: string) => Promise<void>;
   regenerate: (tabId: string, messageIndex: number) => Promise<void>;
   regenerateConversation: (convId: number, messageIndex: number) => Promise<void>;
-  removeFromQueue: (convId: number, index: number) => void;
-  clearQueue: (convId: number) => void;
+  removeFromQueue: (convId: number, index: number) => Promise<void>;
+  clearQueue: (convId: number) => Promise<void>;
 
   // Tab 管理 (delegates to tabStore)
   openConversationTab: (conversationId: number) => Promise<string>;
@@ -2118,15 +2146,37 @@ export const useAIStore = create<AIState>((set, get) => {
       await replayConversation(convId, truncated, "");
     },
 
-    removeFromQueue: (convId: number, index: number) => {
+    removeFromQueue: async (convId: number, index: number) => {
       const streaming = get().conversationStreaming[convId];
       if (!streaming) return;
-      const newQueue = streaming.pendingQueue.filter((_, i) => i !== index);
-      updateConversation(convId, { pendingQueue: newQueue });
+      const item = streaming.pendingQueue[index];
+      if (!item) return;
+      let removed: boolean;
+      try {
+        removed = await RemoveQueuedAIMessage(convId, item.id);
+      } catch {
+        return;
+      }
+      if (!removed) return;
+      const current = get().conversationStreaming[convId];
+      if (!current) return;
+      updateConversation(convId, { pendingQueue: current.pendingQueue.filter((queued) => queued.id !== item.id) });
     },
 
-    clearQueue: (convId: number) => {
-      updateConversation(convId, { pendingQueue: [] });
+    clearQueue: async (convId: number) => {
+      const streaming = get().conversationStreaming[convId];
+      if (!streaming || streaming.pendingQueue.length === 0) return;
+      let removedIDs: string[];
+      try {
+        removedIDs = (await ClearQueuedAIMessages(convId)) ?? [];
+      } catch {
+        return;
+      }
+      if (removedIDs.length === 0) return;
+      const removed = new Set(removedIDs);
+      const current = get().conversationStreaming[convId];
+      if (!current) return;
+      updateConversation(convId, { pendingQueue: current.pendingQueue.filter((item) => !removed.has(item.id)) });
     },
 
     // === 查询 ===

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -314,9 +314,6 @@ function loadInitialSidebarState() {
 const conversationListeners = new Map<number, { cancel: (() => void) | null; generation: number }>();
 const conversationStopRequests = new Set<number>();
 
-// 每个 conversation 只保留一个待执行的落盘定时器。
-// 流式输出期间会持续增量更新消息，如果每次都立即保存，磁盘写入会过于频繁。
-const persistTimers = new Map<number, number>();
 const conversationRenameVersions = new Map<number, number>();
 const conversationRenameInFlight = new Set<number>();
 let conversationListBarrier = 0;
@@ -341,7 +338,6 @@ function cleanupConvListener(convId: number) {
   conversationListeners.delete(convId);
   conversationStopRequests.delete(convId);
   cleanupStreamBuffer(convId);
-  cleanupPersistTimer(convId);
 }
 
 function invalidateConvListenerForReplay(convId: number) {
@@ -355,15 +351,6 @@ function invalidateConvListenerForReplay(convId: number) {
   cleanupStreamBuffer(convId);
 }
 
-// cleanupPersistTimer 清理指定 conversation 尚未执行的落盘定时器。
-function cleanupPersistTimer(convId: number) {
-  const timer = persistTimers.get(convId);
-  if (timer !== undefined) {
-    window.clearTimeout(timer);
-    persistTimers.delete(convId);
-  }
-}
-
 // persistConversationSnapshot 将当前 conversation 的消息快照保存到持久化存储。
 function persistConversationSnapshot(convId: number, includeStreaming = false) {
   const msgs = useAIStore.getState().conversationMessages[convId];
@@ -371,23 +358,9 @@ function persistConversationSnapshot(convId: number, includeStreaming = false) {
   SaveConversationMessages(convId, toDisplayMessages(msgs, includeStreaming)).catch(() => {});
 }
 
-// schedulePersist 为 conversation 安排一次短延迟的消息快照保存。
-// 流式输出期间做一次短延迟防抖：
-// 1. 降低高频写入带来的性能开销；
-// 2. 让应用异常退出前，尽量已经落下最近一段对话快照。
-function schedulePersist(convId: number, includeStreaming = false) {
-  cleanupPersistTimer(convId);
-  const timer = window.setTimeout(() => {
-    persistTimers.delete(convId);
-    persistConversationSnapshot(convId, includeStreaming);
-  }, 300);
-  persistTimers.set(convId, timer);
-}
-
-// persistNow 取消 schedulePersist 的防抖定时器，立即落盘一次。
-// 用于低频关键事件（用户发送、工具调用、审批等），避免防抖窗口内崩溃丢数据。
+// persistNow 立即落盘一次。
+// 用于低频关键事件（用户发送、工具调用、审批、终态等）。
 function persistNow(convId: number, includeStreaming = false) {
-  cleanupPersistTimer(convId);
   persistConversationSnapshot(convId, includeStreaming);
 }
 
@@ -444,9 +417,6 @@ function flushStreamBuffer(convId: number) {
       conversationMessages: { ...state.conversationMessages, [convId]: updated },
     };
   });
-
-  // 增量内容刷入消息列表后，同步安排一次防抖落盘。
-  schedulePersist(convId, true);
 }
 
 function cleanupStreamBuffer(convId: number) {
@@ -847,11 +817,6 @@ function updateConversation(
       conversationStreaming: newConvStreaming,
     };
   });
-
-  if (updates.messages !== undefined) {
-    // 消息列表发生变化后，补一轮防抖持久化。
-    schedulePersist(convId, true);
-  }
 }
 
 function drainQueue(convId: number) {
@@ -885,7 +850,6 @@ function drainQueue(convId: number) {
 function prepareConversationForReplay(convId: number) {
   conversationStopRequests.delete(convId);
   invalidateConvListenerForReplay(convId);
-  cleanupPersistTimer(convId);
   updateConversation(convId, { sending: false, pendingQueue: [] });
 }
 
@@ -1227,7 +1191,6 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
       }
 
       // 终态立即落盘
-      cleanupPersistTimer(convId);
       persistConversationSnapshot(convId);
       useAIStore.getState().fetchConversations();
 
@@ -1266,7 +1229,6 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
       }
 
       // 终态立即落盘，保证标题刷新前后都能恢复到完整会话内容。
-      cleanupPersistTimer(convId);
       persistConversationSnapshot(convId);
       // Refresh conversations (title may have updated); sync any open tab bound to this conv.
       useAIStore
@@ -1311,7 +1273,6 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
       }
 
       // 错误态同样需要落盘，否则强制重启后会丢掉最后一次失败上下文。
-      cleanupPersistTimer(convId);
       persistConversationSnapshot(convId, true);
       cleanupConversationIfUnused(convId);
       break;
@@ -1437,8 +1398,8 @@ async function _sendForConversation(convId: number, content: string) {
       blocks: [],
     });
     updateConversation(convId, { messages: newMessages, sending: true });
-    // 用户消息是用户亲手输入的内容，最不应该丢；绕过 300ms 防抖立即落盘。
-    // includeStreaming=true 保留历史未完成 block（如有），与 schedulePersist 的默认行为一致。
+    // 用户消息是用户亲手输入的内容，最不应该丢；发送后立即落盘。
+    // includeStreaming=true 保留历史未完成 block（如有）。
     persistNow(convId, true);
   }
 
@@ -1815,8 +1776,7 @@ export const useAIStore = create<AIState>((set, get) => {
       const closingTab = state.sidebarTabs[index];
       if (closingTab.conversationId != null) {
         // 侧边宿主关闭前先把当前会话快照刷盘；
-        // 但真正的 listener / persist timer 回收要等到确认没有其它宿主仍引用该会话。
-        cleanupPersistTimer(closingTab.conversationId);
+        // 但真正的 listener 回收要等到确认没有其它宿主仍引用该会话。
         persistConversationSnapshot(closingTab.conversationId, true);
       }
 
@@ -2258,7 +2218,6 @@ registerTabCloseHook((tab) => {
     // 关闭标签前补一次最终快照，避免最后一段对话未落盘。
     // 关闭时流式输出可能仍在进行（streaming=true），必须传 includeStreaming=true 才能
     // 把最后一段 assistant 消息一起落盘；toDisplayMessages 会把未完结的 block 归一为 cancelled。
-    cleanupPersistTimer(meta.conversationId);
     persistConversationSnapshot(meta.conversationId, true);
     cleanupConversationIfUnused(meta.conversationId, { ignoreMainTabId: tab.id });
   }
@@ -2347,7 +2306,6 @@ async function flushAllConversationsAsync(): Promise<void> {
   for (const convIdStr of Object.keys(allMsgs)) {
     const convId = Number(convIdStr);
     if (!convId) continue;
-    cleanupPersistTimer(convId);
     const msgs = allMsgs[convId];
     if (!msgs) continue;
     promises.push(SaveConversationMessages(convId, toDisplayMessages(msgs, true)).catch(() => {}));

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -19,10 +19,13 @@ import { EventsOn, EventsEmit } from "../../wailsjs/runtime/runtime";
 import i18n from "../i18n";
 import { useTabStore, registerTabCloseHook, registerTabRestoreHook, type AITabMeta, type Tab } from "./tabStore";
 import { stripMentionTags } from "@/lib/mentionXml";
+import { classifyError, type ErrorKind } from "@/lib/aiError";
 
-// 内容块：文本、工具调用、Sub Agent 或审批
+// 内容块：文本、工具调用、Sub Agent、审批、错误（持久化字段）。
+// "error" 块由 EventError 推入，或在 retry 中途退出落盘时由 retryStatus 物化而来。
+// 不会作为历史回放发给 LLM —— ToAgentMessages 后端侧需过滤。
 export interface ContentBlock {
-  type: "text" | "tool" | "agent" | "approval" | "thinking";
+  type: "text" | "tool" | "agent" | "approval" | "thinking" | "error";
   content: string;
   toolName?: string;
   toolInput?: string;
@@ -48,6 +51,11 @@ export interface ContentBlock {
   approvalSessionId?: string;
   approvalToolName?: string; // local_tool: "bash" | "write" | "edit"
   approvalPatterns?: string[]; // local_tool: 默认 pattern 列表，本次会话允许时预填可编辑
+  // error 块专用：
+  //   kind   — classifyError 输出的归类标签，UI 据此显示标题/图标
+  //   detail — 原始错误正文（content 保留为空或拼接版，前端展示用 detail 优先）
+  errorKind?: ErrorKind;
+  errorDetail?: string;
 }
 
 // Assistant 消息累计 token 使用量；单次用户 turn 可能跨多轮 LLM 调用，前端按 usage 事件累加。
@@ -56,6 +64,17 @@ export interface TokenUsage {
   outputTokens?: number;
   cacheCreationTokens?: number;
   cacheReadTokens?: number;
+}
+
+// retry 期间的 transient 状态：cago EventRetry 时设置，下一条非 retry 事件到达时清掉。
+// 不持久化到 DB —— toDisplayMessages 序列化时直接 omit。
+// 应用退出 / 关 tab 时若该字段仍存在，会被 materializeRetryStatusAsError 物化成
+// 一个 ErrorBlock(kind=interrupted) 落盘，下次打开仍可见。
+export interface ChatMessageRetryStatus {
+  attempt: number;
+  delayMs: number;
+  startedAt: number; // Date.now()，前端做倒计时 countdown 用
+  cause?: string;
 }
 
 export interface ChatMessage {
@@ -68,6 +87,7 @@ export interface ChatMessage {
   blocks: ContentBlock[];
   streaming?: boolean;
   tokenUsage?: TokenUsage;
+  retryStatus?: ChatMessageRetryStatus;
 }
 
 export interface PendingQueueItem {
@@ -107,6 +127,8 @@ interface StreamEventData {
     cache_creation_tokens?: number;
     cache_read_tokens?: number;
   };
+  // retry 事件：下一次重试前的等待毫秒（Retry-After 头或指数退避）；attempt 序号放在 content 字段
+  retryDelayMs?: number;
 }
 
 // Sidebar 专用 UI 态（inputDraft / scrollTop / editTarget）。workspace tab 不使用这些字段，
@@ -488,8 +510,34 @@ function normalizeSnapshotStatus(status: ContentBlock["status"]): ContentBlock["
   return STREAMING_SNAPSHOT_STATUS_OVERRIDES[status] ?? status;
 }
 
+// materializeRetryStatusAsError 把 retry 进行中的 transient 状态物化成一个
+// kind="interrupted" 的 ErrorBlock。在 includeStreaming=true 的落盘路径调用
+// （关闭 tab / 切会话 / Wails OnBeforeClose 应用退出），保证下次打开仍能看到
+// "重试中被中断"的错误线索，而不是只看到一段灰色 cancelled 文本。
+//
+// 没有 retryStatus 时原样返回，避免无意义的对象拷贝。
+function materializeRetryStatusAsError(msg: ChatMessage): ChatMessage {
+  if (!msg.retryStatus) return msg;
+  const { kind, message } = classifyError(msg.retryStatus.cause, "interrupted");
+  const errBlock: ContentBlock = {
+    type: "error",
+    content: message,
+    errorKind: kind,
+    errorDetail: msg.retryStatus.cause || "",
+  };
+  return {
+    ...msg,
+    blocks: [...msg.blocks, errBlock],
+    retryStatus: undefined,
+  };
+}
+
 function toDisplayMessages(msgs: ChatMessage[], includeStreaming = false): app.ConversationDisplayMessage[] {
-  return msgs
+  // includeStreaming=true 的路径都是"非自然终态落盘"（tab 关闭 / 切会话 / 应用退出），
+  // 在这里把 retryStatus 物化为 interrupted ErrorBlock；其余路径 retryStatus 自动 omit
+  // （ChatMessage 顶层字段不进入 ConversationDisplayMessage）。
+  const prepared = includeStreaming ? msgs.map(materializeRetryStatusAsError) : msgs;
+  return prepared
     .filter((m) => includeStreaming || !m.streaming)
     .map(
       (m) =>
@@ -504,6 +552,8 @@ function toDisplayMessages(msgs: ChatMessage[], includeStreaming = false): app.C
                 toolName: b.toolName,
                 toolInput: b.toolInput,
                 status: includeStreaming ? normalizeSnapshotStatus(b.status) : b.status,
+                errorKind: b.errorKind,
+                errorDetail: b.errorDetail,
               })
           ),
           tokenUsage: m.tokenUsage ? new conversation_entity.TokenUsage(m.tokenUsage) : undefined,
@@ -517,11 +567,13 @@ function convertDisplayMessages(displayMsgs: app.ConversationDisplayMessage[]): 
     role: dm.role as "user" | "assistant" | "tool",
     content: dm.content,
     blocks: (dm.blocks || []).map((b: conversation_entity.ContentBlock) => ({
-      type: b.type as "text" | "tool" | "agent",
+      type: b.type as ContentBlock["type"],
       content: b.content,
       toolName: b.toolName,
       toolInput: b.toolInput,
-      status: b.status as "running" | "completed" | "error" | undefined,
+      status: b.status as ContentBlock["status"],
+      errorKind: b.errorKind as ErrorKind | undefined,
+      errorDetail: b.errorDetail,
     })),
     tokenUsage: dm.tokenUsage
       ? {
@@ -905,10 +957,30 @@ async function replayConversation(convId: number, nextMessages: ChatMessage[], c
   await _sendForConversation(convId, "");
 }
 
+// 清掉 lastAssistant 上的 retryStatus —— 任何非 retry 事件到达都意味着"流恢复"了
+// （要么是 cago handleRetry 后 ChatStream 重新出 delta，要么是 EventError/stopped/done 终止）。
+// 没有 retryStatus 时不触发额外 setState，避免高频事件产生空 update。
+function clearRetryStatusOnLastAssistant(convId: number) {
+  const msgs = useAIStore.getState().conversationMessages[convId];
+  if (!msgs || msgs.length === 0) return;
+  const lastIdx = msgs.length - 1;
+  const last = msgs[lastIdx];
+  if (last.role !== "assistant" || !last.retryStatus) return;
+  const updated = [...msgs];
+  updated[lastIdx] = { ...last, retryStatus: undefined };
+  updateConversation(convId, { messages: updated });
+}
+
 // 事件处理：核心流式状态机，完全基于 convId
 function handleStreamEvent(convId: number, event: StreamEventData) {
   const currentMsgs = useAIStore.getState().conversationMessages[convId] || [];
   if (!currentMsgs) return;
+
+  // 任何非 retry 事件都视为"流恢复"，立即清掉 lastAssistant 上的 retryStatus。
+  // 重试成功后下一帧 content/thinking 一到就把 RetryBanner 关掉，无须 UI 自行判定。
+  if (event.type !== "retry") {
+    clearRetryStatusOnLastAssistant(convId);
+  }
 
   // 高频事件缓冲：content/thinking 通过固定时间窗合并，避免每帧重解析 Markdown 抢占输入。
   if (event.type === "content" || event.type === "thinking") {
@@ -1231,10 +1303,17 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
     }
 
     case "retry": {
-      const reason = event.error ? `: ${event.error}` : "";
+      // Attempt 序号放在 content 字段（后端 strconv.Itoa）；解析失败时退化为 0，
+      // RetryBanner 仍能显示 "正在重试..." 文案。
+      const attempt = parseInt(event.content || "0", 10) || 0;
       const updated = updateLastAssistant(msgs, (msg) => ({
         ...msg,
-        blocks: appendText(msg.blocks, `\n\n*${i18n.t("ai.retrying", "重试中")} (${event.content})${reason}*`),
+        retryStatus: {
+          attempt,
+          delayMs: event.retryDelayMs ?? 0,
+          startedAt: Date.now(),
+          cause: event.error,
+        },
       }));
       if (updated) updateConversation(convId, { messages: updated });
       break;
@@ -1289,9 +1368,16 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
 
     case "error": {
       cleanupStreamBuffer(convId);
+      const { kind, message } = classifyError(event.error);
+      const errBlock: ContentBlock = {
+        type: "error",
+        content: message,
+        errorKind: kind,
+        errorDetail: event.error || "",
+      };
       const updated = updateLastAssistant(msgs, (msg) => ({
         ...msg,
-        blocks: appendText(msg.blocks, `\n\n**Error:** ${event.error}`),
+        blocks: [...msg.blocks, errBlock],
         streaming: false,
       }));
       if (updated) {
@@ -1386,7 +1472,8 @@ function expandToAPIMessages(messages: ChatMessage[]): ai.Message[] {
           })
         );
       }
-      // approval / agent 块不参与 LLM 历史还原，跳过
+      // approval / agent / error 块不参与 LLM 历史还原，跳过。
+      // error 块的归类标签和原始错误正文是 UI 显示用，不应作为历史 prompt 影响 LLM。
     }
     flushAssistant();
   }

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -2073,7 +2073,14 @@ export const useAIStore = create<AIState>((set, get) => {
                   [conv.ID]: { sending: false, pendingQueue: [] },
                 },
             sidebarTabs: state.sidebarTabs.map((tab) =>
-              tab.id === tabId ? { ...tab, conversationId: conv.ID, title: conv.Title || tab.title } : tab
+              tab.id === tabId
+                ? {
+                    ...tab,
+                    conversationId: conv.ID,
+                    title: conv.Title || tab.title,
+                    uiState: createDefaultSidebarUiState(),
+                  }
+                : tab
             ),
           }));
         });

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -43,6 +43,8 @@ export function Cleanup():Promise<void>;
 
 export function ClearGitHubToken():Promise<void>;
 
+export function ClearQueuedAIMessages(arg1:number):Promise<Array<string>>;
+
 export function ClearWebDAVConfig():Promise<void>;
 
 export function ConnectSSH(arg1:app.SSHConnectRequest):Promise<string>;
@@ -361,7 +363,7 @@ export function PreviewSSHConfig():Promise<import_svc.PreviewResult>;
 
 export function PreviewTabbyConfig():Promise<import_svc.PreviewResult>;
 
-export function QueueAIMessage(arg1:number,arg2:string):Promise<void>;
+export function QueueAIMessage(arg1:number,arg2:string,arg3:string):Promise<void>;
 
 export function RecordSnippetUse(arg1:number):Promise<void>;
 
@@ -414,6 +416,8 @@ export function RedisZSetAdd(arg1:number,arg2:number,arg3:string,arg4:string,arg
 export function RedisZSetRemove(arg1:number,arg2:number,arg3:string,arg4:string):Promise<void>;
 
 export function ReloadExtensions():Promise<void>;
+
+export function RemoveQueuedAIMessage(arg1:number,arg2:string):Promise<boolean>;
 
 export function ResizeSSH(arg1:string,arg2:number,arg3:number):Promise<void>;
 

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -38,6 +38,10 @@ export function ClearGitHubToken() {
   return window['go']['app']['App']['ClearGitHubToken']();
 }
 
+export function ClearQueuedAIMessages(arg1) {
+  return window['go']['app']['App']['ClearQueuedAIMessages'](arg1);
+}
+
 export function ClearWebDAVConfig() {
   return window['go']['app']['App']['ClearWebDAVConfig']();
 }
@@ -674,8 +678,8 @@ export function PreviewTabbyConfig() {
   return window['go']['app']['App']['PreviewTabbyConfig']();
 }
 
-export function QueueAIMessage(arg1, arg2) {
-  return window['go']['app']['App']['QueueAIMessage'](arg1, arg2);
+export function QueueAIMessage(arg1, arg2, arg3) {
+  return window['go']['app']['App']['QueueAIMessage'](arg1, arg2, arg3);
 }
 
 export function RecordSnippetUse(arg1) {
@@ -780,6 +784,10 @@ export function RedisZSetRemove(arg1, arg2, arg3, arg4) {
 
 export function ReloadExtensions() {
   return window['go']['app']['App']['ReloadExtensions']();
+}
+
+export function RemoveQueuedAIMessage(arg1, arg2) {
+  return window['go']['app']['App']['RemoveQueuedAIMessage'](arg1, arg2);
 }
 
 export function ResizeSSH(arg1, arg2, arg3) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/opskat/opskat
 go 1.26.0
 
 require (
-	github.com/cago-frame/agents v0.0.0-20260512092641-ad5c470b126f
+	github.com/cago-frame/agents v0.0.0-20260512141207-8061fa2142f6
 	github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947
 	github.com/coder/websocket v1.8.14
 	github.com/fsnotify/fsnotify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/opskat/opskat
 go 1.26.0
 
 require (
-	github.com/cago-frame/agents v0.0.0-20260512141207-8061fa2142f6
+	github.com/cago-frame/agents v0.0.0-20260512154912-6fca6259bc2d
 	github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947
 	github.com/coder/websocket v1.8.14
 	github.com/fsnotify/fsnotify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -182,3 +182,7 @@ require (
 )
 
 // replace github.com/wailsapp/wails/v2 v2.10.2 => /Users/codfrm/go/pkg/mod
+
+// 临时本地路径：cago openai provider 加 wrapProviderError 修复 5xx/429 不重试问题。
+// 等 cago 上游 commit / 发版后请删除这条 replace，并 go get 到对应版本。
+replace github.com/cago-frame/agents => /Users/codfrm/Code/cago/agents

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/bytedance/sonic v1.12.5/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKz
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.1 h1:1GgorWTqf12TA8mma4DDSbaQigE2wOgQo7iCjjJv3+E=
 github.com/bytedance/sonic/loader v0.2.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/cago-frame/agents v0.0.0-20260512154912-6fca6259bc2d h1:uhpSbguBHWLkMFujq9M629dAI8egufp7jUoHYblEKWE=
-github.com/cago-frame/agents v0.0.0-20260512154912-6fca6259bc2d/go.mod h1:Jy+CKjPkZCgu6jc06F+Fa0lj+/wxgnfyxmz1ey06/98=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947 h1:JynA9XgnZAd8sXqdbxkBqp2RiBsQN8zV4ufANBvzrj4=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947/go.mod h1:a+0ZfDfiKrkIletlXDHbgsFZLGd1yo43waHfpfAIFs8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/bytedance/sonic v1.12.5/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKz
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.1 h1:1GgorWTqf12TA8mma4DDSbaQigE2wOgQo7iCjjJv3+E=
 github.com/bytedance/sonic/loader v0.2.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/cago-frame/agents v0.0.0-20260512141207-8061fa2142f6 h1:kL7GqUbwMTVCzsfEIpGzFBRNMpxHbxULz0DPWP3wMVA=
-github.com/cago-frame/agents v0.0.0-20260512141207-8061fa2142f6/go.mod h1:Jy+CKjPkZCgu6jc06F+Fa0lj+/wxgnfyxmz1ey06/98=
+github.com/cago-frame/agents v0.0.0-20260512154912-6fca6259bc2d h1:uhpSbguBHWLkMFujq9M629dAI8egufp7jUoHYblEKWE=
+github.com/cago-frame/agents v0.0.0-20260512154912-6fca6259bc2d/go.mod h1:Jy+CKjPkZCgu6jc06F+Fa0lj+/wxgnfyxmz1ey06/98=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947 h1:JynA9XgnZAd8sXqdbxkBqp2RiBsQN8zV4ufANBvzrj4=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947/go.mod h1:a+0ZfDfiKrkIletlXDHbgsFZLGd1yo43waHfpfAIFs8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/bytedance/sonic v1.12.5/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKz
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.1 h1:1GgorWTqf12TA8mma4DDSbaQigE2wOgQo7iCjjJv3+E=
 github.com/bytedance/sonic/loader v0.2.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/cago-frame/agents v0.0.0-20260512092641-ad5c470b126f h1:7n3G+RgEprvuaP6MOt04Qw4a1Bi8zBzq3FVXpKupZ7c=
-github.com/cago-frame/agents v0.0.0-20260512092641-ad5c470b126f/go.mod h1:Jy+CKjPkZCgu6jc06F+Fa0lj+/wxgnfyxmz1ey06/98=
+github.com/cago-frame/agents v0.0.0-20260512141207-8061fa2142f6 h1:kL7GqUbwMTVCzsfEIpGzFBRNMpxHbxULz0DPWP3wMVA=
+github.com/cago-frame/agents v0.0.0-20260512141207-8061fa2142f6/go.mod h1:Jy+CKjPkZCgu6jc06F+Fa0lj+/wxgnfyxmz1ey06/98=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947 h1:JynA9XgnZAd8sXqdbxkBqp2RiBsQN8zV4ufANBvzrj4=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947/go.mod h1:a+0ZfDfiKrkIletlXDHbgsFZLGd1yo43waHfpfAIFs8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/internal/ai/prompt_builder.go
+++ b/internal/ai/prompt_builder.go
@@ -121,7 +121,9 @@ func (b *PromptBuilder) buildTabContext() string {
 func (b *PromptBuilder) buildKnowledgeGuidance() string {
 	return `Discover before acting: call list_assets / get_asset first, then operate. The asset Description often contains prior findings (OS, services, DB version) — read it to avoid redundant exploration. When you learn new non-secret facts about an asset during work, append them to the asset Description via update_asset.
 
-Pick the dedicated tool for each asset type: exec_sql for databases, exec_redis for Redis, exec_mongo for MongoDB, exec_k8s for kubectl (do not invoke kubectl through run_command), kafka_* for Kafka. Use run_command only for plain SSH shell commands.`
+Pick the dedicated tool for each asset type: exec_sql for databases, exec_redis for Redis, exec_mongo for MongoDB, exec_k8s for kubectl (do not invoke kubectl through run_command), kafka_* for Kafka. Use run_command only for plain SSH shell commands.
+
+Local vs remote: the local tools (bash / write / edit) run on the user's own machine — never use them to act on a remote asset. When the scenario targets a specific server / database / Redis / Kafka / K8s asset (an SSH / Database / Redis / SFTP tab is open for it, or the user names the asset, or the request is clearly about that asset), use that asset's dedicated remote tool (run_command for SSH, exec_sql / exec_redis / exec_mongo / exec_k8s / kafka_* / sftp_*). Do not fall back to local bash even when the command looks identical — running ` + "`df -h`" + ` locally tells the user nothing about the server they asked about.`
 }
 
 func (b *PromptBuilder) buildMultiAssetGuidance() string {

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -42,7 +42,7 @@ type Usage struct {
 
 // StreamEvent 流式响应事件
 type StreamEvent struct {
-	Type       string `json:"type"`                   // "content" | "tool_start" | "tool_result" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "queue_consumed" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage"
+	Type       string `json:"type"`                   // "content" | "tool_start" | "tool_result" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "queue_consumed" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage" | "compacted"
 	Content    string `json:"content,omitempty"`      // type=content/tool_result/approval_result/agent_end 时的文本
 	QueueID    string `json:"queue_id,omitempty"`     // type=queue_consumed 时的前端队列项 ID
 	ToolName   string `json:"tool_name,omitempty"`    // type=tool_start/tool_result 时的工具名

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -42,8 +42,9 @@ type Usage struct {
 
 // StreamEvent 流式响应事件
 type StreamEvent struct {
-	Type       string `json:"type"`                   // "content" | "tool_start" | "tool_result" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage"
+	Type       string `json:"type"`                   // "content" | "tool_start" | "tool_result" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "queue_consumed" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage"
 	Content    string `json:"content,omitempty"`      // type=content/tool_result/approval_result/agent_end 时的文本
+	QueueID    string `json:"queue_id,omitempty"`     // type=queue_consumed 时的前端队列项 ID
 	ToolName   string `json:"tool_name,omitempty"`    // type=tool_start/tool_result 时的工具名
 	ToolInput  string `json:"tool_input,omitempty"`   // type=tool_start 时的输入摘要
 	ToolCallID string `json:"tool_call_id,omitempty"` // type=tool_start/tool_result 时的工具调用 ID，前端用于跨 turn 还原 tool_calls 历史

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -43,6 +43,7 @@ type Usage struct {
 // StreamEvent 流式响应事件
 type StreamEvent struct {
 	Type       string `json:"type"`                   // "content" | "tool_start" | "tool_result" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "queue_consumed" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage" | "compacted"
+	// type=retry 时 Content 携带 attempt 序号（字符串形式，从 1 开始），RetryDelayMs 是下一次重试前的等待毫秒（用于前端倒计时同步）。
 	Content    string `json:"content,omitempty"`      // type=content/tool_result/approval_result/agent_end 时的文本
 	QueueID    string `json:"queue_id,omitempty"`     // type=queue_consumed 时的前端队列项 ID
 	ToolName   string `json:"tool_name,omitempty"`    // type=tool_start/tool_result 时的工具名
@@ -60,6 +61,8 @@ type StreamEvent struct {
 	Patterns    []string       `json:"patterns,omitempty"`    // local_tool 默认 pattern 列表（与 sub-commands 对齐），前端预填可编辑
 	// type=usage 时的 token 统计（前端累加到当前 assistant 消息）
 	Usage *Usage `json:"usage,omitempty"`
+	// type=retry 时的等待毫秒；前端据此显示倒计时。0 表示无显式退避（立即重试）。
+	RetryDelayMs int `json:"retryDelayMs,omitempty"`
 }
 
 // PermissionResponse 权限响应

--- a/internal/ai/runner.go
+++ b/internal/ai/runner.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cago-frame/agents/agent"
 	"github.com/cago-frame/agents/app/coding"
@@ -94,6 +95,17 @@ func BuildSystem(ctx context.Context, cfg SystemConfig) (*coding.System, error) 
 		coding.WithoutSlashCommands(),
 		coding.WithSystemTemplate(opskatSystemTemplate),
 		coding.WithAgentOpts(agent.Use(".*", auditMiddleware)),
+		// Provider/网络瞬态错误自动重试：429/5xx/timeout/EOF 等命中 cago 默认 ShouldRetry。
+		// MaxAttempts=6 = 1 次原始 + 5 次重试；指数退避序列 5s → 10s → 20s → 40s → 60s
+		// (40*2=80 被 MaxDelay=60s clamp)。总等待最长 ~135s，应对共享 distributor 长时
+		// 限流 / 高峰 503 持续 1-2 分钟的场景。命中 Retry-After 头时优先使用 provider 给
+		// 的时间。中途断流时 cago 把已流出的 partial 文本 finalize 为 PartialErrored 并
+		// 作为历史上下文续传，无须 OpsKat 介入。
+		coding.WithAgentOpts(agent.Retry(agent.RetryPolicy{
+			MaxAttempts:  6,
+			InitialDelay: 5 * time.Second,
+			MaxDelay:     60 * time.Second,
+		})),
 	}
 	if cfg.SystemPrompt != "" {
 		opts = append(opts, coding.AppendSystem(cfg.SystemPrompt))

--- a/internal/ai/runner_test.go
+++ b/internal/ai/runner_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -121,6 +124,166 @@ func TestRunner_SystemPromptHasOpsKatIntro(t *testing.T) {
 		So(text, ShouldNotContainSubstring, "lead Cago coding agent")
 		So(text, ShouldContainSubstring, "## Available tools")
 		So(text, ShouldContainSubstring, "## Guidelines")
+	})
+}
+
+// TestRunner_RetriesOn503ProviderError 验证 BuildSystem 注入的 agent.RetryPolicy
+// 在面对 503 时确实走 cago retry 路径：第一次 ChatStream chunk.Err 命中
+// defaultShouldRetry 的 408/425/429/500/502/503/504 白名单 → handleRetry 发出
+// EventRetry（被翻译为前端 type:"retry" StreamEvent）+ sleep InitialDelay →
+// 第二次 ChatStream 正常吐出 content + finish_reason → 整轮成功。
+//
+// 这是 OpsKat 端到端的回归 —— 当 cago 升级 / 配置漂移导致 RetryPolicy 失效时
+// 该测试会先于线上挂掉。
+func TestRunner_RetriesOn503ProviderError(t *testing.T) {
+	Convey("503 ProviderError 触发 cago retry → 收到 retry 事件 + 续传完成", t, func() {
+		// 两个 QueueStream entry：FIFO 消费，第一次 503 触发 retry，第二次正常返回。
+		mock := providertest.New().
+			QueueStream(provider.StreamChunk{Err: &provider.ProviderError{
+				Err:        errors.New("503 service unavailable"),
+				StatusCode: 503,
+			}}).
+			QueueStream(
+				provider.StreamChunk{ContentDelta: "recovered"},
+				provider.StreamChunk{FinishReason: provider.FinishStop},
+			)
+
+		// timeout 大于 InitialDelay(1s) 即可。
+		out := runOneTurn(t, mock, "", []Message{
+			{Role: RoleUser, Content: "hello"},
+		}, 8*time.Second)
+
+		var retryCount, contentCount, doneCount, errorCount int
+		var retryEv *StreamEvent
+		for i := range out {
+			e := &out[i]
+			switch e.Type {
+			case "retry":
+				retryCount++
+				retryEv = e
+			case "content":
+				contentCount++
+			case "done":
+				doneCount++
+			case "error":
+				errorCount++
+			}
+		}
+		So(retryCount, ShouldEqual, 1)
+		So(retryEv, ShouldNotBeNil)
+		// Attempt 序号放在 Content 字段；RetryDelayMs 透传 cago Delay。
+		So(retryEv.Content, ShouldEqual, "1")
+		So(retryEv.RetryDelayMs, ShouldBeGreaterThan, 0)
+		So(retryEv.Error, ShouldContainSubstring, "503")
+		So(contentCount, ShouldBeGreaterThanOrEqualTo, 1)
+		So(doneCount, ShouldEqual, 1)
+		So(errorCount, ShouldEqual, 0)
+		// ChatStream 被调用 2 次（首次失败 + 重试）。
+		So(len(mock.Received()), ShouldEqual, 2)
+	})
+}
+
+// TestRunner_EndToEnd_RealOpenAIProvider_503TriggersRetry 是更彻底的端到端回归：
+// 起一个真 httptest server，前 N 次返 503，最后一次正常返回 SSE 流。
+// 走的链路完全是生产路径：BuildProvider(*openai.AIProvider, apiKey) →
+// cago openai.NewProvider → BuildSystem (注入 RetryPolicy) → Runner.Send。
+//
+// 这条路径覆盖的关键 bug:
+//   - cago openai provider 必须把 *openai.APIError 包装成 *provider.ProviderError
+//     (status_code 走 defaultShouldRetry 白名单)
+//   - 如果包装失效，503 直接走 EventError，前端只看到 ErrorBlock 没有 RetryBanner
+//
+// 跟 TestRunner_RetriesOn503ProviderError 的区别：那个测试用 providertest
+// 直接注入 chunk.Err{ProviderError}，跳过了 OpenAI provider 的 HTTP 错误转换层。
+func TestRunner_EndToEnd_RealOpenAIProvider_503TriggersRetry(t *testing.T) {
+	Convey("真 OpenAI provider + 503 HTTP → cago retry 链路", t, func() {
+		var hits atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			n := hits.Add(1)
+			if n < 2 {
+				// 第一次返 503，模拟用户截图里的错误。
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = io.WriteString(w, `{"error":{"message":"No available channel for model gpt-5.51"}}`)
+				return
+			}
+			// 第二次返一段正常 SSE 流。
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher := w.(http.Flusher)
+			frames := []string{
+				`{"id":"1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"recovered"}}]}`,
+				`{"id":"1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			}
+			for _, f := range frames {
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", f)
+				flusher.Flush()
+			}
+			_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+			flusher.Flush()
+		}))
+		defer srv.Close()
+
+		// 走生产路径：BuildProvider 从 entity 构造 cago openai provider。
+		entity := &ai_provider_entity.AIProvider{
+			Type:    "openai",
+			APIBase: srv.URL,
+			Model:   "gpt-4o",
+		}
+		prov, err := BuildProvider(entity, "test-key")
+		So(err, ShouldBeNil)
+
+		cfg := SystemConfig{
+			Provider: prov,
+			Cwd:      t.TempDir(),
+			Model:    "gpt-4o",
+		}
+		sys, err := BuildSystem(context.Background(), cfg)
+		So(err, ShouldBeNil)
+		defer func() { _ = sys.Close(context.Background()) }()
+
+		conv := agent.LoadConversation(fmt.Sprintf("e2e-%d", time.Now().UnixNano()), nil)
+		runner := sys.Agent().Runner(conv)
+		defer func() { _ = runner.Close() }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		events, err := runner.Send(ctx, "hello")
+		So(err, ShouldBeNil)
+
+		var retryCount, contentCount, doneCount, errorCount int
+		var retryEv *StreamEvent
+		translator := NewStreamTranslator()
+		for ev := range events {
+			translator.Translate(ev, func(se StreamEvent) {
+				switch se.Type {
+				case "retry":
+					retryCount++
+					sc := se
+					retryEv = &sc
+				case "content":
+					contentCount++
+				case "done":
+					doneCount++
+				case "error":
+					errorCount++
+				}
+			})
+		}
+
+		// 第一次 503 必须命中 cago retry：
+		//   - 后端 emit 一次 EventRetry → 前端 type:"retry" StreamEvent
+		//   - RetryDelayMs 应该 > 0 (cago InitialDelay=1s)
+		//   - Error 文本包含 503 状态码
+		So(retryCount, ShouldEqual, 1)
+		So(retryEv, ShouldNotBeNil)
+		So(retryEv.RetryDelayMs, ShouldBeGreaterThan, 0)
+		So(retryEv.Error, ShouldContainSubstring, "503")
+		// 第二次正常返回 → content + done，没有 error。
+		So(contentCount, ShouldBeGreaterThanOrEqualTo, 1)
+		So(doneCount, ShouldEqual, 1)
+		So(errorCount, ShouldEqual, 0)
+		// 服务器被命中 2 次。
+		So(hits.Load(), ShouldEqual, int32(2))
 	})
 }
 

--- a/internal/ai/stream_event.go
+++ b/internal/ai/stream_event.go
@@ -107,7 +107,7 @@ func (t *EventTranslator) Translate(ev agent.Event, emit func(StreamEvent)) {
 		// 并从 pendingQueue 弹出首条。Delta 是 displayText（含 @mention 原样），
 		// 没有 display 时回落 LLM 文本，前端把它当 user 消息内容渲染。
 		t.flushThinking(emit)
-		emit(StreamEvent{Type: "queue_consumed", Content: ev.Delta})
+		emit(StreamEvent{Type: "queue_consumed", Content: ev.Delta, QueueID: ev.SteerID})
 
 	case agent.EventDone:
 		t.flushThinking(emit)

--- a/internal/ai/stream_event.go
+++ b/internal/ai/stream_event.go
@@ -151,7 +151,7 @@ func extractToolResultText(blk *agent.ToolResultBlock) string {
 // convertUsage 把 cago provider.Usage 折算成 OpsKat Usage。
 //
 // 映射规则：
-//   - InputTokens         ← PromptTokens
+//   - InputTokens         ← normalized PromptTokens (uncached input)
 //   - OutputTokens        ← CompletionTokens（ReasoningTokens 已合并进 CompletionTokens 由 provider 上送）
 //   - CacheCreationTokens ← CacheCreationTokens
 //   - CacheReadTokens     ← CachedTokens
@@ -160,9 +160,27 @@ func convertUsage(u *provider.Usage) *Usage {
 		return nil
 	}
 	return &Usage{
-		InputTokens:         u.PromptTokens,
+		InputTokens:         normalizeInputTokens(u),
 		OutputTokens:        u.CompletionTokens,
 		CacheCreationTokens: u.CacheCreationTokens,
 		CacheReadTokens:     u.CachedTokens,
 	}
+}
+
+func normalizeInputTokens(u *provider.Usage) int {
+	input := u.PromptTokens
+	// OpenAI reports prompt_tokens with cached_tokens included, while Anthropic reports
+	// fresh input separately from cache read/write. Use TotalTokens to detect the former
+	// and keep OpsKat's InputTokens meaning consistent: uncached prompt input only.
+	if u.CachedTokens > 0 && u.TotalTokens > 0 {
+		cacheIncludedTotal := u.PromptTokens + u.CompletionTokens
+		cacheSeparatedTotal := u.PromptTokens + u.CacheCreationTokens + u.CachedTokens + u.CompletionTokens
+		if u.TotalTokens == cacheIncludedTotal && cacheSeparatedTotal != cacheIncludedTotal {
+			input -= u.CachedTokens
+		}
+	}
+	if input < 0 {
+		return 0
+	}
+	return input
 }

--- a/internal/ai/stream_event.go
+++ b/internal/ai/stream_event.go
@@ -2,10 +2,14 @@ package ai
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cago-frame/agents/agent"
 	"github.com/cago-frame/agents/provider"
+	"github.com/cago-frame/cago/pkg/logger"
+	"go.uber.org/zap"
 )
 
 // EventTranslator 把 cago agent.Event 翻译成 OpsKat 现有 StreamEvent。
@@ -79,13 +83,33 @@ func (t *EventTranslator) Translate(ev agent.Event, emit func(StreamEvent)) {
 		}
 
 	case agent.EventRetry:
+		// 透传 Attempt / Delay / Cause —— 前端用 RetryDelayMs 做倒计时同步、Content 显示第几次。
 		msg := ""
-		if ev.Retry != nil && ev.Retry.Cause != nil {
-			msg = ev.Retry.Cause.Error()
+		attempt := 0
+		delayMs := 0
+		if ev.Retry != nil {
+			attempt = ev.Retry.Attempt
+			delayMs = int(ev.Retry.Delay / time.Millisecond)
+			if ev.Retry.Cause != nil {
+				msg = ev.Retry.Cause.Error()
+			}
 		} else if ev.Error != nil {
 			msg = ev.Error.Error()
 		}
-		emit(StreamEvent{Type: "retry", Error: msg})
+		// 落运维日志：用户线上反馈"看不到 RetryBanner"时，先查后端日志确认 cago
+		// 真的触发了 retry。如果日志没有，说明 cago shouldRetry 没识别错误（多半
+		// 是 provider 没把 *APIError 包成 *provider.ProviderError），与前端无关。
+		logger.Default().Info("AI provider retry",
+			zap.Int("attempt", attempt),
+			zap.Int("delay_ms", delayMs),
+			zap.String("cause", msg),
+		)
+		emit(StreamEvent{
+			Type:         "retry",
+			Error:        msg,
+			Content:      strconv.Itoa(attempt),
+			RetryDelayMs: delayMs,
+		})
 
 	case agent.EventCancelled:
 		emit(StreamEvent{Type: "stopped"})

--- a/internal/ai/stream_event_test.go
+++ b/internal/ai/stream_event_test.go
@@ -177,11 +177,12 @@ func TestEventTranslator_Compacted(t *testing.T) {
 }
 
 func TestEventTranslator_SteerConsumed(t *testing.T) {
-	Convey("EventSteerConsumed → queue_consumed，Content 透传 Delta", t, func() {
-		out := drain(NewStreamTranslator(), agent.Event{Kind: agent.EventSteerConsumed, Delta: "排队的内容"})
+	Convey("EventSteerConsumed → queue_consumed，Content / QueueID 透传", t, func() {
+		out := drain(NewStreamTranslator(), agent.Event{Kind: agent.EventSteerConsumed, Delta: "排队的内容", SteerID: "q1"})
 		So(out, ShouldHaveLength, 1)
 		So(out[0].Type, ShouldEqual, "queue_consumed")
 		So(out[0].Content, ShouldEqual, "排队的内容")
+		So(out[0].QueueID, ShouldEqual, "q1")
 	})
 
 	Convey("仍处于 thinking 时先发 thinking_done", t, func() {

--- a/internal/ai/stream_event_test.go
+++ b/internal/ai/stream_event_test.go
@@ -96,6 +96,7 @@ func TestEventTranslator_TurnEndUsage(t *testing.T) {
 				CompletionTokens:    50,
 				CachedTokens:        20,
 				CacheCreationTokens: 10,
+				TotalTokens:         180,
 			}},
 		)
 		So(out, ShouldHaveLength, 1)
@@ -105,6 +106,22 @@ func TestEventTranslator_TurnEndUsage(t *testing.T) {
 		So(out[0].Usage.OutputTokens, ShouldEqual, 50)
 		So(out[0].Usage.CacheReadTokens, ShouldEqual, 20)
 		So(out[0].Usage.CacheCreationTokens, ShouldEqual, 10)
+	})
+
+	Convey("OpenAI 风格 usage：prompt_tokens 已包含 cached_tokens 时归一化为非缓存输入", t, func() {
+		out := drain(NewStreamTranslator(),
+			agent.Event{Kind: agent.EventTurnEnd, Usage: &provider.Usage{
+				PromptTokens:     100,
+				CompletionTokens: 50,
+				CachedTokens:     20,
+				TotalTokens:      150,
+			}},
+		)
+		So(out, ShouldHaveLength, 1)
+		So(out[0].Usage, ShouldNotBeNil)
+		So(out[0].Usage.InputTokens, ShouldEqual, 80)
+		So(out[0].Usage.OutputTokens, ShouldEqual, 50)
+		So(out[0].Usage.CacheReadTokens, ShouldEqual, 20)
 	})
 }
 

--- a/internal/ai/stream_event_test.go
+++ b/internal/ai/stream_event_test.go
@@ -133,18 +133,33 @@ func TestEventTranslator_TurnEndNoUsage(t *testing.T) {
 }
 
 func TestEventTranslator_Retry(t *testing.T) {
-	Convey("EventRetry → retry，错误信息透传", t, func() {
+	Convey("EventRetry → retry，Attempt/Delay/Cause 全部透传", t, func() {
 		out := drain(NewStreamTranslator(), agent.Event{
 			Kind: agent.EventRetry,
 			Retry: &agent.RetryEvent{
-				Attempt: 1,
-				Delay:   2 * time.Second,
+				Attempt: 2,
+				Delay:   3 * time.Second,
 				Cause:   errors.New("timeout"),
 			},
 		})
 		So(out, ShouldHaveLength, 1)
 		So(out[0].Type, ShouldEqual, "retry")
 		So(out[0].Error, ShouldEqual, "timeout")
+		// Attempt 放在 Content 字段，前端 parseInt(event.content) 解析。
+		So(out[0].Content, ShouldEqual, "2")
+		So(out[0].RetryDelayMs, ShouldEqual, 3000)
+	})
+
+	Convey("EventRetry 无 Retry 字段时退化到 ev.Error，不带 Attempt/Delay", t, func() {
+		out := drain(NewStreamTranslator(), agent.Event{
+			Kind:  agent.EventRetry,
+			Error: errors.New("fallback"),
+		})
+		So(out, ShouldHaveLength, 1)
+		So(out[0].Type, ShouldEqual, "retry")
+		So(out[0].Error, ShouldEqual, "fallback")
+		So(out[0].Content, ShouldEqual, "0")
+		So(out[0].RetryDelayMs, ShouldEqual, 0)
 	})
 }
 

--- a/internal/app/app_ai.go
+++ b/internal/app/app_ai.go
@@ -477,7 +477,7 @@ func (a *App) SendAIMessage(convID int64, messages []ai.Message, aiCtx ai.AICont
 // QueueAIMessage 在生成过程中通过 cago Runner.Steer 把用户消息注入当前 turn，
 // 由 cago 在下一次 LLM 调用前把消息追加到 conversation。
 // content 已包含内联 <mention> XML（前端构造），无需再行 prepend。
-func (a *App) QueueAIMessage(convID int64, content string) error {
+func (a *App) QueueAIMessage(convID int64, queueID string, content string) error {
 	v, ok := a.runners.Load(convID)
 	if !ok {
 		return fmt.Errorf("会话 %d 没有正在运行的生成", convID)
@@ -486,12 +486,44 @@ func (a *App) QueueAIMessage(convID int64, content string) error {
 	if entry.runner == nil {
 		return fmt.Errorf("会话 %d 没有正在运行的生成", convID)
 	}
-	err := entry.runner.Steer(context.Background(), content, agent.WithSteerDisplay(content))
+	err := entry.runner.Steer(context.Background(), content, agent.WithSteerID(queueID), agent.WithSteerDisplay(content))
 	if err != nil && !errors.Is(err, agent.ErrSteerNoActiveTurn) {
 		logger.Default().Warn("cago Steer failed", zap.Error(err))
 		return err
 	}
 	return nil
+}
+
+// RemoveQueuedAIMessage 尝试从 cago Runner 尚未消费的 Steer 队列里删除一条消息。
+// 返回 false 表示该消息不存在、已被消费，或当前没有活跃 runner；调用方应等待
+// queue_consumed 事件来保持 UI 与 LLM 上下文一致。
+func (a *App) RemoveQueuedAIMessage(convID int64, queueID string) bool {
+	v, ok := a.runners.Load(convID)
+	if !ok || queueID == "" {
+		return false
+	}
+	entry := v.(*runnerEntry)
+	if entry.runner == nil {
+		return false
+	}
+	return entry.runner.RemovePendingSteer(queueID)
+}
+
+// ClearQueuedAIMessages 清空 cago Runner 尚未消费的 Steer 队列，并返回实际删除的队列 ID。
+func (a *App) ClearQueuedAIMessages(convID int64) []string {
+	v, ok := a.runners.Load(convID)
+	if !ok {
+		return []string{}
+	}
+	entry := v.(*runnerEntry)
+	if entry.runner == nil {
+		return []string{}
+	}
+	ids := entry.runner.ClearPendingSteers()
+	if ids == nil {
+		return []string{}
+	}
+	return ids
 }
 
 // StopAIGeneration 调用 cago Runner.Cancel 触发取消；事件消费 goroutine

--- a/internal/model/entity/conversation_entity/conversation.go
+++ b/internal/model/entity/conversation_entity/conversation.go
@@ -82,13 +82,26 @@ func (Message) TableName() string {
 }
 
 // ContentBlock 前端内容块（用于持久化显示状态）
+//
+// "error" 类型的 block 用于持久化对话级错误：
+//   - EventError 命中时由前端推入（含分类标签 + 原始错误正文）
+//   - 重试期间被关闭 tab/切会话/应用退出时，由前端 materializeRetryStatusAsError
+//     把 retryStatus 物化成 kind=interrupted 的 ErrorBlock 落盘
+//
+// 历史回放（internal/ai/message_convert.go ToAgentMessages）必须跳过 type="error"，
+// 否则错误正文会作为 assistant 历史发回给 LLM。
 type ContentBlock struct {
-	Type       string `json:"type"` // "text" | "tool"
+	Type       string `json:"type"` // "text" | "tool" | "agent" | "approval" | "thinking" | "error"
 	Content    string `json:"content"`
 	ToolName   string `json:"toolName,omitempty"`
 	ToolInput  string `json:"toolInput,omitempty"`
 	ToolCallID string `json:"toolCallId,omitempty"` // 跨 turn 还原 tool_calls 历史；老数据无此字段，前端兜底为塌缩消息
-	Status     string `json:"status,omitempty"`     // "running" | "completed" | "error"
+	Status     string `json:"status,omitempty"`     // "running" | "completed" | "error" | "cancelled"
+	// error 块字段：
+	//   ErrorKind   — "rate_limit" | "server" | "network" | "auth" | "interrupted" | "unknown"
+	//   ErrorDetail — 原始错误正文，UI 直接展示
+	ErrorKind   string `json:"errorKind,omitempty"`
+	ErrorDetail string `json:"errorDetail,omitempty"`
 }
 
 // GetBlocks 获取前端显示块


### PR DESCRIPTION
## Summary
- 前端流式场景大幅优化：Zustand 精确订阅、deferred markdown 渲染、智能跟随滚动、缓存 groupPath 回溯、流式缓冲策略升级
- 后端修正 OpenAI/Anthropic prompt_tokens 计数差异，统一 InputTokens 含义为未缓存输入
- AIChatInput 拆分为独立模块（content/extensions/keyboard/types/useInputDraft），降低单文件复杂度

## 改动细节

### 前端 — 流式重渲染优化
- `AIChatContent` 使用 `useShallow` 选择器，避免整张 store 变化触发渲染
- 新增 `MarkdownContent`（`memo` + `useDeferredValue`），长文本 markdown 不再阻塞 IME 输入
- 智能滚动跟随：底部自动跟随流式内容，用户上滑停止跟随，滑回底部自动恢复；`ResizeObserver` 兜底 deferred commit 撑高
- `UserMessage` 传 `index` 替代闭包，保证 `onEdit` 稳定引用让 `memo` 生效
- `groupPath` 新增 `WeakMap` 缓存，消除 AI 输入框每次按键的 O(N²) 路径回溯
- `TokenUsageBadge` 显示原始 input token 而非合并 cache 的 total

### 前端 — 流式缓冲 & 滚动跟随
- `setTimeout` 替代 `requestAnimationFrame` 缓冲流式 token，减少无效重绘
- 排队消息 `queue_id` 精确管理，发送/重发时主动跟随滚动
- `ThinkingBlock` 内部滚动跟随，prompt 引导 local/remote 工具区分
- 跟随滚动状态机修复：scrollTop 减小排除 scrollHeight 收缩导致的浏览器钳位

### 前端 — AIChatInput 拆分重构
- `input/content.ts` — XML 内容提取逻辑
- `input/extensions.ts` — Mention / Snippet 扩展配置
- `input/keyboard.ts` — 输入历史上下导航
- `input/types.ts` — 共享类型定义
- `input/useInputDraft.ts` — Draft 持久化 hook

### 后端 — token 计数修正
- `normalizeInputTokens` 检测 OpenAI `prompt_tokens` 含 `cached_tokens` 的情况并扣除
- 保持 `InputTokens` 统一含义：仅计算未缓存输入部分

## Test plan
- [x] 前端单元测试通过（AIChatContent、AIChatInput、UserMessage、aiStore）
- [x] 后端单元测试通过（stream_event normalizeInputTokens）
- [ ] 手动验证流式输出滚动跟随行为
- [ ] 手动验证 OpenAI / Anthropic token 显示正确