### PR TITLE
🐛 Terminal IME：旁路 xterm key-rollover input 丢字 bug

### DIFF
--- a/frontend/src/components/terminal/terminalRegistry.ts
+++ b/frontend/src/components/terminal/terminalRegistry.ts
@@ -60,9 +60,38 @@ export function getOrCreateTerminal(
     onCopy: () => false,
   });
 
-  const onDataDispose = term.onData((data) => {
+  const writeSSHData = (data: string) =>
     WriteSSH(sessionId, bytesToBase64(new TextEncoder().encode(data))).catch(console.error);
-  });
+
+  const onDataDispose = term.onData(writeSSHData);
+
+  // 上游 bug 旁路（xterm v6.0.0，CoreBrowserTerminal._inputEvent）：
+  // xterm 用全局 _keyDownSeen 给 IME composed insertText 做去重，假定一次只按一个键。
+  // 百度五笔等输入法在「英文模式」下把每个按键都伪装成 keyCode=229，加上用户快速
+  // 输入造成 key-rollover（前一键 keyup 之前下一键 input 已触发），xterm 误判
+  // 「_keyDownSeen=true => 重复输入」把中间字符丢弃。这里精确匹配 xterm 的跳过条件，
+  // 在它跳过时补一次 WriteSSH。screenReaderMode 下 xterm 走另一条路径会自己发，
+  // 所以同步加守卫避免双发。
+  let detachRolloverPatch: () => void = () => {};
+  const ta = term.textarea;
+  if (ta) {
+    const coreRef = (term as unknown as { _core?: { _keyDownSeen?: boolean } })._core;
+    const rolloverHandler = (e: Event) => {
+      const ie = e as InputEvent;
+      if (
+        ie.inputType === "insertText" &&
+        ie.data &&
+        !ie.isComposing &&
+        ie.composed &&
+        coreRef?._keyDownSeen === true &&
+        !term.options.screenReaderMode
+      ) {
+        writeSSHData(ie.data);
+      }
+    };
+    ta.addEventListener("input", rolloverHandler, true);
+    detachRolloverPatch = () => ta.removeEventListener("input", rolloverHandler, true);
+  }
 
   const dataEvent = "ssh:data:" + sessionId;
   EventsOn(dataEvent, (dataB64: string) => {
@@ -90,6 +119,7 @@ export function getOrCreateTerminal(
       // bridge 持有 term.attachCustomKeyEventHandler 槽位的还原逻辑,
       // 必须在 term.dispose 之前调用,避免 dispose 后访问已释放对象。
       bridge.dispose();
+      detachRolloverPatch();
       onDataDispose.dispose();
       onKeyDispose.dispose();
       EventsOff(dataEvent);


### PR DESCRIPTION
## Summary

- 修复 #94：百度五笔等输入法「英文模式」下快速输入时丢字（`cat` → `ct`、`clear` → `cear`）
- 根因是 xterm v6.0.0 `CoreBrowserTerminal._inputEvent` 用全局 `_keyDownSeen` 给 IME `composed insertText` 去重，假定一次只按一个键
- 在 textarea capture 阶段加 input 监听，精确匹配 xterm 的跳过条件时补一次 `WriteSSH`

## 根因分析

百度五笔在「英文模式」下把每个按键都伪装成 `keyCode=229` 走 IME 通道（每个键 textarea 都触发 `inputType:"insertText"` 的 input 事件 + 紧随其后的 `keyCode=229` keydown）。快速输入造成 key-rollover——前一键 `keyup` 之前下一键 input 已触发，此时 xterm 的 `_keyDownSeen` 仍是 `true`，被 `(!ev.composed || !this._keyDownSeen)` 判定为重复输入而丢弃。

诊断时实测时间线（输入 `cat`）：

| 字符 | input 时 `_keyDownSeen` | xterm 处理 | 结果 |
|---|---|---|---|
| c | `false` | ✓ 发出 | `onData "c"` |
| **a** | **`true`**（c 未抬起） | ✗ 跳过 | **丢失** |
| t | `false`（c 抬起把全局标志清零，虽然 a 还按着） | ✓ 发出 | `onData "t"` |

## 旁路设计

按本仓 fix policy（上游 bug 只在自有路径里旁路、不在本仓 fully bypass）：

```ts
ta.addEventListener("input", (e: InputEvent) => {
  if (
    e.inputType === "insertText" &&
    e.data &&
    !e.isComposing &&
    e.composed &&
    core?._keyDownSeen === true &&         // xterm 会跳过这条
    !term.options.screenReaderMode          // 保持与 xterm 跳过条件一致避免双发
  ) {
    writeSSHData(e.data);
  }
}, true);
```

**为什么不会双发：**
- `_keyDownSeen=false` 时 xterm 自己发，我们条件不成立
- `_keyDownSeen=true` 时 xterm 跳过，我们补
- 非 IME 路径（普通 ASCII / 快捷键）xterm 在 keydown 上 preventDefault，根本不触发 input
- 复制粘贴 `inputType=insertFromPaste`，条件不匹配
- 真正中文 composition 期间 `isComposing=true`，条件不匹配

## Test plan

- [ ] 百度五笔英文模式快速输入 `cat`、`clear`、`pwd`、`ls -la`，所有字符正确进终端
- [ ] 同样场景下不会双发（不会变 `ccaatt`）
- [ ] 普通英文键盘正常输入无影响
- [ ] 中文 IME（搜狗/微软拼音）输入「中文」正常上屏，无重复
- [ ] 复制粘贴文本正常
- [ ] `Ctrl+C` / `Cmd+C` / 快捷键 (`Mod+F` 过滤) 行为不变
- [ ] `pnpm test` 终端相关单测全过

Closes #94