### PR TITLE
🐛 修复 AI 助手输入框快捷换行

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-virtual": "^3.13.23",
     "@tiptap/core": "^2.27.2",
     "@tiptap/extension-document": "^2.27.2",
+    "@tiptap/extension-hard-break": "^2.27.2",
     "@tiptap/extension-mention": "^2.27.2",
     "@tiptap/extension-paragraph": "^2.27.2",
     "@tiptap/extension-placeholder": "^2.27.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@tiptap/extension-document':
         specifier: ^2.27.2
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-hard-break':
+        specifier: ^2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
       '@tiptap/extension-mention':
         specifier: ^2.27.2
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@tiptap/suggestion@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))
@@ -1635,6 +1638,11 @@ packages:
     peerDependencies:
       '@tiptap/core': ^2.7.0
       '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-hard-break@2.27.2':
+    resolution: {integrity: sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
 
   '@tiptap/extension-mention@2.27.2':
     resolution: {integrity: sha512-uHxVf8RISscb4xgCEJmDSNcFQmzlBTKJh7fp2QAXWIF4Xtrg3zD08PIXUvvHapoluGD9OdBugW4YCu1PJ3xWNw==}
@@ -4468,6 +4476,10 @@ snapshots:
       '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
       '@tiptap/pm': 2.27.2
       tippy.js: 6.3.7
+
+  '@tiptap/extension-hard-break@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
 
   '@tiptap/extension-mention@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@tiptap/suggestion@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))':
     dependencies:

--- a/frontend/src/__tests__/AIChatInput.test.tsx
+++ b/frontend/src/__tests__/AIChatInput.test.tsx
@@ -64,6 +64,38 @@ describe("AIChatInput", () => {
     expect(onSubmit).toHaveBeenCalledWith("hello\nworld");
   });
 
+  it("Enter 换行模式下 Ctrl+Enter 发送，普通 Enter 换行", async () => {
+    const onSubmit = vi.fn();
+    render(<AIChatInput onSubmit={onSubmit} sendOnEnter={false} />);
+    const editor = screen.getByRole("textbox");
+
+    await userEvent.click(editor);
+    await userEvent.keyboard("hello");
+    await userEvent.keyboard("{Enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+    await userEvent.keyboard("world");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith("hello\nworld");
+  });
+
+  it("Enter 换行模式下 Shift+Enter 插入硬换行而不发送", async () => {
+    const onSubmit = vi.fn();
+    render(<AIChatInput onSubmit={onSubmit} sendOnEnter={false} />);
+    const editor = screen.getByRole("textbox");
+
+    await userEvent.click(editor);
+    await userEvent.keyboard("hello");
+    await userEvent.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onSubmit).not.toHaveBeenCalled();
+    await userEvent.keyboard("world");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith("hello\nworld");
+  });
+
   it("提交后同步清空外部草稿和编辑器内容", async () => {
     const onSubmit = vi.fn();
     const onDraftChange = vi.fn();

--- a/frontend/src/__tests__/AIChatInput.test.tsx
+++ b/frontend/src/__tests__/AIChatInput.test.tsx
@@ -32,6 +32,38 @@ describe("AIChatInput", () => {
     expect(content).not.toContain("<mention");
   });
 
+  it("Shift+Enter 插入换行而不是发送", async () => {
+    const onSubmit = vi.fn();
+    render(<AIChatInput onSubmit={onSubmit} sendOnEnter={true} />);
+    const editor = screen.getByRole("textbox");
+
+    await userEvent.click(editor);
+    await userEvent.keyboard("hello");
+    await userEvent.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onSubmit).not.toHaveBeenCalled();
+    await userEvent.keyboard("world");
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith("hello\nworld");
+  });
+
+  it("Enter 发送模式下 Ctrl+Enter 插入换行而不是发送", async () => {
+    const onSubmit = vi.fn();
+    render(<AIChatInput onSubmit={onSubmit} sendOnEnter={true} />);
+    const editor = screen.getByRole("textbox");
+
+    await userEvent.click(editor);
+    await userEvent.keyboard("hello");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    expect(onSubmit).not.toHaveBeenCalled();
+    await userEvent.keyboard("world");
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith("hello\nworld");
+  });
+
   it("提交后同步清空外部草稿和编辑器内容", async () => {
     const onSubmit = vi.fn();
     const onDraftChange = vi.fn();

--- a/frontend/src/components/ai/AIChatInput.tsx
+++ b/frontend/src/components/ai/AIChatInput.tsx
@@ -128,11 +128,6 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
         if (isEnter && suggestionActive) {
           return false;
         }
-        if (isEnter && (event.shiftKey || (shouldSendOnEnter && mod))) {
-          event.preventDefault();
-          editor.commands.setHardBreak();
-          return true;
-        }
         if (isEnter && shouldSendOnEnter && !event.shiftKey && !mod) {
           event.preventDefault();
           triggerSubmitRef.current();

--- a/frontend/src/components/ai/AIChatInput.tsx
+++ b/frontend/src/components/ai/AIChatInput.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useImperativeHandle, useMemo, useRef, forwardRef, type MutableRefObject } from "react";
 import { EditorContent, useEditor, type Editor } from "@tiptap/react";
 import Document from "@tiptap/extension-document";
+import HardBreak from "@tiptap/extension-hard-break";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
@@ -77,6 +78,7 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
   const editor = useEditor({
     extensions: [
       Document,
+      HardBreak,
       Paragraph,
       Text,
       Placeholder.configure({ placeholder: placeholder || "" }),
@@ -125,6 +127,11 @@ const AIChatInputComponent = forwardRef<AIChatInputHandle, AIChatInputProps>(fun
         const suggestionActive = mentionActiveRef.current || snippetSuggestionActiveRef.current;
         if (isEnter && suggestionActive) {
           return false;
+        }
+        if (isEnter && (event.shiftKey || (shouldSendOnEnter && mod))) {
+          event.preventDefault();
+          editor.commands.setHardBreak();
+          return true;
         }
         if (isEnter && shouldSendOnEnter && !event.shiftKey && !mod) {
           event.preventDefault();

--- a/frontend/src/components/ai/input/content.ts
+++ b/frontend/src/components/ai/input/content.ts
@@ -28,6 +28,8 @@ export function extractContentXml(doc: ProseMirrorLikeNode): string {
   doc.descendants((node) => {
     if (node.type.name === "text") {
       out += escapeXmlText(node.text ?? "");
+    } else if (node.type.name === "hardBreak") {
+      out += "\n";
     } else if (node.type.name === "mention") {
       const id = Number(node.attrs.id);
       const label = String(node.attrs.label ?? "");


### PR DESCRIPTION
## 变更说明

- 为 AI 助手输入框启用 TipTap HardBreak，支持快捷键插入软换行。
- 在 Enter 发送模式下，`Shift+Enter` 和 `Ctrl/Meta+Enter` 插入换行，不触发发送。
- 提交内容序列化时保留 hardBreak 对应的换行，避免发送给 AI 时丢失多行格式。
- 增加 AIChatInput 回归测试覆盖 `Shift+Enter` 与 `Ctrl+Enter`。

## 验证

- `pnpm exec vitest run src/__tests__/AIChatInput.test.tsx`
- `pnpm lint`
- `pnpm build`

Closes #108