### PR TITLE
🐛 修复更新后立即重启未自动启动

### DIFF
--- a/frontend/src/__tests__/UpdateSection.test.tsx
+++ b/frontend/src/__tests__/UpdateSection.test.tsx
@@ -3,13 +3,16 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { UpdateSection } from "@/components/settings/UpdateSection";
 import {
+  CheckForUpdate,
+  DownloadAndInstallUpdate,
   GetAppVersion,
   GetAvailableMirrors,
   GetDebugMode,
   GetDownloadMirror,
   GetUpdateChannel,
+  RestartApp,
 } from "../../wailsjs/go/app/App";
-import { BrowserOpenURL, EventsOn } from "../../wailsjs/runtime/runtime";
+import { BrowserOpenURL, EventsOn, Quit } from "../../wailsjs/runtime/runtime";
 
 describe("UpdateSection", () => {
   const repositoryURL = "https://github.com/opskat/opskat";
@@ -22,6 +25,16 @@ describe("UpdateSection", () => {
     vi.mocked(GetDebugMode).mockResolvedValue(false);
     vi.mocked(GetDownloadMirror).mockResolvedValue("");
     vi.mocked(GetAvailableMirrors).mockResolvedValue([]);
+    vi.mocked(CheckForUpdate).mockResolvedValue({
+      hasUpdate: false,
+      currentVersion: "dev",
+      latestVersion: "dev",
+      releaseNotes: "",
+      releaseURL: "",
+      publishedAt: "",
+    });
+    vi.mocked(DownloadAndInstallUpdate).mockResolvedValue();
+    vi.mocked(RestartApp).mockResolvedValue();
   });
 
   it("shows and opens the project repository from settings", async () => {
@@ -32,5 +45,25 @@ describe("UpdateSection", () => {
     await userEvent.click(screen.getByRole("button", { name: repositoryURL }));
 
     expect(BrowserOpenURL).toHaveBeenCalledWith(repositoryURL);
+  });
+
+  it("relaunches the app instead of only quitting after an update", async () => {
+    vi.mocked(CheckForUpdate).mockResolvedValue({
+      hasUpdate: true,
+      currentVersion: "v1.0.0",
+      latestVersion: "v1.0.1",
+      releaseNotes: "",
+      releaseURL: "https://github.com/opskat/opskat/releases/tag/v1.0.1",
+      publishedAt: "2026-05-14T00:00:00Z",
+    });
+
+    render(<UpdateSection />);
+
+    await userEvent.click(screen.getByRole("button", { name: "appUpdate.checkUpdate" }));
+    await userEvent.click(await screen.findByRole("button", { name: "appUpdate.download" }));
+    await userEvent.click(await screen.findByRole("button", { name: "appUpdate.restartNow" }));
+
+    expect(RestartApp).toHaveBeenCalledTimes(1);
+    expect(Quit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/settings/UpdateSection.tsx
+++ b/frontend/src/components/settings/UpdateSection.tsx
@@ -36,10 +36,11 @@ import {
   GetDebugMode,
   SetDebugMode,
   OpenLogsDir,
+  RestartApp,
 } from "../../../wailsjs/go/app/App";
 import { Bug, Download, FolderOpen, Loader2, ExternalLink, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
-import { BrowserOpenURL, EventsOn, Quit } from "../../../wailsjs/runtime/runtime";
+import { BrowserOpenURL, EventsOn } from "../../../wailsjs/runtime/runtime";
 
 const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e));
 const REPOSITORY_URL = "https://github.com/opskat/opskat";
@@ -64,6 +65,7 @@ export function UpdateSection() {
   const [customMirror, setCustomMirror] = useState("");
   const [showChecksumDialog, setShowChecksumDialog] = useState(false);
   const [debugMode, setDebugModeState] = useState(false);
+  const [restarting, setRestarting] = useState(false);
 
   useEffect(() => {
     GetAppVersion()
@@ -204,6 +206,16 @@ export function UpdateSection() {
       }
     } finally {
       setUpdating(false);
+    }
+  };
+
+  const handleRestart = async () => {
+    setRestarting(true);
+    try {
+      await RestartApp();
+    } catch (e: unknown) {
+      setRestarting(false);
+      toast.error(errMsg(e));
     }
   };
 
@@ -365,7 +377,8 @@ export function UpdateSection() {
               </Button>
             ) : (
               <div className="flex gap-2">
-                <Button onClick={() => Quit()} size="sm">
+                <Button onClick={handleRestart} size="sm" disabled={restarting}>
+                  {restarting && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
                   {t("appUpdate.restartNow")}
                 </Button>
                 <Button variant="outline" size="sm" onClick={() => setUpdateDone(false)}>

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -431,6 +431,8 @@ export function RespondOpsctlApproval(arg1:string,arg2:ai.ApprovalResponse):Prom
 
 export function RespondPermission(arg1:string,arg2:string):Promise<void>;
 
+export function RestartApp():Promise<void>;
+
 export function SFTPCancelTransfer(arg1:string):Promise<void>;
 
 export function SFTPDelete(arg1:string,arg2:string,arg3:boolean):Promise<void>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -814,6 +814,10 @@ export function RespondPermission(arg1, arg2) {
   return window['go']['app']['App']['RespondPermission'](arg1, arg2);
 }
 
+export function RestartApp() {
+  return window['go']['app']['App']['RestartApp']();
+}
+
 export function SFTPCancelTransfer(arg1) {
   return window['go']['app']['App']['SFTPCancelTransfer'](arg1);
 }

--- a/internal/app/app_restart.go
+++ b/internal/app/app_restart.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+type relaunchTarget struct {
+	executablePath string
+	appBundlePath  string
+}
+
+// RestartApp relaunches OpsKat after the current process exits.
+func (a *App) RestartApp() error {
+	if a.ctx == nil {
+		return fmt.Errorf("app context is not ready")
+	}
+
+	target, err := currentRelaunchTarget()
+	if err != nil {
+		return err
+	}
+	if err := startRelaunchHelper(os.Getpid(), target); err != nil {
+		return err
+	}
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		wailsRuntime.Quit(a.ctx)
+	}()
+	return nil
+}
+
+func currentRelaunchTarget() (relaunchTarget, error) {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return relaunchTarget{}, fmt.Errorf("get executable path failed: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(executablePath); err == nil {
+		executablePath = resolved
+	}
+	return resolveRelaunchTargetFromExecutablePath(runtime.GOOS, executablePath)
+}
+
+func resolveRelaunchTargetFromExecutablePath(goos, executablePath string) (relaunchTarget, error) {
+	if strings.TrimSpace(executablePath) == "" {
+		return relaunchTarget{}, fmt.Errorf("executable path is empty")
+	}
+
+	target := relaunchTarget{
+		executablePath: normalizeExecutablePathForRelaunch(goos, executablePath),
+	}
+	if goos == "darwin" {
+		if appBundlePath, ok := findMacAppBundlePath(executablePath); ok {
+			target.appBundlePath = appBundlePath
+		}
+	}
+	return target, nil
+}
+
+func normalizeExecutablePathForRelaunch(goos, executablePath string) string {
+	path := strings.TrimSuffix(executablePath, " (deleted)")
+	switch goos {
+	case "windows":
+		if strings.HasSuffix(strings.ToLower(path), ".exe.old") {
+			return path[:len(path)-len(".old")]
+		}
+	case "darwin", "linux":
+		if strings.HasSuffix(path, ".backup") {
+			return strings.TrimSuffix(path, ".backup")
+		}
+	}
+	return path
+}
+
+func findMacAppBundlePath(executablePath string) (string, bool) {
+	path := strings.TrimSuffix(executablePath, " (deleted)")
+	for current := filepath.Clean(path); current != "." && current != string(filepath.Separator); current = filepath.Dir(current) {
+		base := filepath.Base(current)
+		if strings.HasSuffix(base, ".app") {
+			return current, true
+		}
+		if strings.HasSuffix(base, ".app.backup") {
+			return filepath.Join(filepath.Dir(current), strings.TrimSuffix(base, ".backup")), true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+	}
+	return "", false
+}

--- a/internal/app/app_restart_darwin.go
+++ b/internal/app/app_restart_darwin.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package app
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+func startRelaunchHelper(pid int, target relaunchTarget) error {
+	launchPath := target.executablePath
+	mode := "exec"
+	if target.appBundlePath != "" {
+		launchPath = target.appBundlePath
+		mode = "app"
+	}
+	if launchPath == "" {
+		return fmt.Errorf("restart target path is empty")
+	}
+
+	script := `while kill -0 "$1" 2>/dev/null; do sleep 0.1; done
+sleep 0.3
+if [ "$3" = "app" ]; then
+  open -n "$2"
+else
+  nohup "$2" >/dev/null 2>&1 &
+fi`
+	cmd := exec.Command("/bin/sh", "-c", script, "opskat-restart", strconv.Itoa(pid), launchPath, mode)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return cmd.Start()
+}

--- a/internal/app/app_restart_test.go
+++ b/internal/app/app_restart_test.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveRelaunchTargetFromExecutablePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mac app bundle", func(t *testing.T) {
+		t.Parallel()
+
+		target, err := resolveRelaunchTargetFromExecutablePath("darwin", "/Applications/OpsKat.app/Contents/MacOS/opskat")
+		if err != nil {
+			t.Fatalf("resolveRelaunchTargetFromExecutablePath() error = %v", err)
+		}
+		if got, want := filepath.ToSlash(target.appBundlePath), "/Applications/OpsKat.app"; got != want {
+			t.Fatalf("appBundlePath = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("mac app backup bundle", func(t *testing.T) {
+		t.Parallel()
+
+		target, err := resolveRelaunchTargetFromExecutablePath("darwin", "/Applications/OpsKat.app.backup/Contents/MacOS/opskat")
+		if err != nil {
+			t.Fatalf("resolveRelaunchTargetFromExecutablePath() error = %v", err)
+		}
+		if got, want := filepath.ToSlash(target.appBundlePath), "/Applications/OpsKat.app"; got != want {
+			t.Fatalf("appBundlePath = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("mac non bundle", func(t *testing.T) {
+		t.Parallel()
+
+		target, err := resolveRelaunchTargetFromExecutablePath("darwin", "/tmp/opskat")
+		if err != nil {
+			t.Fatalf("resolveRelaunchTargetFromExecutablePath() error = %v", err)
+		}
+		if target.appBundlePath != "" {
+			t.Fatalf("appBundlePath = %q, want empty", target.appBundlePath)
+		}
+		if target.executablePath != "/tmp/opskat" {
+			t.Fatalf("executablePath = %q, want /tmp/opskat", target.executablePath)
+		}
+	})
+
+	t.Run("mac non bundle backup executable", func(t *testing.T) {
+		t.Parallel()
+
+		target, err := resolveRelaunchTargetFromExecutablePath("darwin", "/tmp/opskat.backup")
+		if err != nil {
+			t.Fatalf("resolveRelaunchTargetFromExecutablePath() error = %v", err)
+		}
+		if target.executablePath != "/tmp/opskat" {
+			t.Fatalf("executablePath = %q, want /tmp/opskat", target.executablePath)
+		}
+	})
+
+	t.Run("windows old executable", func(t *testing.T) {
+		t.Parallel()
+
+		target, err := resolveRelaunchTargetFromExecutablePath("windows", `C:\Users\me\AppData\Local\OpsKat\opskat.exe.old`)
+		if err != nil {
+			t.Fatalf("resolveRelaunchTargetFromExecutablePath() error = %v", err)
+		}
+		if want := `C:\Users\me\AppData\Local\OpsKat\opskat.exe`; target.executablePath != want {
+			t.Fatalf("executablePath = %q, want %q", target.executablePath, want)
+		}
+	})
+
+	t.Run("linux deleted backup executable", func(t *testing.T) {
+		t.Parallel()
+
+		target, err := resolveRelaunchTargetFromExecutablePath("linux", "/opt/opskat/opskat.backup (deleted)")
+		if err != nil {
+			t.Fatalf("resolveRelaunchTargetFromExecutablePath() error = %v", err)
+		}
+		if target.executablePath != "/opt/opskat/opskat" {
+			t.Fatalf("executablePath = %q, want /opt/opskat/opskat", target.executablePath)
+		}
+	})
+}

--- a/internal/app/app_restart_unix.go
+++ b/internal/app/app_restart_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows && !darwin
+
+package app
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+func startRelaunchHelper(pid int, target relaunchTarget) error {
+	if target.executablePath == "" {
+		return fmt.Errorf("restart target executable is empty")
+	}
+
+	script := `while kill -0 "$1" 2>/dev/null; do sleep 0.1; done
+sleep 0.3
+nohup "$2" >/dev/null 2>&1 &`
+	cmd := exec.Command("/bin/sh", "-c", script, "opskat-restart", strconv.Itoa(pid), target.executablePath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return cmd.Start()
+}

--- a/internal/app/app_restart_windows.go
+++ b/internal/app/app_restart_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package app
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/opskat/opskat/internal/pkg/executil"
+)
+
+func startRelaunchHelper(pid int, target relaunchTarget) error {
+	if target.executablePath == "" {
+		return fmt.Errorf("restart target executable is empty")
+	}
+
+	script := "try { Wait-Process -Id " + strconv.Itoa(pid) + " -ErrorAction SilentlyContinue } catch {}; " +
+		"Start-Sleep -Milliseconds 300; " +
+		"Start-Process -FilePath " + quotePowerShellSingle(target.executablePath)
+	cmd := exec.Command("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-WindowStyle", "Hidden", "-Command", script)
+	executil.HideWindow(cmd)
+	return cmd.Start()
+}
+
+func quotePowerShellSingle(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}


### PR DESCRIPTION
## 摘要
- 新增 `RestartApp` 后端绑定，先启动外部 helper，再让 Wails 正常退出。
- Windows、macOS、Linux helper 会等待旧进程退出后再启动更新后的应用，避免 `SingleInstanceLock` 导致新实例提前退出。
- 设置页“立即重启”按钮改为调用 `RestartApp`，并补充路径解析与前端回归测试。

## 验证
- `go test ./internal/app`
- `cd frontend && pnpm test -- UpdateSection.test.tsx`
- `cd frontend && pnpm exec eslint src/components/settings/UpdateSection.tsx src/__tests__/UpdateSection.test.tsx`

Closes #91