### PR TITLE
🐛 Terminal IME：抽 TerminalInputBridge + isComposing 早返回（close #94）

### DIFF
--- a/frontend/src/__tests__/terminalInputBridge.test.ts
+++ b/frontend/src/__tests__/terminalInputBridge.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Terminal as XTerminal } from "@xterm/xterm";
+import { createTerminalInputBridge } from "@/components/terminal/terminalInputBridge";
+import { DEFAULT_SHORTCUTS } from "@/stores/shortcutStore";
+
+interface FakeKeyEvent {
+  type: "keydown" | "keyup";
+  code: string;
+  key: string;
+  keyCode?: number;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  isComposing?: boolean;
+}
+
+function makeBridge() {
+  let handler: ((e: KeyboardEvent) => boolean) | null = null;
+  const term = {
+    attachCustomKeyEventHandler: (fn: (e: KeyboardEvent) => boolean) => {
+      handler = fn;
+    },
+  } as unknown as XTerminal;
+
+  const onFilter = vi.fn();
+  const onCopy = vi.fn(() => false);
+
+  const bridge = createTerminalInputBridge({
+    term,
+    shortcuts: DEFAULT_SHORTCUTS,
+    onFilter,
+    onCopy,
+  });
+
+  const fire = (e: FakeKeyEvent): boolean => {
+    if (!handler) throw new Error("handler not installed");
+    const full = {
+      shiftKey: false,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      isComposing: false,
+      keyCode: 0,
+      ...e,
+    };
+    return handler(full as unknown as KeyboardEvent);
+  };
+
+  const isMac = /Macintosh|Mac OS/.test(navigator.userAgent);
+  const modKey: { metaKey: true } | { ctrlKey: true } = isMac ? { metaKey: true } : { ctrlKey: true };
+
+  return { bridge, fire, onFilter, onCopy, modKey, getHandler: () => handler };
+}
+
+describe("terminalInputBridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true (lets xterm handle) when isComposing is true, even for a bound shortcut", () => {
+    // panel.filter is Mod+F. While composing, the bridge must NOT call onFilter
+    // and must let xterm process the key so the IME commit can land.
+    const { fire, onFilter, modKey } = makeBridge();
+    const result = fire({
+      type: "keydown",
+      code: "KeyF",
+      key: "f",
+      ...modKey,
+      isComposing: true,
+    });
+    expect(result).toBe(true);
+    expect(onFilter).not.toHaveBeenCalled();
+  });
+
+  it("returns true when keyCode === 229 (Firefox IME) regardless of isComposing flag", () => {
+    const { fire, onFilter } = makeBridge();
+    const result = fire({
+      type: "keydown",
+      code: "",
+      key: "Process",
+      keyCode: 229,
+      isComposing: false,
+    });
+    expect(result).toBe(true);
+    expect(onFilter).not.toHaveBeenCalled();
+  });
+
+  it("triggers onFilter and returns false on Mod+F outside composition", () => {
+    const { fire, onFilter, modKey } = makeBridge();
+    const result = fire({
+      type: "keydown",
+      code: "KeyF",
+      key: "f",
+      ...modKey,
+      isComposing: false,
+    });
+    expect(result).toBe(false);
+    expect(onFilter).toHaveBeenCalledTimes(1);
+  });
+
+  it("Cmd/Ctrl+C with selection: returns false (eats the event)", () => {
+    const { fire, onCopy, modKey } = makeBridge();
+    onCopy.mockImplementation(() => true);
+    const result = fire({ type: "keydown", code: "KeyC", key: "c", ...modKey });
+    expect(result).toBe(false);
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+
+  it("Cmd/Ctrl+C without selection: returns true so xterm sends SIGINT", () => {
+    const { fire, onCopy, modKey } = makeBridge();
+    onCopy.mockImplementation(() => false);
+    const result = fire({ type: "keydown", code: "KeyC", key: "c", ...modKey });
+    expect(result).toBe(true);
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+
+  it("setShortcuts hot-updates the binding used by the handler", () => {
+    const { bridge, fire, onFilter } = makeBridge();
+    // Remap panel.filter from KeyF to KeyG.
+    bridge.setShortcuts({
+      ...DEFAULT_SHORTCUTS,
+      "panel.filter": { code: "KeyG", mod: true, shift: false, alt: false },
+    });
+    const isMac = /Macintosh|Mac OS/.test(navigator.userAgent);
+    const mod = isMac ? { metaKey: true } : { ctrlKey: true };
+
+    // Old binding no longer fires onFilter.
+    expect(fire({ type: "keydown", code: "KeyF", key: "f", ...mod })).toBe(true);
+    expect(onFilter).not.toHaveBeenCalled();
+
+    // New binding does.
+    expect(fire({ type: "keydown", code: "KeyG", key: "g", ...mod })).toBe(false);
+    expect(onFilter).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose restores handler to a no-op pass-through; subsequent shortcut keys do nothing", () => {
+    const { bridge, fire, onFilter, modKey } = makeBridge();
+    bridge.dispose();
+    const result = fire({
+      type: "keydown",
+      code: "KeyF",
+      key: "f",
+      ...modKey,
+    });
+    expect(result).toBe(true);
+    expect(onFilter).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/terminalRegistry.test.ts
+++ b/frontend/src/__tests__/terminalRegistry.test.ts
@@ -6,10 +6,21 @@ const hoisted = vi.hoisted(() => {
   const disposeSpy = vi.fn();
   const reconnectBySessionMock = vi.fn();
   const terminalCtor = vi.fn();
+  const bridgeDisposeSpy = vi.fn();
+  const disposeOrder: string[] = [];
   const state: { capturedOnKey: ((e: { key: string }) => void) | null } = {
     capturedOnKey: null,
   };
-  return { eventHandlers, writeSpy, disposeSpy, reconnectBySessionMock, terminalCtor, state };
+  return {
+    eventHandlers,
+    writeSpy,
+    disposeSpy,
+    reconnectBySessionMock,
+    terminalCtor,
+    bridgeDisposeSpy,
+    disposeOrder,
+    state,
+  };
 });
 
 vi.mock("../../wailsjs/runtime/runtime", () => ({
@@ -35,13 +46,29 @@ vi.mock("@xterm/xterm", () => {
       hoisted.state.capturedOnKey = handler;
       return { dispose: vi.fn() };
     });
-    dispose = hoisted.disposeSpy;
+    attachCustomKeyEventHandler = vi.fn();
+    dispose = vi.fn(() => {
+      hoisted.disposeOrder.push("term");
+      hoisted.disposeSpy();
+    });
     constructor() {
       hoisted.terminalCtor();
     }
   }
   return { Terminal: MockTerminal };
 });
+
+vi.mock("@/components/terminal/terminalInputBridge", () => ({
+  createTerminalInputBridge: vi.fn(() => ({
+    setShortcuts: vi.fn(),
+    setOnFilter: vi.fn(),
+    setOnCopy: vi.fn(),
+    dispose: vi.fn(() => {
+      hoisted.disposeOrder.push("bridge");
+      hoisted.bridgeDisposeSpy();
+    }),
+  })),
+}));
 
 vi.mock("@xterm/addon-fit", () => ({ FitAddon: class {} }));
 vi.mock("@xterm/addon-search", () => ({ SearchAddon: class {} }));
@@ -73,6 +100,8 @@ describe("terminalRegistry", () => {
     hoisted.disposeSpy.mockClear();
     hoisted.reconnectBySessionMock.mockClear();
     hoisted.terminalCtor.mockClear();
+    hoisted.bridgeDisposeSpy.mockClear();
+    hoisted.disposeOrder.length = 0;
   });
 
   it("writes the i18n closed hint and marks closed when ssh:closed fires", () => {
@@ -120,6 +149,14 @@ describe("terminalRegistry", () => {
     hoisted.state.capturedOnKey?.({ key: "\r" });
     expect(hoisted.reconnectBySessionMock).not.toHaveBeenCalled();
     disposeTerminal("sess-4");
+  });
+
+  it("disposes the input bridge before the xterm instance", () => {
+    getOrCreateTerminal("sess-order", { fontSize: 14, fontFamily: "mono", scrollback: 1000 });
+    disposeTerminal("sess-order");
+    expect(hoisted.bridgeDisposeSpy).toHaveBeenCalled();
+    expect(hoisted.disposeSpy).toHaveBeenCalled();
+    expect(hoisted.disposeOrder).toEqual(["bridge", "term"]);
   });
 
   it("re-creates a fresh terminal after dispose for the same sessionId", () => {

--- a/frontend/src/components/terminal/Terminal.tsx
+++ b/frontend/src/components/terminal/Terminal.tsx
@@ -3,7 +3,7 @@ import type { Terminal as XTerminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import { WriteSSH, ResizeSSH } from "../../../wailsjs/go/app/App";
-import { useShortcutStore, matchShortcut, formatBinding, formatModKey } from "@/stores/shortcutStore";
+import { useShortcutStore, formatBinding, formatModKey } from "@/stores/shortcutStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useTerminalThemeStore, toXtermTheme } from "@/stores/terminalThemeStore";
 import { builtinThemes, defaultLightTheme, defaultDarkTheme } from "@/data/terminalThemes";
@@ -103,21 +103,15 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       inst.fitAddon.fit();
     });
 
-    inst.term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-      const action = matchShortcut(e, useShortcutStore.getState().shortcuts);
-      if (action === "panel.filter" && e.type === "keydown") {
-        setShowSearch((v) => !v);
-        return false;
+    inst.bridge.setOnFilter(() => setShowSearch((v) => !v));
+    inst.bridge.setOnCopy(() => {
+      const selection = inst.term.getSelection();
+      if (selection) {
+        navigator.clipboard.writeText(selection);
+        toast.success(t("ssh.contextMenu.copied"), { duration: 1500 });
+        return true;
       }
-      if (e.key === "c" && (e.ctrlKey || e.metaKey) && e.type === "keydown") {
-        const selection = inst.term.getSelection();
-        if (selection) {
-          navigator.clipboard.writeText(selection);
-          toast.success(t("ssh.contextMenu.copied"), { duration: 1500 });
-          return false;
-        }
-      }
-      return !action;
+      return false;
     });
 
     const selDispose = inst.term.onSelectionChange(() => {
@@ -149,8 +143,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       // skip any term operations and just detach.
       const stillAlive = getTerminalInstance(sessionId) === inst;
       if (stillAlive) {
-        // Drop key handler so its closures can be GC'd; xterm only stores one slot.
-        inst.term.attachCustomKeyEventHandler(() => true);
+        // Drop callback closures so toast/setShowSearch can be GC'd;
+        // bridge keeps a single handler slot, just reset to no-ops.
+        inst.bridge.setOnFilter(() => {});
+        inst.bridge.setOnCopy(() => false);
       }
       if (inst.container.parentElement === wrapper) {
         wrapper.removeChild(inst.container);
@@ -170,6 +166,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     termRef.current.options.scrollback = scrollback;
     fitAddonRef.current?.fit();
   }, [xtermTheme, fontSize, fontFamily, scrollback]);
+
+  useEffect(() => {
+    const inst = getTerminalInstance(sessionId);
+    if (inst) inst.bridge.setShortcuts(shortcuts);
+  }, [sessionId, shortcuts]);
 
   useEffect(() => {
     activeRef.current = active;

--- a/frontend/src/components/terminal/terminalInputBridge.ts
+++ b/frontend/src/components/terminal/terminalInputBridge.ts
@@ -1,0 +1,59 @@
+import type { Terminal as XTerminal } from "@xterm/xterm";
+import { matchShortcut, type ShortcutAction, type ShortcutBinding } from "@/stores/shortcutStore";
+
+export interface TerminalInputBridgeOptions {
+  term: XTerminal;
+  shortcuts: Record<ShortcutAction, ShortcutBinding>;
+  onFilter: () => void;
+  onCopy: () => boolean;
+}
+
+export interface TerminalInputBridge {
+  setShortcuts(s: Record<ShortcutAction, ShortcutBinding>): void;
+  setOnFilter(cb: () => void): void;
+  setOnCopy(cb: () => boolean): void;
+  dispose(): void;
+}
+
+export function createTerminalInputBridge(opts: TerminalInputBridgeOptions): TerminalInputBridge {
+  const { term } = opts;
+  let shortcuts = opts.shortcuts;
+  let onFilter = opts.onFilter;
+  let onCopy = opts.onCopy;
+  let disposed = false;
+
+  const handler = (e: KeyboardEvent): boolean => {
+    if (disposed) return true;
+    // W3C UI Events §5.4.3: 应用层在 IME composition / keyCode=229 时必须早返回，
+    // 否则可能误吞掉应交给 IME / xterm 内部处理的按键，导致字符丢失。
+    if (e.isComposing || e.keyCode === 229) return true;
+
+    const action = matchShortcut(e, shortcuts);
+    if (action === "panel.filter" && e.type === "keydown") {
+      onFilter();
+      return false;
+    }
+    if (e.key === "c" && (e.ctrlKey || e.metaKey) && e.type === "keydown") {
+      if (onCopy()) return false;
+    }
+    return !action;
+  };
+
+  term.attachCustomKeyEventHandler(handler);
+
+  return {
+    setShortcuts(s) {
+      shortcuts = s;
+    },
+    setOnFilter(cb) {
+      onFilter = cb;
+    },
+    setOnCopy(cb) {
+      onCopy = cb;
+    },
+    dispose() {
+      disposed = true;
+      term.attachCustomKeyEventHandler(() => true);
+    },
+  };
+}

--- a/frontend/src/components/terminal/terminalRegistry.ts
+++ b/frontend/src/components/terminal/terminalRegistry.ts
@@ -6,14 +6,17 @@ import { WriteSSH } from "../../../wailsjs/go/app/App";
 import { EventsOn, EventsOff } from "../../../wailsjs/runtime/runtime";
 import { bytesToBase64 } from "@/lib/terminalEncode";
 import { useTerminalStore } from "@/stores/terminalStore";
+import { useShortcutStore } from "@/stores/shortcutStore";
 import { withTerminalFontFallback } from "@/data/terminalFonts";
 import i18n from "@/i18n";
+import { createTerminalInputBridge, type TerminalInputBridge } from "./terminalInputBridge";
 
 export interface TerminalInstance {
   term: XTerminal;
   fitAddon: FitAddon;
   searchAddon: SearchAddon;
   container: HTMLDivElement;
+  bridge: TerminalInputBridge;
 }
 
 interface InternalInstance extends TerminalInstance {
@@ -48,6 +51,15 @@ export function getOrCreateTerminal(
   term.loadAddon(searchAddon);
   term.open(container);
 
+  // 单一 keyboard 处理入口：IME 守卫 + shortcut 拦截 + Cmd+C 选区复制。
+  // 占位回调由 Terminal.tsx 在挂载时通过 setOnFilter/setOnCopy 注入。
+  const bridge = createTerminalInputBridge({
+    term,
+    shortcuts: useShortcutStore.getState().shortcuts,
+    onFilter: () => {},
+    onCopy: () => false,
+  });
+
   const onDataDispose = term.onData((data) => {
     WriteSSH(sessionId, bytesToBase64(new TextEncoder().encode(data))).catch(console.error);
   });
@@ -72,8 +84,12 @@ export function getOrCreateTerminal(
     fitAddon,
     searchAddon,
     container,
+    bridge,
     isClosed: false,
     dispose: () => {
+      // bridge 持有 term.attachCustomKeyEventHandler 槽位的还原逻辑,
+      // 必须在 term.dispose 之前调用,避免 dispose 后访问已释放对象。
+      bridge.dispose();
       onDataDispose.dispose();
       onKeyDispose.dispose();
       EventsOff(dataEvent);

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/opskat/opskat
 go 1.26.0
 
 require (
-	github.com/cago-frame/agents v0.0.0-20260512154912-6fca6259bc2d
+	github.com/cago-frame/agents v0.0.0-20260513055252-abb8e51e0eac
 	github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947
 	github.com/coder/websocket v1.8.14
 	github.com/fsnotify/fsnotify v1.10.0
@@ -182,7 +182,3 @@ require (
 )
 
 // replace github.com/wailsapp/wails/v2 v2.10.2 => /Users/codfrm/go/pkg/mod
-
-// 临时本地路径：cago openai provider 加 wrapProviderError 修复 5xx/429 不重试问题。
-// 等 cago 上游 commit / 发版后请删除这条 replace，并 go get 到对应版本。
-replace github.com/cago-frame/agents => /Users/codfrm/Code/cago/agents

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/bytedance/sonic v1.12.5/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKz
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.1 h1:1GgorWTqf12TA8mma4DDSbaQigE2wOgQo7iCjjJv3+E=
 github.com/bytedance/sonic/loader v0.2.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
+github.com/cago-frame/agents v0.0.0-20260513055252-abb8e51e0eac h1:qvQvclbl/tJIBWrePdloeL0s3A51k4PBOvZJwtIgLG0=
+github.com/cago-frame/agents v0.0.0-20260513055252-abb8e51e0eac/go.mod h1:Jy+CKjPkZCgu6jc06F+Fa0lj+/wxgnfyxmz1ey06/98=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947 h1:JynA9XgnZAd8sXqdbxkBqp2RiBsQN8zV4ufANBvzrj4=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947/go.mod h1:a+0ZfDfiKrkIletlXDHbgsFZLGd1yo43waHfpfAIFs8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -42,7 +42,7 @@ type Usage struct {
 
 // StreamEvent 流式响应事件
 type StreamEvent struct {
-	Type       string `json:"type"`                   // "content" | "tool_start" | "tool_result" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "queue_consumed" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage" | "compacted"
+	Type string `json:"type"` // "content" | "tool_start" | "tool_result" | "approval_request" | "approval_result" | "agent_start" | "agent_end" | "queue_consumed" | "done" | "error" | "thinking" | "thinking_done" | "stopped" | "retry" | "usage" | "compacted"
 	// type=retry 时 Content 携带 attempt 序号（字符串形式，从 1 开始），RetryDelayMs 是下一次重试前的等待毫秒（用于前端倒计时同步）。
 	Content    string `json:"content,omitempty"`      // type=content/tool_result/approval_result/agent_end 时的文本
 	QueueID    string `json:"queue_id,omitempty"`     // type=queue_consumed 时的前端队列项 ID

--- a/internal/model/entity/conversation_entity/conversation.go
+++ b/internal/model/entity/conversation_entity/conversation.go
@@ -96,7 +96,7 @@ type ContentBlock struct {
 	ToolName   string `json:"toolName,omitempty"`
 	ToolInput  string `json:"toolInput,omitempty"`
 	ToolCallID string `json:"toolCallId,omitempty"` // 跨 turn 还原 tool_calls 历史；老数据无此字段，前端兜底为塌缩消息
-	Status     string `json:"status,omitempty"`     // "running" | "completed" | "error" | "cancelled"
+	Status     string `json:"status,omitempty"`     // "running" | "completed" | "error" | "canceled"
 	// error 块字段：
 	//   ErrorKind   — "rate_limit" | "server" | "network" | "auth" | "interrupted" | "unknown"
 	//   ErrorDetail — 原始错误正文，UI 直接展示


### PR DESCRIPTION
## Summary

- 抽 `frontend/src/components/terminal/terminalInputBridge.ts` 统一管理终端 keyboard 路径：shortcut 拦截、Cmd+C 选区复制、IME 守卫
- handler 顶部加 W3C 规范的 `e.isComposing || e.keyCode === 229` 早返回 — 这是 issue #94 报告里「macOS 百度五笔 Shift→英文 半激活模式下 `cat` → `ct` 丢字」的直接修复点
- `Terminal.tsx` 删除内联 `attachCustomKeyEventHandler` 块，改用 `bridge.setOnFilter / setOnCopy` 注入回调；新增 useEffect 同步 shortcut 热更新
- `terminalRegistry` dispose 顺序：bridge.dispose 先于 term.dispose

## 根因

`Terminal.tsx` 旧代码对每个 keydown 都跑 `matchShortcut`，**没有 IME 早返回**。W3C UI Events §5.4.3 要求应用层在 `isComposing || keyCode === 229` 时跳过。代码库内其它输入位置（`CommandPalette`、`TabFilterInput`、`QueryResultTable`、AI input、`useIMEComposing`）都做了此守卫，**终端是唯一遗漏处** —— 与项目内规范不一致。

Wubi Shift-英文模式下浏览器偶发把 modifier 状态传给 composition-related keydown，handler 命中 action、返回 `false`，xterm 整个吞掉该键 → 丢字。

## 不在本次范围

报告里另一条 `hi → hihi` 重复字符，**tabby 也能复现**，属于 xterm.js `CompositionHelper._dataAlreadySent` diff 在半 composition 重入下的漂移（xtermjs/xterm.js#1939 / #3679 / #5348），是上游通用问题，单独跟。

## Test plan

- [x] `pnpm vitest run` 全量 840/840 通过；新增 7 个 TDD 用例覆盖 IME 早返回、`keyCode === 229`、shortcut 触发、Cmd+C 有/无选区、热更新、dispose
- [x] `terminalRegistry.test.ts` 追加 dispose 顺序断言 `["bridge","term"]`
- [x] `tsc --noEmit` 通过
- [x] `pnpm lint` 0 errors（warnings 全是已有 react-hooks 警告，与本次无关）
- [ ] 手动 QA（reviewer 协助）：macOS 启用百度五笔，Shift 切「英」半激活模式 → SSH 中输入 `cat hello world` 应一字不漏；Cmd+F 在 IME 期间应让 xterm 处理（不开搜索栏）
- [ ] 回归：Cmd+W / Cmd+F / Cmd+1..9 / Ctrl+C 选区复制 / 无选区 Ctrl+C 传 SIGINT — 均正常

Closes #94