### PR TITLE
🐛 Fix terminal input write ordering

### DIFF
--- a/frontend/src/__tests__/terminalInputWriter.test.ts
+++ b/frontend/src/__tests__/terminalInputWriter.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalInputWriter } from "@/components/terminal/terminalInputWriter";
+
+function decodeBytes(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("TerminalInputWriter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("batches printable input before writing to SSH", () => {
+    const writeSSH = vi.fn().mockResolvedValue(undefined);
+    const writer = new TerminalInputWriter("sess-1", {
+      writeSSH,
+      encodeBytes: decodeBytes,
+      flushDelayMs: 8,
+    });
+
+    writer.write("c");
+    writer.write("a");
+    writer.write("t");
+
+    vi.advanceTimersByTime(7);
+    expect(writeSSH).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(writeSSH).toHaveBeenCalledTimes(1);
+    expect(writeSSH).toHaveBeenCalledWith("sess-1", "cat");
+  });
+
+  it("serializes writes while an earlier WriteSSH call is still in flight", async () => {
+    const first = deferred();
+    const second = deferred();
+    const writeSSH = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const writer = new TerminalInputWriter("sess-2", {
+      writeSSH,
+      encodeBytes: decodeBytes,
+      flushDelayMs: 8,
+    });
+
+    writer.write("c");
+    vi.advanceTimersByTime(8);
+    expect(writeSSH).toHaveBeenCalledTimes(1);
+    expect(writeSSH).toHaveBeenNthCalledWith(1, "sess-2", "c");
+
+    writer.write("at");
+    vi.advanceTimersByTime(8);
+    expect(writeSSH).toHaveBeenCalledTimes(1);
+
+    first.resolve();
+    await flushPromises();
+    vi.advanceTimersByTime(8);
+
+    expect(writeSSH).toHaveBeenCalledTimes(2);
+    expect(writeSSH).toHaveBeenNthCalledWith(2, "sess-2", "at");
+    second.resolve();
+  });
+
+  it("flushes pending printable input immediately when control input arrives", () => {
+    const writeSSH = vi.fn().mockResolvedValue(undefined);
+    const writer = new TerminalInputWriter("sess-3", {
+      writeSSH,
+      encodeBytes: decodeBytes,
+      flushDelayMs: 8,
+    });
+
+    writer.write("ls");
+    writer.write("\r");
+
+    expect(writeSSH).toHaveBeenCalledTimes(1);
+    expect(writeSSH).toHaveBeenCalledWith("sess-3", "ls\r");
+  });
+
+  it("drops pending input after dispose", () => {
+    const writeSSH = vi.fn().mockResolvedValue(undefined);
+    const writer = new TerminalInputWriter("sess-4", {
+      writeSSH,
+      encodeBytes: decodeBytes,
+      flushDelayMs: 8,
+    });
+
+    writer.write("cat");
+    writer.dispose();
+    writer.write(" clear");
+    vi.advanceTimersByTime(8);
+
+    expect(writeSSH).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/terminal/Terminal.tsx
+++ b/frontend/src/components/terminal/Terminal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState,
 import type { Terminal as XTerminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
-import { WriteSSH, ResizeSSH } from "../../../wailsjs/go/app/App";
+import { ResizeSSH } from "../../../wailsjs/go/app/App";
 import { useShortcutStore, matchShortcut, formatBinding, formatModKey } from "@/stores/shortcutStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useTerminalThemeStore, toXtermTheme } from "@/stores/terminalThemeStore";
@@ -22,8 +22,7 @@ import {
 import { TerminalSearchBar } from "./TerminalSearchBar";
 import { useSFTPStore } from "@/stores/sftpStore";
 import { useTabStore } from "@/stores/tabStore";
-import { bytesToBase64 } from "@/lib/terminalEncode";
-import { getOrCreateTerminal, getTerminalInstance } from "./terminalRegistry";
+import { getOrCreateTerminal, getTerminalInstance, writeTerminalInput } from "./terminalRegistry";
 
 export interface TerminalHandle {
   toggleSearch: () => void;
@@ -75,7 +74,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   const handlePaste = useCallback(() => {
     navigator.clipboard.readText().then((text) => {
       if (text && termRef.current) {
-        WriteSSH(sessionId, bytesToBase64(new TextEncoder().encode(text))).catch(console.error);
+        writeTerminalInput(sessionId, text);
       }
     });
   }, [sessionId]);

--- a/frontend/src/components/terminal/terminalInputWriter.ts
+++ b/frontend/src/components/terminal/terminalInputWriter.ts
@@ -1,0 +1,96 @@
+import { WriteSSH } from "../../../wailsjs/go/app/App";
+import { bytesToBase64 } from "@/lib/terminalEncode";
+
+type WriteSSHFn = (sessionId: string, dataB64: string) => Promise<void>;
+
+interface TerminalInputWriterOptions {
+  writeSSH?: WriteSSHFn;
+  encodeBytes?: (bytes: Uint8Array) => string;
+  flushDelayMs?: number;
+}
+
+const defaultFlushDelayMs = 8;
+const encoder = new TextEncoder();
+
+function hasControlInput(data: string): boolean {
+  for (let i = 0; i < data.length; i++) {
+    const code = data.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+export class TerminalInputWriter {
+  private pending = "";
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private writing = false;
+  private disposed = false;
+  private readonly writeSSH: WriteSSHFn;
+  private readonly encodeBytes: (bytes: Uint8Array) => string;
+  private readonly flushDelayMs: number;
+
+  constructor(
+    private readonly sessionId: string,
+    options: TerminalInputWriterOptions = {}
+  ) {
+    this.writeSSH = options.writeSSH ?? WriteSSH;
+    this.encodeBytes = options.encodeBytes ?? bytesToBase64;
+    this.flushDelayMs = options.flushDelayMs ?? defaultFlushDelayMs;
+  }
+
+  write(data: string): void {
+    if (this.disposed || !data) return;
+
+    this.pending += data;
+    if (hasControlInput(data)) {
+      this.clearTimer();
+      this.flush();
+      return;
+    }
+
+    if (this.flushTimer === null) {
+      this.flushTimer = setTimeout(() => {
+        this.flushTimer = null;
+        this.flush();
+      }, this.flushDelayMs);
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.pending = "";
+    this.clearTimer();
+  }
+
+  private clearTimer(): void {
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  private flush(): void {
+    if (this.disposed || this.writing || !this.pending) return;
+
+    const data = this.pending;
+    this.pending = "";
+    this.writing = true;
+
+    this.writeSSH(this.sessionId, this.encodeBytes(encoder.encode(data)))
+      .catch(console.error)
+      .finally(() => {
+        this.writing = false;
+        if (this.disposed || !this.pending) return;
+        if (hasControlInput(this.pending)) {
+          this.flush();
+          return;
+        }
+        if (this.flushTimer === null) {
+          this.flushTimer = setTimeout(() => {
+            this.flushTimer = null;
+            this.flush();
+          }, this.flushDelayMs);
+        }
+      });
+  }
+}

--- a/frontend/src/components/terminal/terminalRegistry.ts
+++ b/frontend/src/components/terminal/terminalRegistry.ts
@@ -2,18 +2,18 @@ import { Terminal as XTerminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import "@xterm/xterm/css/xterm.css";
-import { WriteSSH } from "../../../wailsjs/go/app/App";
 import { EventsOn, EventsOff } from "../../../wailsjs/runtime/runtime";
-import { bytesToBase64 } from "@/lib/terminalEncode";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { withTerminalFontFallback } from "@/data/terminalFonts";
 import i18n from "@/i18n";
+import { TerminalInputWriter } from "./terminalInputWriter";
 
 export interface TerminalInstance {
   term: XTerminal;
   fitAddon: FitAddon;
   searchAddon: SearchAddon;
   container: HTMLDivElement;
+  writeInput: (data: string) => void;
 }
 
 interface InternalInstance extends TerminalInstance {
@@ -44,12 +44,13 @@ export function getOrCreateTerminal(
 
   const fitAddon = new FitAddon();
   const searchAddon = new SearchAddon();
+  const inputWriter = new TerminalInputWriter(sessionId);
   term.loadAddon(fitAddon);
   term.loadAddon(searchAddon);
   term.open(container);
 
   const onDataDispose = term.onData((data) => {
-    WriteSSH(sessionId, bytesToBase64(new TextEncoder().encode(data))).catch(console.error);
+    inputWriter.write(data);
   });
 
   const dataEvent = "ssh:data:" + sessionId;
@@ -72,10 +73,12 @@ export function getOrCreateTerminal(
     fitAddon,
     searchAddon,
     container,
+    writeInput: (data: string) => inputWriter.write(data),
     isClosed: false,
     dispose: () => {
       onDataDispose.dispose();
       onKeyDispose.dispose();
+      inputWriter.dispose();
       EventsOff(dataEvent);
       EventsOff(closedEvent);
       term.dispose();
@@ -108,4 +111,8 @@ export function disposeTerminal(sessionId: string): void {
 
 export function getTerminalInstance(sessionId: string): TerminalInstance | undefined {
   return registry.get(sessionId);
+}
+
+export function writeTerminalInput(sessionId: string, data: string): void {
+  registry.get(sessionId)?.writeInput(data);
 }


### PR DESCRIPTION
## Summary
- add a per-session terminal input writer that batches printable input and serializes WriteSSH calls
- route xterm input and context-menu paste through the same queued writer
- add tests for batching, ordering, control-character flushing, and dispose behavior

## Verification
- wails build -s -nopackage -m -nosyncgomod
- cd frontend && pnpm test -- terminalInputWriter terminalRegistry
- cd frontend && pnpm lint
- cd frontend && pnpm build

Closes #94