### PR TITLE
🐛 修复 SFTP 传输进度显示到错误 tab

### DIFF
--- a/frontend/src/__tests__/FileManagerPanel.test.tsx
+++ b/frontend/src/__tests__/FileManagerPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FileManagerPanel } from "../components/terminal/FileManagerPanel";
 import { useTerminalStore, type TerminalDirectorySyncState } from "../stores/terminalStore";
-import { useSFTPStore } from "../stores/sftpStore";
+import { useSFTPStore, type SFTPTransfer } from "../stores/sftpStore";
 import { ChangeSSHDirectory, SFTPListDir } from "../../wailsjs/go/app/App";
 
 const { toastError } = vi.hoisted(() => ({
@@ -33,6 +33,22 @@ function makeSyncState(partial: Partial<TerminalDirectorySyncState> = {}): Termi
   };
 }
 
+function makeTransfer(
+  partial: Partial<SFTPTransfer> & Pick<SFTPTransfer, "transferId" | "tabId" | "sessionId">
+): SFTPTransfer {
+  return {
+    direction: "upload",
+    currentFile: "test.txt",
+    filesCompleted: 0,
+    filesTotal: 1,
+    bytesDone: 100,
+    bytesTotal: 100,
+    speed: 0,
+    status: "active",
+    ...partial,
+  };
+}
+
 describe("FileManagerPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,17 +60,24 @@ describe("FileManagerPanel", () => {
           panes: { s1: { sessionId: "s1", connected: true, connectedAt: Date.now() } },
           directoryFollowMode: "off",
         },
+        tab2: {
+          splitTree: { type: "terminal", sessionId: "s2" },
+          activePaneId: "s2",
+          panes: { s2: { sessionId: "s2", connected: true, connectedAt: Date.now() } },
+          directoryFollowMode: "off",
+        },
       },
       sessionSync: {
         s1: makeSyncState(),
+        s2: makeSyncState({ sessionId: "s2", cwd: "/srv/www" }),
       },
       connections: {},
       connectingAssetIds: new Set(),
     });
     useSFTPStore.setState({
       transfers: {},
-      fileManagerOpenTabs: { tab1: true },
-      fileManagerPaths: { tab1: "/srv/app" },
+      fileManagerOpenTabs: { tab1: true, tab2: true },
+      fileManagerPaths: { tab1: "/srv/app", tab2: "/srv/www" },
       fileManagerWidth: 280,
     });
     vi.mocked(SFTPListDir).mockResolvedValue([]);
@@ -125,5 +148,54 @@ describe("FileManagerPanel", () => {
 
     expect(toastError).toHaveBeenCalledWith("sftp.sync.busy");
     expect(useTerminalStore.getState().tabData.tab1.directoryFollowMode).toBe("off");
+  });
+
+  it("renders only transfers owned by the current tab", async () => {
+    useSFTPStore.setState({
+      transfers: {
+        t1: makeTransfer({ transferId: "t1", tabId: "tab1", sessionId: "s1", currentFile: "file-one.txt" }),
+        t2: makeTransfer({ transferId: "t2", tabId: "tab2", sessionId: "s2", currentFile: "file-two.txt" }),
+      },
+    });
+
+    render(<FileManagerPanel tabId="tab2" sessionId="s2" isOpen width={280} onWidthChange={vi.fn()} />);
+
+    expect(screen.queryByText("file-one.txt")).not.toBeInTheDocument();
+    expect(screen.getByText("file-two.txt")).toBeInTheDocument();
+  });
+
+  it("refreshes only when an upload owned by the current tab completes", async () => {
+    render(<FileManagerPanel tabId="tab1" sessionId="s1" isOpen width={280} onWidthChange={vi.fn()} />);
+
+    await waitFor(() => expect(SFTPListDir).toHaveBeenCalledWith("s1", "/srv/app"));
+    vi.clearAllMocks();
+
+    useSFTPStore.setState({
+      transfers: {
+        t2: makeTransfer({
+          transferId: "t2",
+          tabId: "tab2",
+          sessionId: "s2",
+          currentFile: "other-tab.txt",
+          status: "done",
+        }),
+      },
+    });
+    await Promise.resolve();
+    expect(SFTPListDir).not.toHaveBeenCalled();
+
+    useSFTPStore.setState({
+      transfers: {
+        t1: makeTransfer({
+          transferId: "t1",
+          tabId: "tab1",
+          sessionId: "s1",
+          currentFile: "current-tab.txt",
+          status: "done",
+        }),
+      },
+    });
+
+    await waitFor(() => expect(SFTPListDir).toHaveBeenCalledWith("s1", "/srv/app"));
   });
 });

