### PR TITLE
🐛 修复 SSH 私钥认证后无法继续 keyboard-interactive(MFA/OTP)

### DIFF
--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -635,6 +635,8 @@ func buildAuthMethods(authType, password, key, keyPassphrase string, privateKeyP
 		if len(methods) == 0 {
 			return nil, fmt.Errorf("密钥认证方式需要提供私钥")
 		}
+		// 追加 keyboard-interactive 以支持 publickey + MFA/OTP 链路（JumpServer / 堡垒机场景，issue #77）
+		methods = append(methods, kbInteractive())
 	case "keyboard-interactive":
 		methods = append(methods, kbInteractive())
 	default:

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -1,8 +1,15 @@
 package ssh_svc
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -714,4 +721,88 @@ func TestEnableSyncReturnsErrorIfDisableRacesIn(t *testing.T) {
 	if state := sess.GetSyncState(); state.Supported {
 		t.Fatalf("Supported must be false after disable race, got %#v", state)
 	}
+}
+
+// generateTestPrivateKeyPEM 生成 ed25519 测试私钥的 PKCS8 PEM 编码。
+func generateTestPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("生成 ed25519 密钥失败: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("PKCS8 编码失败: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// TestBuildAuthMethods 校验各 authType 分支返回正确的 ssh.AuthMethod 序列。
+// 重点回归 issue #77：authType=key 分支必须在末尾追加 keyboard-interactive，
+// 以支持 publickey + MFA/OTP 链路（JumpServer 等堡垒机场景）。
+func TestBuildAuthMethods(t *testing.T) {
+	convey.Convey("buildAuthMethods 按 authType 返回正确的认证方法序列", t, func() {
+		pemKey := generateTestPrivateKeyPEM(t)
+		keyPath := filepath.Join(t.TempDir(), "id_test")
+		if err := os.WriteFile(keyPath, []byte(pemKey), 0o600); err != nil {
+			t.Fatalf("写入测试密钥文件失败: %v", err)
+		}
+
+		// crypto/ssh 包内的具体类型是私有的，但 %T 格式化能拿到稳定的类型名称，
+		// 足够用来断言 method 序列的组成与顺序。
+		const (
+			tPassword = "ssh.passwordCallback"
+			tPubKey   = "ssh.publicKeyCallback"
+			tKBI      = "ssh.KeyboardInteractiveChallenge"
+		)
+		typeNames := func(ms []ssh.AuthMethod) []string {
+			out := make([]string, len(ms))
+			for i, m := range ms {
+				out[i] = fmt.Sprintf("%T", m)
+			}
+			return out
+		}
+
+		convey.Convey("authType=password 返回 [password, keyboard-interactive]", func() {
+			ms, err := buildAuthMethods("password", "hunter2", "", "", nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, []string{tPassword, tKBI}, typeNames(ms))
+		})
+
+		convey.Convey("authType=key + inline key 返回 [publickey, keyboard-interactive]（issue #77）", func() {
+			ms, err := buildAuthMethods("key", "", pemKey, "", nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, []string{tPubKey, tKBI}, typeNames(ms))
+		})
+
+		convey.Convey("authType=key + 多个 file paths 返回 [publickey...publickey, keyboard-interactive]", func() {
+			ms, err := buildAuthMethods("key", "", "", "", []string{keyPath, keyPath}, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, []string{tPubKey, tPubKey, tKBI}, typeNames(ms))
+		})
+
+		convey.Convey("authType=key + inline + file paths 同时存在", func() {
+			ms, err := buildAuthMethods("key", "", pemKey, "", []string{keyPath}, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, []string{tPubKey, tPubKey, tKBI}, typeNames(ms))
+		})
+
+		convey.Convey("authType=key 但未提供任何密钥返回错误", func() {
+			_, err := buildAuthMethods("key", "", "", "", nil, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "需要提供私钥")
+		})
+
+		convey.Convey("authType=keyboard-interactive 仅返回 [keyboard-interactive]", func() {
+			ms, err := buildAuthMethods("keyboard-interactive", "", "", "", nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, []string{tKBI}, typeNames(ms))
+		})
+
+		convey.Convey("未知 authType 返回错误", func() {
+			_, err := buildAuthMethods("magic", "", "", "", nil, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "不支持的认证方式")
+		})
+	})
 }


### PR DESCRIPTION
## Summary

- `internal/service/ssh_svc/ssh.go` 的 `case "key"` 分支只 append 了 `ssh.PublicKeys`，没有附加 `keyboard-interactive` fallback。Go 的 `crypto/ssh` 要求 `ClientConfig.Auth` 切片里同时包含两种方法，才能处理服务端 `AuthenticationMethods publickey,keyboard-interactive` 在 publickey partial-success 后切到 keyboard-interactive 阶段。导致 JumpServer / 堡垒机的 "私钥 + MFA/OTP" 场景登录失败。
- 现与 `case "password"` 对齐，分支末尾追加 `kbInteractive()`。复用已存在的 `OnAuthChallenge` 链路（`internal/app/app_ssh.go` 的 `pendingAuthResponses` channel）和前端 `ConnectionProgress.tsx` 的 `AuthChallengeForm`，无需新增 UI / IPC。
- 新增 `TestBuildAuthMethods` 7 个子用例，覆盖 password / key inline / key file paths / key inline+file 同时存在 / key 空 / keyboard-interactive / unknown 七个分支返回的 method 序列与顺序，固化对 issue #77 修复的回归保护。

## Test plan

- [x] `go test ./internal/service/ssh_svc/ -run TestBuildAuthMethods -v` — 7 个子用例全部 PASS
- [x] `go test ./internal/service/ssh_svc/...` — 全包 PASS
- [x] `golangci-lint run ./internal/service/ssh_svc/...` — 0 issues
- [ ] 端到端：在 `make dev` 下连接配置了 `AuthenticationMethods publickey,keyboard-interactive` + PAM google_authenticator 的服务器（例 `linuxserver/openssh-server` 容器加 OTP），期望 publickey 通过后弹出 `AuthChallengeForm` 提示 OTP，输入正确 TOTP 后成功登录
- [ ] 回归：连接纯 publickey（无 MFA）的服务器，因服务端不发起 keyboard-interactive 阶段，附加的 `kbInteractive()` 永远不会被触发，行为应保持不变

Closes #77