--- a/frontend/src/__tests__/sftpStore.test.ts
+++ b/frontend/src/__tests__/sftpStore.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useSFTPStore, type SFTPTransfer } from "../stores/sftpStore";
 import { SFTPUpload, SFTPDownload, SFTPCancelTransfer } from "../../wailsjs/go/app/App";
 
-function makeTransfer(id: string, sessionId: string, status: SFTPTransfer["status"] = "active"): SFTPTransfer {
+function makeTransfer(
+  id: string,
+  sessionId: string,
+  status: SFTPTransfer["status"] = "active",
+  tabId = `tab-${sessionId}`
+): SFTPTransfer {
   return {
     transferId: id,
+    tabId,
     sessionId,
     direction: "upload",
     currentFile: "test.txt",
@@ -93,6 +99,25 @@ describe("sftpStore", () => {
     });
   });
 
+  describe("clearCompletedForTab", () => {
+    it("removes non-active transfers for a specific tab only", () => {
+      useSFTPStore.setState({
+        transfers: {
+          t1: makeTransfer("t1", "s1", "done", "tab1"),
+          t2: makeTransfer("t2", "s1", "active", "tab1"),
+          t3: makeTransfer("t3", "s2", "done", "tab2"),
+        },
+      });
+
+      useSFTPStore.getState().clearCompletedForTab("tab1");
+
+      const transfers = useSFTPStore.getState().transfers;
+      expect(transfers).not.toHaveProperty("t1");
+      expect(transfers).toHaveProperty("t2");
+      expect(transfers).toHaveProperty("t3");
+    });
+  });
+
   describe("getSessionTransfers", () => {
     it("returns only transfers for the given session", () => {
       useSFTPStore.setState({
@@ -111,6 +136,22 @@ describe("sftpStore", () => {
     it("returns empty array when no transfers for session", () => {
       const result = useSFTPStore.getState().getSessionTransfers("unknown");
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("getTabTransfers", () => {
+    it("returns only transfers for the given tab", () => {
+      useSFTPStore.setState({
+        transfers: {
+          t1: makeTransfer("t1", "s1", "active", "tab1"),
+          t2: makeTransfer("t2", "s2", "active", "tab2"),
+          t3: makeTransfer("t3", "s3", "active", "tab1"),
+        },
+      });
+
+      const result = useSFTPStore.getState().getTabTransfers("tab1");
+      expect(result).toHaveLength(2);
+      expect(result.map((t) => t.transferId).sort()).toEqual(["t1", "t3"]);
     });
   });
 
@@ -162,10 +203,12 @@ describe("sftpStore", () => {
     it("calls backend and initializes transfer on success", async () => {
       vi.mocked(SFTPUpload).mockResolvedValue("transfer-123");
 
-      const result = await useSFTPStore.getState().startUpload("s1", "/remote/path");
+      const result = await useSFTPStore.getState().startUpload({ tabId: "tab1", sessionId: "s1" }, "/remote/path");
       expect(result).toBe("transfer-123");
       expect(SFTPUpload).toHaveBeenCalledWith("s1", "/remote/path");
       expect(useSFTPStore.getState().transfers["transfer-123"]).toBeDefined();
+      expect(useSFTPStore.getState().transfers["transfer-123"].tabId).toBe("tab1");
+      expect(useSFTPStore.getState().transfers["transfer-123"].sessionId).toBe("s1");
       expect(useSFTPStore.getState().transfers["transfer-123"].status).toBe("active");
       expect(useSFTPStore.getState().transfers["transfer-123"].direction).toBe("upload");
     });
@@ -173,8 +216,30 @@ describe("sftpStore", () => {
     it("returns null when backend returns empty", async () => {
       vi.mocked(SFTPUpload).mockResolvedValue("");
 
-      const result = await useSFTPStore.getState().startUpload("s1", "/remote/path");
+      const result = await useSFTPStore.getState().startUpload({ tabId: "tab1", sessionId: "s1" }, "/remote/path");
       expect(result).toBeNull();
+    });
+
+    it("keeps transfers scoped to their initiating tabs", async () => {
+      vi.mocked(SFTPUpload).mockResolvedValueOnce("transfer-1").mockResolvedValueOnce("transfer-2");
+
+      await useSFTPStore.getState().startUpload({ tabId: "tab1", sessionId: "s1" }, "/remote/file1");
+      await useSFTPStore.getState().startUpload({ tabId: "tab2", sessionId: "s2" }, "/remote/file2");
+
+      expect(
+        useSFTPStore
+          .getState()
+          .getTabTransfers("tab1")
+          .map((transfer) => transfer.transferId)
+      ).toEqual(["transfer-1"]);
+      expect(
+        useSFTPStore
+          .getState()
+          .getTabTransfers("tab2")
+          .map((transfer) => transfer.transferId)
+      ).toEqual(["transfer-2"]);
+      expect(SFTPUpload).toHaveBeenNthCalledWith(1, "s1", "/remote/file1");
+      expect(SFTPUpload).toHaveBeenNthCalledWith(2, "s2", "/remote/file2");
     });
   });
 
@@ -182,8 +247,11 @@ describe("sftpStore", () => {
     it("calls backend and initializes download transfer", async () => {
       vi.mocked(SFTPDownload).mockResolvedValue("dl-123");
 
-      const result = await useSFTPStore.getState().startDownload("s1", "/remote/file.txt");
+      const result = await useSFTPStore
+        .getState()
+        .startDownload({ tabId: "tab1", sessionId: "s1" }, "/remote/file.txt");
       expect(result).toBe("dl-123");
+      expect(useSFTPStore.getState().transfers["dl-123"].tabId).toBe("tab1");
       expect(useSFTPStore.getState().transfers["dl-123"].direction).toBe("download");
     });
   });

--- a/frontend/src/components/layout/MainPanel.tsx
+++ b/frontend/src/components/layout/MainPanel.tsx
@@ -261,6 +261,7 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset, commandO
                     <FileManagerPanel
                       tabId={tab.id}
                       sessionId={data.activePaneId}
+                      isActive={isActive}
                       isOpen={!!fileManagerOpenTabs[tab.id]}
                       width={fileManagerWidth}
                       onWidthChange={setFileManagerWidth}

--- a/frontend/src/components/terminal/FileManagerPanel.tsx
+++ b/frontend/src/components/terminal/FileManagerPanel.tsx
@@ -19,12 +19,20 @@ import { getEntryPath, getParentPath, HANDLE_PX } from "./file-manager/utils";
 interface FileManagerPanelProps {
   tabId: string;
   sessionId: string;
+  isActive?: boolean;
   isOpen: boolean;
   width: number;
   onWidthChange: (width: number) => void;
 }
 
-export function FileManagerPanel({ tabId, sessionId, isOpen, width, onWidthChange }: FileManagerPanelProps) {
+export function FileManagerPanel({
+  tabId,
+  sessionId,
+  isActive = true,
+  isOpen,
+  width,
+  onWidthChange,
+}: FileManagerPanelProps) {
   const { t } = useTranslation();
   const {
     currentPath,
@@ -69,17 +77,20 @@ export function FileManagerPanel({ tabId, sessionId, isOpen, width, onWidthChang
   const startDownloadDir = useSFTPStore((s) => s.startDownloadDir);
   const allTransfers = useSFTPStore((s) => s.transfers);
 
-  const sessionTransfers = useMemo(
-    () => Object.values(allTransfers).filter((transfer) => transfer.sessionId === sessionId),
-    [allTransfers, sessionId]
+  const transferTarget = useMemo(() => ({ tabId, sessionId }), [tabId, sessionId]);
+  const tabTransfers = useMemo(
+    () => Object.values(allTransfers).filter((transfer) => transfer.tabId === tabId),
+    [allTransfers, tabId]
   );
 
   const isDragOver = useNativeFileDrop({
     currentPathRef,
+    isActive,
     isOpen,
     panelRef,
     sessionId,
     startUploadFile,
+    tabId,
   });
   const { handleResizeStart, isResizing, outerRef } = useResizeHandle({ onWidthChange, panelRef, width });
 
@@ -113,7 +124,7 @@ export function FileManagerPanel({ tabId, sessionId, isOpen, width, onWidthChang
     void loadDir(sessionSync.cwd);
   }, [currentPath, directoryFollowMode, isOpen, loadDir, sessionSync?.cwd, sessionSync?.cwdKnown]);
 
-  const doneUploadCount = sessionTransfers.filter((transfer) => {
+  const doneUploadCount = tabTransfers.filter((transfer) => {
     return transfer.status === "done" && transfer.direction === "upload";
   }).length;
   const prevDoneCount = useRef(0);
@@ -161,16 +172,16 @@ export function FileManagerPanel({ tabId, sessionId, isOpen, width, onWidthChang
           if (entry?.isDir) void navigateToPath(getFullPath(entry));
           break;
         case "download":
-          if (entry) startDownload(sessionId, getFullPath(entry));
+          if (entry) startDownload(transferTarget, getFullPath(entry));
           break;
         case "downloadDir":
-          if (entry) startDownloadDir(sessionId, getFullPath(entry));
+          if (entry) startDownloadDir(transferTarget, getFullPath(entry));
           break;
         case "upload":
-          startUpload(sessionId, currentPath.endsWith("/") ? currentPath : currentPath + "/");
+          startUpload(transferTarget, currentPath.endsWith("/") ? currentPath : currentPath + "/");
           break;
         case "uploadDir":
-          startUploadDir(sessionId, currentPath.endsWith("/") ? currentPath : currentPath + "/");
+          startUploadDir(transferTarget, currentPath.endsWith("/") ? currentPath : currentPath + "/");
           break;
         case "delete":
           if (entry) {
@@ -193,11 +204,11 @@ export function FileManagerPanel({ tabId, sessionId, isOpen, width, onWidthChang
       getFullPath,
       loadDir,
       navigateToPath,
-      sessionId,
       startDownload,
       startDownloadDir,
       startUpload,
       startUploadDir,
+      transferTarget,
     ]
   );
 
@@ -269,7 +280,7 @@ export function FileManagerPanel({ tabId, sessionId, isOpen, width, onWidthChang
               setSelected={setSelected}
             />
 
-            <TransferSection sessionId={sessionId} transfers={sessionTransfers} />
+            <TransferSection tabId={tabId} transfers={tabTransfers} />
           </div>
         </div>
       </div>

--- a/frontend/src/components/terminal/file-manager/TransferSection.tsx
+++ b/frontend/src/components/terminal/file-manager/TransferSection.tsx
@@ -4,7 +4,7 @@ import { Button, ScrollArea } from "@opskat/ui";
 import { type SFTPTransfer, useSFTPStore } from "@/stores/sftpStore";
 
 interface TransferSectionProps {
-  sessionId: string;
+  tabId: string;
   transfers: SFTPTransfer[];
 }
 
@@ -64,9 +64,9 @@ function TransferRow({ transfer }: { transfer: SFTPTransfer }) {
   );
 }
 
-export function TransferSection({ sessionId, transfers }: TransferSectionProps) {
+export function TransferSection({ tabId, transfers }: TransferSectionProps) {
   const { t } = useTranslation();
-  const clearCompletedForSession = useSFTPStore((s) => s.clearCompletedForSession);
+  const clearCompletedForTab = useSFTPStore((s) => s.clearCompletedForTab);
 
   if (transfers.length === 0) {
     return null;
@@ -80,7 +80,7 @@ export function TransferSection({ sessionId, transfers }: TransferSectionProps) 
           variant="ghost"
           size="icon-xs"
           className="h-4 w-4"
-          onClick={() => clearCompletedForSession(sessionId)}
+          onClick={() => clearCompletedForTab(tabId)}
           title={t("sftp.clear")}
         >
           <X className="h-2.5 w-2.5" />

--- a/frontend/src/components/terminal/file-manager/useNativeFileDrop.ts
+++ b/frontend/src/components/terminal/file-manager/useNativeFileDrop.ts
@@ -3,44 +3,52 @@ import { OnFileDrop, OnFileDropOff } from "../../../../wailsjs/runtime/runtime";
 
 interface UseNativeFileDropOptions {
   currentPathRef: MutableRefObject<string>;
+  isActive: boolean;
   isOpen: boolean;
   panelRef: RefObject<HTMLDivElement | null>;
+  tabId: string;
   sessionId: string;
-  startUploadFile: (sessionId: string, localPath: string, remotePath: string) => Promise<string | null>;
+  startUploadFile: (
+    target: { tabId: string; sessionId: string },
+    localPath: string,
+    remotePath: string
+  ) => Promise<string | null>;
 }
 
 export function useNativeFileDrop({
   currentPathRef,
+  isActive,
   isOpen,
   panelRef,
+  tabId,
   sessionId,
   startUploadFile,
 }: UseNativeFileDropOptions) {
   const [isDragOver, setIsDragOver] = useState(false);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !isActive) return;
     const handler = (_x: number, _y: number, paths: string[]) => {
       setIsDragOver(false);
       for (const path of paths) {
-        startUploadFile(sessionId, path, currentPathRef.current + "/");
+        startUploadFile({ tabId, sessionId }, path, currentPathRef.current + "/");
       }
     };
     OnFileDrop(handler, true);
     return () => {
       OnFileDropOff();
     };
-  }, [currentPathRef, isOpen, sessionId, startUploadFile]);
+  }, [currentPathRef, isActive, isOpen, sessionId, startUploadFile, tabId]);
 
   useEffect(() => {
     const el = panelRef.current;
-    if (!el || !isOpen) return;
+    if (!el || !isOpen || !isActive) return;
     const observer = new MutationObserver(() => {
       setIsDragOver(el.classList.contains("wails-drop-target-active"));
     });
     observer.observe(el, { attributes: true, attributeFilter: ["class"] });
     return () => observer.disconnect();
-  }, [isOpen, panelRef]);
+  }, [isActive, isOpen, panelRef]);
 
   return isDragOver;
 }

--- a/frontend/src/stores/sftpStore.ts
+++ b/frontend/src/stores/sftpStore.ts
@@ -12,6 +12,7 @@ import { registerTabCloseHook } from "./tabStore";
 
 export interface SFTPTransfer {
   transferId: string;
+  tabId: string;
   sessionId: string;
   direction: "upload" | "download";
   currentFile: string;
@@ -22,6 +23,11 @@ export interface SFTPTransfer {
   speed: number;
   status: "active" | "done" | "error" | "cancelled";
   error?: string;
+}
+
+export interface SFTPTransferTarget {
+  tabId: string;
+  sessionId: string;
 }
 
 const DEFAULT_FILE_MANAGER_WIDTH = 280;
@@ -36,16 +42,18 @@ interface SFTPState {
   fileManagerPaths: Record<string, string>;
   fileManagerWidth: number;
 
-  startUpload: (sessionId: string, remotePath: string) => Promise<string | null>;
-  startUploadDir: (sessionId: string, remotePath: string) => Promise<string | null>;
-  startUploadFile: (sessionId: string, localPath: string, remotePath: string) => Promise<string | null>;
-  startDownload: (sessionId: string, remotePath: string) => Promise<string | null>;
-  startDownloadDir: (sessionId: string, remotePath: string) => Promise<string | null>;
+  startUpload: (target: SFTPTransferTarget, remotePath: string) => Promise<string | null>;
+  startUploadDir: (target: SFTPTransferTarget, remotePath: string) => Promise<string | null>;
+  startUploadFile: (target: SFTPTransferTarget, localPath: string, remotePath: string) => Promise<string | null>;
+  startDownload: (target: SFTPTransferTarget, remotePath: string) => Promise<string | null>;
+  startDownloadDir: (target: SFTPTransferTarget, remotePath: string) => Promise<string | null>;
   cancelTransfer: (transferId: string) => void;
   clearTransfer: (transferId: string) => void;
   clearCompleted: () => void;
   clearCompletedForSession: (sessionId: string) => void;
+  clearCompletedForTab: (tabId: string) => void;
   getSessionTransfers: (sessionId: string) => SFTPTransfer[];
+  getTabTransfers: (tabId: string) => SFTPTransfer[];
 
   toggleFileManager: (tabId: string) => void;
   setFileManagerPath: (tabId: string, path: string) => void;
@@ -54,7 +62,7 @@ interface SFTPState {
 
 function subscribeProgress(
   transferId: string,
-  sessionId: string,
+  target: SFTPTransferTarget,
   direction: "upload" | "download",
   set: (fn: (state: SFTPState) => Partial<SFTPState>) => void,
   get: () => SFTPState
@@ -65,7 +73,8 @@ function subscribeProgress(
       ...state.transfers,
       [transferId]: {
         transferId,
-        sessionId,
+        tabId: target.tabId,
+        sessionId: target.sessionId,
         direction,
         currentFile: "",
         filesCompleted: 0,
@@ -156,38 +165,38 @@ export const useSFTPStore = create<SFTPState>((set, get) => ({
   fileManagerPaths: {},
   fileManagerWidth: DEFAULT_FILE_MANAGER_WIDTH,
 
-  startUpload: async (sessionId, remotePath) => {
-    const transferId = await SFTPUpload(sessionId, remotePath);
+  startUpload: async (target, remotePath) => {
+    const transferId = await SFTPUpload(target.sessionId, remotePath);
     if (!transferId) return null;
-    subscribeProgress(transferId, sessionId, "upload", set, get);
+    subscribeProgress(transferId, target, "upload", set, get);
     return transferId;
   },
 
-  startUploadDir: async (sessionId, remotePath) => {
-    const transferId = await SFTPUploadDir(sessionId, remotePath);
+  startUploadDir: async (target, remotePath) => {
+    const transferId = await SFTPUploadDir(target.sessionId, remotePath);
     if (!transferId) return null;
-    subscribeProgress(transferId, sessionId, "upload", set, get);
+    subscribeProgress(transferId, target, "upload", set, get);
     return transferId;
   },
 
-  startUploadFile: async (sessionId, localPath, remotePath) => {
-    const transferId = await SFTPUploadFile(sessionId, localPath, remotePath);
+  startUploadFile: async (target, localPath, remotePath) => {
+    const transferId = await SFTPUploadFile(target.sessionId, localPath, remotePath);
     if (!transferId) return null;
-    subscribeProgress(transferId, sessionId, "upload", set, get);
+    subscribeProgress(transferId, target, "upload", set, get);
     return transferId;
   },
 
-  startDownload: async (sessionId, remotePath) => {
-    const transferId = await SFTPDownload(sessionId, remotePath);
+  startDownload: async (target, remotePath) => {
+    const transferId = await SFTPDownload(target.sessionId, remotePath);
     if (!transferId) return null;
-    subscribeProgress(transferId, sessionId, "download", set, get);
+    subscribeProgress(transferId, target, "download", set, get);
     return transferId;
   },
 
-  startDownloadDir: async (sessionId, remotePath) => {
-    const transferId = await SFTPDownloadDir(sessionId, remotePath);
+  startDownloadDir: async (target, remotePath) => {
+    const transferId = await SFTPDownloadDir(target.sessionId, remotePath);
     if (!transferId) return null;
-    subscribeProgress(transferId, sessionId, "download", set, get);
+    subscribeProgress(transferId, target, "download", set, get);
     return transferId;
   },
 
@@ -226,8 +235,24 @@ export const useSFTPStore = create<SFTPState>((set, get) => ({
     });
   },
 
+  clearCompletedForTab: (tabId) => {
+    set((state) => {
+      const kept: Record<string, SFTPTransfer> = {};
+      for (const [id, t] of Object.entries(state.transfers)) {
+        if (t.tabId !== tabId || t.status === "active") {
+          kept[id] = t;
+        }
+      }
+      return { transfers: kept };
+    });
+  },
+
   getSessionTransfers: (sessionId) => {
     return Object.values(get().transfers).filter((t) => t.sessionId === sessionId);
+  },
+
+  getTabTransfers: (tabId) => {
+    return Object.values(get().transfers).filter((t) => t.tabId === tabId);
   },
 
   toggleFileManager: (tabId) => {


### PR DESCRIPTION
## 概要
- 将 SFTP 传输进度归属到发起传输的终端 tab，同时后端仍按 session ID 执行上传/下载
- 避免隐藏的终端 tab 继续持有原生文件拖拽上传处理器
- 增加跨 tab 传输隔离和上传完成刷新行为的回归测试

## 测试
- pnpm exec vitest run src/__tests__/sftpStore.test.ts src/__tests__/FileManagerPanel.test.tsx
- pnpm lint
- pnpm build

Closes #90