### PR TITLE
✨ 顶部增加 VSCode 风搜索/命令面板与资产、AI 面板折叠按钮

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@iconify/react": "^6.0.2",
     "@monaco-editor/react": "^4.7.0",
     "@opskat/ui": "workspace:*",
+    "@tabler/icons-react": "^3.44.0",
     "@tailwindcss/typography": "0.5.0-alpha.3",
     "@tanstack/react-virtual": "^3.13.23",
     "@tiptap/core": "^2.27.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@opskat/ui':
         specifier: workspace:*
         version: link:packages/ui
+      '@tabler/icons-react':
+        specifier: ^3.44.0
+        version: 3.44.0(react@19.2.4)
       '@tailwindcss/typography':
         specifier: 0.5.0-alpha.3
         version: 0.5.0-alpha.3(tailwindcss@4.2.2)
@@ -1519,6 +1522,14 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tabler/icons-react@3.44.0':
+    resolution: {integrity: sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==}
+    peerDependencies:
+      react: '>= 16'
+
+  '@tabler/icons@3.44.0':
+    resolution: {integrity: sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==}
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -4408,6 +4419,13 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tabler/icons-react@3.44.0(react@19.2.4)':
+    dependencies:
+      '@tabler/icons': 3.44.0
+      react: 19.2.4
+
+  '@tabler/icons@3.44.0': {}
 
   '@tailwindcss/node@4.2.2':
     dependencies:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import { AssetTree } from "@/components/layout/AssetTree";
 import { MainPanel } from "@/components/layout/MainPanel";
 import { SideAssistantPanel } from "@/components/ai/SideAssistantPanel";
 import { WindowControls } from "@/components/layout/WindowControls";
+import { TopBar } from "@/components/layout/TopBar";
+import { CommandPaletteDialog } from "@/components/command/CommandPaletteDialog";
 import { EdgeRevealStrip } from "@/components/layout/EdgeRevealStrip";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { LeftPanel } from "@/components/layout/LeftPanel";
@@ -350,125 +352,145 @@ function App() {
   const activeTab = useTabStore((s) => s.tabs.find((t) => t.id === s.activeTabId));
   const activePage = activeTab?.type === "page" ? activeTab.id : "home";
 
+  // 顶部「隐藏资产列表」按钮：根据 tab 布局适配不同的可见状态
+  const assetTreeIsCollapsed = tabBarLayout === "left" ? !leftPanelVisible : assetTreeCollapsed;
+  const handleToggleAssetTree = useCallback(() => {
+    if (tabBarLayout === "left") {
+      useLayoutStore.getState().toggleVisible();
+    } else {
+      toggleSidebar();
+    }
+  }, [tabBarLayout, toggleSidebar]);
+
   return (
     <ThemeProvider defaultTheme="system">
       <ErrorBoundary>
         <TooltipProvider>
-          <div className="flex h-screen w-screen overflow-hidden bg-background">
+          <div className="flex h-screen w-screen flex-col overflow-hidden bg-background">
+            {!sidebarHidden && (
+              <TopBar
+                commandOpen={commandOpen}
+                onCommandOpenChange={setCommandOpen}
+                onConnectAsset={handleConnectAsset}
+                assetTreeCollapsed={assetTreeIsCollapsed}
+                onToggleAssetTree={handleToggleAssetTree}
+                aiPanelCollapsed={aiPanelCollapsed}
+                onToggleAIPanel={toggleAIPanel}
+              />
+            )}
+            {sidebarHidden && (
+              <CommandPaletteDialog
+                open={commandOpen}
+                onOpenChange={setCommandOpen}
+                onConnectAsset={handleConnectAsset}
+              />
+            )}
             <WindowControls />
-            {tabBarLayout === "left" ? (
-              <>
-                {sidebarHidden && <EdgeRevealStrip onClick={toggleSidebarHidden} />}
-                {!sidebarHidden && (
-                  <Sidebar
-                    activePage={activePage}
-                    onPageChange={handlePageChange}
-                    sidebarCollapsed={false}
-                    onToggleSidebar={() => useLayoutStore.getState().toggleVisible()}
-                    onHideSidebar={toggleSidebarHidden}
-                    aiPanelCollapsed={aiPanelCollapsed}
-                    onToggleAIPanel={toggleAIPanel}
-                  />
-                )}
-                {leftPanelVisible && (
-                  <LeftPanel>
-                    {activeSidePanel === "assets" ? (
-                      <AssetTree
-                        collapsed={false}
-                        sidebarHidden={sidebarHidden}
-                        onShowSidebar={toggleSidebarHidden}
-                        onAddAsset={handleAddAsset}
-                        onAddGroup={() => {
-                          setEditingGroup(null);
-                          setGroupDialogOpen(true);
-                        }}
-                        onEditGroup={(group) => {
-                          setEditingGroup(group);
-                          setGroupDialogOpen(true);
-                        }}
-                        onGroupDetail={(group) => {
-                          selectGroup(group.ID);
-                          selectAsset(null);
-                          handleOpenInfoTab("group", group.ID, group.Name, group.Icon || undefined);
-                        }}
-                        onEditAsset={handleEditAsset}
-                        onCopyAsset={handleCopyAsset}
-                        onConnectAsset={handleConnectAsset}
-                        onConnectAssetInNewTab={handleConnectAssetInNewTab}
-                        onOpenFileManager={handleOpenFileManager}
-                        onSelectAsset={handleSelectAsset}
-                        onOpenInfoTab={handleOpenInfoTab}
-                      />
-                    ) : (
-                      <SideTabList />
-                    )}
-                  </LeftPanel>
-                )}
-              </>
-            ) : (
-              <>
-                {sidebarHidden && <EdgeRevealStrip onClick={toggleSidebarHidden} />}
-                {!sidebarHidden && (
-                  <Sidebar
-                    activePage={activePage}
-                    onPageChange={handlePageChange}
-                    sidebarCollapsed={assetTreeCollapsed}
-                    onToggleSidebar={toggleSidebar}
-                    onHideSidebar={toggleSidebarHidden}
-                    aiPanelCollapsed={aiPanelCollapsed}
-                    onToggleAIPanel={toggleAIPanel}
-                  />
-                )}
-                <div
-                  className="relative overflow-hidden shrink-0 transition-[width] duration-200"
-                  style={{ width: assetTreeCollapsed ? 0 : assetTreeWidth }}
-                >
-                  <AssetTree
-                    collapsed={false}
-                    sidebarHidden={sidebarHidden}
-                    onShowSidebar={toggleSidebarHidden}
-                    onAddAsset={handleAddAsset}
-                    onAddGroup={() => {
-                      setEditingGroup(null);
-                      setGroupDialogOpen(true);
-                    }}
-                    onEditGroup={(group) => {
-                      setEditingGroup(group);
-                      setGroupDialogOpen(true);
-                    }}
-                    onGroupDetail={(group) => {
-                      selectGroup(group.ID);
-                      selectAsset(null);
-                      handleOpenInfoTab("group", group.ID, group.Name, group.Icon || undefined);
-                    }}
-                    onEditAsset={handleEditAsset}
-                    onCopyAsset={handleCopyAsset}
-                    onConnectAsset={handleConnectAsset}
-                    onConnectAssetInNewTab={handleConnectAssetInNewTab}
-                    onOpenFileManager={handleOpenFileManager}
-                    onSelectAsset={handleSelectAsset}
-                    onOpenInfoTab={handleOpenInfoTab}
-                  />
-                  {/* Resize handle */}
-                  {!assetTreeCollapsed && (
-                    <div
-                      className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize z-10 hover:bg-primary/20 active:bg-primary/30 transition-colors"
-                      onMouseDown={handleAssetTreeResizeStart}
+            <div className="flex flex-1 min-h-0 overflow-hidden">
+              {tabBarLayout === "left" ? (
+                <>
+                  {sidebarHidden && <EdgeRevealStrip onClick={toggleSidebarHidden} />}
+                  {!sidebarHidden && (
+                    <Sidebar
+                      activePage={activePage}
+                      onPageChange={handlePageChange}
+                      onHideSidebar={toggleSidebarHidden}
                     />
                   )}
-                </div>
-                {assetTreeResizing && <div className="fixed inset-0 z-50 cursor-col-resize" />}
-              </>
-            )}
-            <MainPanel
-              onEditAsset={handleEditAsset}
-              onDeleteAsset={handleDeleteAsset}
-              onConnectAsset={handleConnectAsset}
-              commandOpen={commandOpen}
-              setCommandOpen={setCommandOpen}
-            />
-            <SideAssistantPanel collapsed={aiPanelCollapsed} onToggle={toggleAIPanel} />
-            {aiPanelCollapsed && <EdgeRevealStrip side="right" onClick={toggleAIPanel} />}
+                  {leftPanelVisible && (
+                    <LeftPanel>
+                      {activeSidePanel === "assets" ? (
+                        <AssetTree
+                          collapsed={false}
+                          sidebarHidden={sidebarHidden}
+                          onShowSidebar={toggleSidebarHidden}
+                          onAddAsset={handleAddAsset}
+                          onAddGroup={() => {
+                            setEditingGroup(null);
+                            setGroupDialogOpen(true);
+                          }}
+                          onEditGroup={(group) => {
+                            setEditingGroup(group);
+                            setGroupDialogOpen(true);
+                          }}
+                          onGroupDetail={(group) => {
+                            selectGroup(group.ID);
+                            selectAsset(null);
+                            handleOpenInfoTab("group", group.ID, group.Name, group.Icon || undefined);
+                          }}
+                          onEditAsset={handleEditAsset}
+                          onCopyAsset={handleCopyAsset}
+                          onConnectAsset={handleConnectAsset}
+                          onConnectAssetInNewTab={handleConnectAssetInNewTab}
+                          onOpenFileManager={handleOpenFileManager}
+                          onSelectAsset={handleSelectAsset}
+                          onOpenInfoTab={handleOpenInfoTab}
+                        />
+                      ) : (
+                        <SideTabList />
+                      )}
+                    </LeftPanel>
+                  )}
+                </>
+              ) : (
+                <>
+                  {sidebarHidden && <EdgeRevealStrip onClick={toggleSidebarHidden} />}
+                  {!sidebarHidden && (
+                    <Sidebar
+                      activePage={activePage}
+                      onPageChange={handlePageChange}
+                      onHideSidebar={toggleSidebarHidden}
+                    />
+                  )}
+                  <div
+                    className="relative overflow-hidden shrink-0 transition-[width] duration-200"
+                    style={{ width: assetTreeCollapsed ? 0 : assetTreeWidth }}
+                  >
+                    <AssetTree
+                      collapsed={false}
+                      sidebarHidden={sidebarHidden}
+                      onShowSidebar={toggleSidebarHidden}
+                      onAddAsset={handleAddAsset}
+                      onAddGroup={() => {
+                        setEditingGroup(null);
+                        setGroupDialogOpen(true);
+                      }}
+                      onEditGroup={(group) => {
+                        setEditingGroup(group);
+                        setGroupDialogOpen(true);
+                      }}
+                      onGroupDetail={(group) => {
+                        selectGroup(group.ID);
+                        selectAsset(null);
+                        handleOpenInfoTab("group", group.ID, group.Name, group.Icon || undefined);
+                      }}
+                      onEditAsset={handleEditAsset}
+                      onCopyAsset={handleCopyAsset}
+                      onConnectAsset={handleConnectAsset}
+                      onConnectAssetInNewTab={handleConnectAssetInNewTab}
+                      onOpenFileManager={handleOpenFileManager}
+                      onSelectAsset={handleSelectAsset}
+                      onOpenInfoTab={handleOpenInfoTab}
+                    />
+                    {/* Resize handle */}
+                    {!assetTreeCollapsed && (
+                      <div
+                        className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize z-10 hover:bg-primary/20 active:bg-primary/30 transition-colors"
+                        onMouseDown={handleAssetTreeResizeStart}
+                      />
+                    )}
+                  </div>
+                  {assetTreeResizing && <div className="fixed inset-0 z-50 cursor-col-resize" />}
+                </>
+              )}
+              <MainPanel
+                onEditAsset={handleEditAsset}
+                onDeleteAsset={handleDeleteAsset}
+                onConnectAsset={handleConnectAsset}
+              />
+              <SideAssistantPanel collapsed={aiPanelCollapsed} onToggle={toggleAIPanel} />
+              {aiPanelCollapsed && <EdgeRevealStrip side="right" onClick={toggleAIPanel} />}
+            </div>
           </div>
 
           <AssetForm

--- a/frontend/src/__tests__/commandPalette.test.tsx
+++ b/frontend/src/__tests__/commandPalette.test.tsx
@@ -62,10 +62,10 @@ function makeAITab(id: string, label: string) {
 }
 
 const onConnectAsset = vi.fn();
-const onOpenChange = vi.fn();
+const onClose = vi.fn();
 
 function renderPalette(open: boolean) {
-  return render(<CommandPalette open={open} onOpenChange={onOpenChange} onConnectAsset={onConnectAsset} />);
+  return render(<CommandPalette open={open} onClose={onClose} onConnectAsset={onConnectAsset} />);
 }
 
 // ──────────────────────────────────────────────
@@ -147,7 +147,7 @@ describe("CommandPalette", () => {
     expect(screen.queryByText("commandPalette.section.assets")).toBeNull();
   });
 
-  // 4. ↓ then Enter on an opened tab → calls activateTab and onOpenChange(false)
+  // 4. ↓ then Enter on an opened tab → calls activateTab and onClose(false)
   it("keyboard: down arrow + enter on opened tab calls activateTab and closes palette", () => {
     const tab1 = makeTerminalTab("tab-1", "Server A", 1);
     const tab2 = makeTerminalTab("tab-2", "Server B", 2);
@@ -161,7 +161,7 @@ describe("CommandPalette", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(useTabStore.getState().activeTabId).toBe("tab-1");
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onClose).toHaveBeenCalled();
   });
 
   it("keyboard: down arrow moves selection and enter activates second tab", () => {
@@ -178,10 +178,10 @@ describe("CommandPalette", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(useTabStore.getState().activeTabId).toBe("tab-2");
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onClose).toHaveBeenCalled();
   });
 
-  // 5. ↓ ↓ Enter on an asset → calls onConnectAsset (for canConnect asset) and onOpenChange(false)
+  // 5. ↓ ↓ Enter on an asset → calls onConnectAsset (for canConnect asset) and onClose(false)
   it("keyboard: enter on an asset row calls openAssetDefault", () => {
     const spy = vi.spyOn(openAssetDefaultModule, "openAssetDefault");
 
@@ -198,20 +198,15 @@ describe("CommandPalette", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(spy).toHaveBeenCalledWith(asset1, onConnectAsset);
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onClose).toHaveBeenCalled();
   });
 
-  // 6. Escape → onOpenChange(false)
-  // Note: Radix Dialog handles Escape natively; we verify the onOpenChange prop is wired
-  // by testing that the dialog responds to `open=false` transition.
-  it("onOpenChange is called when dialog wants to close", () => {
+  // 6. Escape key inside the input → calls onClose
+  it("escape key calls onClose", () => {
     renderPalette(true);
-    // The dialog is open; Radix would call onOpenChange(false) on Escape.
-    // We verify the prop is wired by checking the component renders and accepts the prop.
-    expect(screen.getByRole("textbox")).toBeDefined();
-    // Simulate programmatic close
-    onOpenChange(false);
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    const input = screen.getByRole("textbox");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
   });
 
   // 7. IME composing: keydown with isComposing=true does NOT move activeIndex
@@ -232,7 +227,7 @@ describe("CommandPalette", () => {
 
     // activeTabId should remain null (no tab was activated)
     expect(useTabStore.getState().activeTabId).toBeNull();
-    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   // 8. activeIndex clamps at boundaries (no wrap)

--- a/frontend/src/components/command/CommandPalette.tsx
+++ b/frontend/src/components/command/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Server, MessageSquare } from "lucide-react";
-import { Dialog, DialogContent, DialogTitle, Input, ScrollArea, cn } from "@opskat/ui";
+import { Input, ScrollArea, cn } from "@opskat/ui";
 import { getIconComponent, getIconColor } from "@/components/asset/IconPicker";
 import { filterAssets } from "@/lib/assetSearch";
 import { highlightMatch, type HighlightSegment } from "@/lib/highlightMatch";
@@ -17,7 +17,7 @@ import type { asset_entity } from "../../../wailsjs/go/models";
 
 export interface CommandPaletteProps {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  onClose: () => void;
   onConnectAsset: (asset: asset_entity.Asset) => void;
 }
 
@@ -112,10 +112,10 @@ function HighlightedText({ segments }: { segments: HighlightSegment[] }) {
 }
 
 // ──────────────────────────────────────────────
-// Main component
+// Main component — popover body (no wrapper)
 // ──────────────────────────────────────────────
 
-export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPaletteProps) {
+export function CommandPalette({ open, onClose, onConnectAsset }: CommandPaletteProps) {
   const { t } = useTranslation();
 
   // Store subscriptions
@@ -127,13 +127,16 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
   // Local state
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  // Reset state on open
+  // Reset state on open transition (closed -> open)
   const prevOpen = useRef(false);
   useEffect(() => {
     if (open && !prevOpen.current) {
       setQuery("");
       setActiveIndex(0);
+      // Focus on next tick to win against Radix focus management
+      requestAnimationFrame(() => inputRef.current?.focus());
     }
     prevOpen.current = open;
   }, [open]);
@@ -151,29 +154,14 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
     const assetById = new Map(assets.map((a) => [a.ID, a]));
 
     if (!query.trim()) {
-      // ── Empty query ──────────────────────────
-      // Section 1: all open tabs
-      const openedRows: TabRow[] = tabs.map((tab) => ({
-        kind: "tab",
-        id: `tab-${tab.id}`,
-        tab,
-      }));
-
-      // Collect assetIds already in section 1
+      const openedRows: TabRow[] = tabs.map((tab) => ({ kind: "tab", id: `tab-${tab.id}`, tab }));
       const openedAssetIds = new Set(tabs.map(tabAssetId).filter((id): id is number => id !== null));
-
-      // Section 2: recent assets (not already in opened, still in store, take first 5)
       const recentRows: AssetRow[] = recentIds
         .filter((id) => !openedAssetIds.has(id) && assetById.has(id))
         .slice(0, 5)
         .map((id) => {
           const asset = assetById.get(id)!;
-          return {
-            kind: "asset",
-            id: `asset-recent-${id}`,
-            asset,
-            groupPath: "",
-          };
+          return { kind: "asset", id: `asset-recent-${id}`, asset, groupPath: "" };
         });
 
       const result: Section[] = [];
@@ -186,10 +174,8 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
       return result;
     }
 
-    // ── Non-empty query ──────────────────────
     const lowerQuery = query.toLowerCase();
 
-    // Section 1: opened tabs matching query
     const matchedTabs = tabs.filter((tab) => {
       if (tab.label.toLowerCase().includes(lowerQuery)) return true;
       const assetId = tabAssetId(tab);
@@ -200,25 +186,13 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
       return false;
     });
 
-    const openedRows: TabRow[] = matchedTabs.map((tab) => ({
-      kind: "tab",
-      id: `tab-${tab.id}`,
-      tab,
-    }));
-
-    // Collect assetIds already in section 1
+    const openedRows: TabRow[] = matchedTabs.map((tab) => ({ kind: "tab", id: `tab-${tab.id}`, tab }));
     const openedAssetIds = new Set(matchedTabs.map(tabAssetId).filter((id): id is number => id !== null));
 
-    // Section 2: filtered assets (deduped against opened)
     const filtered = filterAssets(assets, groups, { query, limit: 50 });
     const assetRows: AssetRow[] = filtered
       .filter(({ asset }) => !openedAssetIds.has(asset.ID))
-      .map(({ asset, groupPath }) => ({
-        kind: "asset",
-        id: `asset-${asset.ID}`,
-        asset,
-        groupPath,
-      }));
+      .map(({ asset, groupPath }) => ({ kind: "asset", id: `asset-${asset.ID}`, asset, groupPath }));
 
     const result: Section[] = [];
     if (openedRows.length > 0) {
@@ -230,7 +204,6 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
     return result;
   }, [query, tabs, assets, groups, recentIds, t]);
 
-  // Flat list for keyboard navigation
   const flatRows = useMemo(() => sections.flatMap((s) => s.rows), [sections]);
 
   // ────────────────────────────────────────────
@@ -258,7 +231,11 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
       activateRow(row);
       return;
     }
-    // Escape is handled by Radix Dialog, we don't need to duplicate it
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
   };
 
   const activateRow = (row: Row) => {
@@ -267,7 +244,7 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
     } else {
       openAssetDefault(row.asset, onConnectAsset);
     }
-    onOpenChange(false);
+    onClose();
   };
 
   // ────────────────────────────────────────────
@@ -312,86 +289,47 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
     flatRows.length === 0 ? (query.trim() ? "commandPalette.empty.noMatch" : "commandPalette.empty.noContent") : null;
 
   // ────────────────────────────────────────────
-  // Render
+  // Render — flat body, meant to live inside a popover
   // ────────────────────────────────────────────
 
-  // Track row index across sections
+  if (!open) return null;
+
   let rowIndex = 0;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="max-w-2xl p-0 gap-0 top-[12%] translate-y-0 data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2"
-        showCloseButton={false}
-      >
-        <DialogTitle className="sr-only">{t("commandPalette.placeholder")}</DialogTitle>
+    <div className="flex flex-col" role="dialog" aria-label={t("commandPalette.placeholder")}>
+      {/* Search input */}
+      <div className="flex items-center border-b px-3">
+        <Input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={t("commandPalette.placeholder")}
+          className="border-0 shadow-none focus-visible:ring-0 rounded-none h-11 text-sm px-0"
+        />
+      </div>
 
-        {/* Search input */}
-        <div className="flex items-center border-b px-3">
-          <Input
-            autoFocus
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={t("commandPalette.placeholder")}
-            className="border-0 shadow-none focus-visible:ring-0 rounded-none h-12 text-sm px-0"
-          />
-        </div>
+      {/* Results list */}
+      <ScrollArea className="max-h-96">
+        <div ref={listRef} className="py-1">
+          {emptyKey ? (
+            <p className="px-4 py-8 text-center text-sm text-muted-foreground">{t(emptyKey)}</p>
+          ) : (
+            <div role="listbox" aria-label={t("commandPalette.placeholder")}>
+              {sections.map((section) => (
+                <div key={section.label}>
+                  <p className="px-3 py-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {section.label}
+                  </p>
+                  {section.rows.map((row) => {
+                    const idx = rowIndex++;
+                    const isActive = idx === activeIndex;
 
-        {/* Results list */}
-        <ScrollArea className="max-h-96">
-          <div ref={listRef} className="py-1">
-            {emptyKey ? (
-              <p className="px-4 py-8 text-center text-sm text-muted-foreground">{t(emptyKey)}</p>
-            ) : (
-              <div role="listbox" aria-label={t("commandPalette.placeholder")}>
-                {sections.map((section) => (
-                  <div key={section.label}>
-                    <p className="px-3 py-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      {section.label}
-                    </p>
-                    {section.rows.map((row) => {
-                      const idx = rowIndex++;
-                      const isActive = idx === activeIndex;
-
-                      if (row.kind === "tab") {
-                        const { tab } = row;
-                        const key = badgeKey(tab);
-                        const segments = highlightMatch(tab.label, query);
-                        return (
-                          <button
-                            key={row.id}
-                            type="button"
-                            role="option"
-                            data-active-index={idx}
-                            aria-selected={isActive}
-                            className={cn(
-                              "flex w-full items-center gap-2.5 px-3 py-2 cursor-pointer select-none rounded-sm mx-1 text-left",
-                              isActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
-                            )}
-                            onClick={() => activateRow(row)}
-                            onMouseEnter={() => setActiveIndex(idx)}
-                          >
-                            {/* Green dot: open tab indicator */}
-                            <span className="h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" />
-                            {renderIcon(resolveTabIcon(tab))}
-                            <span className="flex-1 truncate text-sm">
-                              <HighlightedText segments={segments} />
-                            </span>
-                            {key && (
-                              <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-                                {t(key)}
-                              </span>
-                            )}
-                          </button>
-                        );
-                      }
-
-                      // Asset row
-                      const { asset, groupPath } = row;
-                      const assetIconMeta = resolveAssetIcon(asset);
-                      const segments = highlightMatch(asset.Name, query);
-
+                    if (row.kind === "tab") {
+                      const { tab } = row;
+                      const key = badgeKey(tab);
+                      const segments = highlightMatch(tab.label, query);
                       return (
                         <button
                           key={row.id}
@@ -406,28 +344,59 @@ export function CommandPalette({ open, onOpenChange, onConnectAsset }: CommandPa
                           onClick={() => activateRow(row)}
                           onMouseEnter={() => setActiveIndex(idx)}
                         >
-                          {renderIcon(assetIconMeta)}
-                          <span className="flex-1 min-w-0 truncate text-sm">
+                          <span className="h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" />
+                          {renderIcon(resolveTabIcon(tab))}
+                          <span className="flex-1 truncate text-sm">
                             <HighlightedText segments={segments} />
-                            {groupPath && <span className="ml-2 text-xs text-muted-foreground">{groupPath}</span>}
                           </span>
+                          {key && (
+                            <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                              {t(key)}
+                            </span>
+                          )}
                         </button>
                       );
-                    })}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        </ScrollArea>
+                    }
 
-        {/* Footer */}
-        <div className="flex items-center gap-3 border-t px-4 py-2 text-xs text-muted-foreground">
-          <span>↑↓ {t("commandPalette.footer.navigate")}</span>
-          <span>↵ {t("commandPalette.footer.open")}</span>
-          <span>Esc {t("commandPalette.footer.close")}</span>
+                    const { asset, groupPath } = row;
+                    const assetIconMeta = resolveAssetIcon(asset);
+                    const segments = highlightMatch(asset.Name, query);
+
+                    return (
+                      <button
+                        key={row.id}
+                        type="button"
+                        role="option"
+                        data-active-index={idx}
+                        aria-selected={isActive}
+                        className={cn(
+                          "flex w-full items-center gap-2.5 px-3 py-2 cursor-pointer select-none rounded-sm mx-1 text-left",
+                          isActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+                        )}
+                        onClick={() => activateRow(row)}
+                        onMouseEnter={() => setActiveIndex(idx)}
+                      >
+                        {renderIcon(assetIconMeta)}
+                        <span className="flex-1 min-w-0 truncate text-sm">
+                          <HighlightedText segments={segments} />
+                          {groupPath && <span className="ml-2 text-xs text-muted-foreground">{groupPath}</span>}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
-      </DialogContent>
-    </Dialog>
+      </ScrollArea>
+
+      {/* Footer */}
+      <div className="flex items-center gap-3 border-t px-4 py-2 text-xs text-muted-foreground">
+        <span>↑↓ {t("commandPalette.footer.navigate")}</span>
+        <span>↵ {t("commandPalette.footer.open")}</span>
+        <span>Esc {t("commandPalette.footer.close")}</span>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/command/CommandPaletteDialog.tsx
+++ b/frontend/src/components/command/CommandPaletteDialog.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogTitle } from "@opskat/ui";
+import { CommandPalette } from "./CommandPalette";
+import type { asset_entity } from "../../../wailsjs/go/models";
+
+interface CommandPaletteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConnectAsset: (asset: asset_entity.Asset) => void;
+}
+
+/**
+ * 居中的 CommandPalette 弹层 —— 当顶栏被隐藏时作为 Cmd+P 的回退入口。
+ */
+export function CommandPaletteDialog({ open, onOpenChange, onConnectAsset }: CommandPaletteDialogProps) {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-2xl p-0 gap-0 top-[12%] translate-y-0 data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">{t("commandPalette.placeholder")}</DialogTitle>
+        <CommandPalette open={open} onClose={() => onOpenChange(false)} onConnectAsset={onConnectAsset} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/layout/AssetTree.tsx
+++ b/frontend/src/components/layout/AssetTree.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useFullscreen } from "@/hooks/useFullscreen";
 import {
   ChevronRight,
   ChevronDown,
@@ -120,7 +119,6 @@ export function AssetTree({
   onOpenInfoTab,
 }: AssetTreeProps) {
   const { t } = useTranslation();
-  const isFullscreen = useFullscreen();
   const { assets, groups, selectedAssetId, fetchAssets, fetchGroups, deleteAsset, deleteGroup, refresh } =
     useAssetStore();
   const connectingAssetIds = useTerminalStore((s) => s.connectingAssetIds);
@@ -316,12 +314,7 @@ export function AssetTree({
 
   return (
     <div className="flex h-full w-full flex-col border-r border-panel-divider bg-sidebar">
-      {/* Drag region for frameless window */}
-      <div
-        className={`${isFullscreen ? "h-0" : "h-8"} w-full shrink-0`}
-        style={{ "--wails-draggable": "drag" } as React.CSSProperties}
-      />
-      <div className="flex flex-col gap-1.5 px-3 pb-2 border-b border-panel-divider">
+      <div className="flex flex-col gap-1.5 px-3 pt-2 pb-2 border-b border-panel-divider">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">
             {sidebarHidden && (

--- a/frontend/src/components/layout/MainPanel.tsx
+++ b/frontend/src/components/layout/MainPanel.tsx
@@ -14,7 +14,6 @@ import { asset_entity } from "../../../wailsjs/go/models";
 import { ExtensionPage } from "@/extension";
 import { TopTabBar } from "./TopTabBar";
 import { useLayoutStore } from "@/stores/layoutStore";
-import { CommandPalette } from "@/components/command/CommandPalette";
 
 const AssetDetail = lazy(() => import("@/components/asset/AssetDetail").then((m) => ({ default: m.AssetDetail })));
 const GroupDetail = lazy(() => import("@/components/asset/GroupDetail").then((m) => ({ default: m.GroupDetail })));
@@ -51,8 +50,6 @@ interface MainPanelProps {
   onEditAsset: (asset: asset_entity.Asset) => void;
   onDeleteAsset: (id: number) => void;
   onConnectAsset: (asset: asset_entity.Asset) => void;
-  commandOpen: boolean;
-  setCommandOpen: (open: boolean) => void;
 }
 
 function PanelFallback() {
@@ -67,7 +64,7 @@ function LazySurface({ children }: { children: ReactNode }) {
   return <Suspense fallback={<PanelFallback />}>{children}</Suspense>;
 }
 
-export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset, commandOpen, setCommandOpen }: MainPanelProps) {
+export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPanelProps) {
   const { t } = useTranslation();
   const isFullscreen = useFullscreen();
 
@@ -384,8 +381,6 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset, commandO
           </div>
         )}
       </div>
-
-      <CommandPalette open={commandOpen} onOpenChange={setCommandOpen} onConnectAsset={onConnectAsset} />
     </div>
   );
 }

--- a/frontend/src/components/layout/MainPanel.tsx
+++ b/frontend/src/components/layout/MainPanel.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import logoLight from "@/assets/images/logo.png";
 import logoDark from "@/assets/images/logo-dark.png";
-import { useFullscreen } from "@/hooks/useFullscreen";
 import { K8sClusterPage } from "@/components/k8s/K8sClusterPage";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useAssetStore } from "@/stores/assetStore";
@@ -66,7 +65,6 @@ function LazySurface({ children }: { children: ReactNode }) {
 
 export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPanelProps) {
   const { t } = useTranslation();
-  const isFullscreen = useFullscreen();
 
   const tabs = useTabStore((s) => s.tabs);
   const activeTabId = useTabStore((s) => s.activeTabId);
@@ -213,14 +211,6 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPa
 
   return (
     <div className="flex flex-1 flex-col min-w-0">
-      {/* When no tabs, show standalone drag region; also always shown in left layout (TopTabBar absent) */}
-      {(!hasTabs || tabBarLayout === "left") && (
-        <div
-          className={`${isFullscreen ? "h-0" : "h-8"} w-full shrink-0`}
-          style={{ "--wails-draggable": "drag" } as React.CSSProperties}
-        />
-      )}
-
       {/* Tab bar with integrated drag region (top layout only) */}
       {hasTabs && tabBarLayout === "top" && <TopTabBar />}
 

--- a/frontend/src/components/layout/SideTabList.tsx
+++ b/frontend/src/components/layout/SideTabList.tsx
@@ -4,7 +4,6 @@ import { Search, Server, Folder, MessageSquare } from "lucide-react";
 import { cn } from "@opskat/ui";
 import { useTabStore, type Tab, type InfoTabMeta } from "@/stores/tabStore";
 import { useTerminalStore } from "@/stores/terminalStore";
-import { useFullscreen } from "@/hooks/useFullscreen";
 import { getIconComponent, getIconColor } from "@/components/asset/IconPicker";
 import { filterMatches, highlightMatch } from "@/lib/highlightMatch";
 import { useLayoutStore, isCollapsed } from "@/stores/layoutStore";
@@ -15,7 +14,6 @@ import { getBuiltinPageMeta, resolveTabLabel } from "./pageTabMeta";
 
 export function SideTabList() {
   const { t } = useTranslation();
-  const isFullscreen = useFullscreen();
   const tabs = useTabStore((s) => s.tabs);
   const activeTabId = useTabStore((s) => s.activeTabId);
   const visibleTabs = tabs;
@@ -92,10 +90,6 @@ export function SideTabList() {
 
   return (
     <div data-tab-panel className="flex flex-col h-full bg-sidebar">
-      <div
-        className={`${isFullscreen ? "h-0" : "h-8"} w-full shrink-0`}
-        style={{ "--wails-draggable": "drag" } as React.CSSProperties}
-      />
       {!collapsed && (
         <div className="flex items-center gap-1 px-2 py-1.5 border-b border-panel-divider shrink-0">
           <span className="text-xs font-medium uppercase text-muted-foreground tracking-wide flex-1">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,13 +2,13 @@ import {
   Home,
   Settings,
   KeyRound,
+  EyeOff,
   ScrollText,
   ArrowRightLeft,
   Server,
   LayoutList,
   FileCode,
 } from "lucide-react";
-import { IconEyeClosed } from "@tabler/icons-react";
 import logoLight from "@/assets/images/logo.png";
 import logoDark from "@/assets/images/logo-dark.png";
 import { useTranslation } from "react-i18next";
@@ -151,7 +151,7 @@ export function Sidebar({ activePage, onPageChange, onHideSidebar }: SidebarProp
               className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors duration-150"
               onClick={onHideSidebar}
             >
-              <IconEyeClosed className="h-4 w-4" stroke={1.75} />
+              <EyeOff className="h-4 w-4" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">{t("panel.hideSidebar")}</TooltipContent>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,10 +2,7 @@ import {
   Home,
   Settings,
   KeyRound,
-  PanelLeftClose,
-  PanelLeftOpen,
   EyeOff,
-  Bot,
   ScrollText,
   ArrowRightLeft,
   Server,
@@ -17,30 +14,16 @@ import logoDark from "@/assets/images/logo-dark.png";
 import { useTranslation } from "react-i18next";
 import { cn, Tooltip, TooltipContent, TooltipTrigger } from "@opskat/ui";
 import { ModeToggle } from "@/components/mode-toggle";
-import { useFullscreen } from "@/hooks/useFullscreen";
 import { useLayoutStore, type SidePanel } from "@/stores/layoutStore";
 
 interface SidebarProps {
   activePage: string;
   onPageChange: (page: string) => void;
-  sidebarCollapsed: boolean;
-  onToggleSidebar: () => void;
   onHideSidebar: () => void;
-  aiPanelCollapsed: boolean;
-  onToggleAIPanel: () => void;
 }
 
-export function Sidebar({
-  activePage,
-  onPageChange,
-  sidebarCollapsed,
-  onToggleSidebar,
-  onHideSidebar,
-  aiPanelCollapsed,
-  onToggleAIPanel,
-}: SidebarProps) {
+export function Sidebar({ activePage, onPageChange, onHideSidebar }: SidebarProps) {
   const { t } = useTranslation();
-  const isFullscreen = useFullscreen();
 
   const tabBarLayout = useLayoutStore((s) => s.tabBarLayout);
   const activeSidePanel = useLayoutStore((s) => s.activeSidePanel);
@@ -75,14 +58,8 @@ export function Sidebar({
 
   return (
     <div className="flex h-full w-14 flex-col items-center border-r border-panel-divider bg-sidebar/80 backdrop-blur-sm">
-      {/* Drag region for Wails window */}
-      <div
-        className={`${isFullscreen ? "h-0" : "h-8"} w-full shrink-0`}
-        style={{ "--wails-draggable": "drag" } as React.CSSProperties}
-      />
-
       {/* App logo */}
-      <div className="mb-3 flex h-9 w-9 items-center justify-center">
+      <div className="mt-2 mb-3 flex h-9 w-9 items-center justify-center">
         <img src={logoLight} alt="opskat" className="h-8 w-8 rounded-lg dark:hidden" />
         <img src={logoDark} alt="opskat" className="h-8 w-8 rounded-lg hidden dark:block" />
       </div>
@@ -154,22 +131,6 @@ export function Sidebar({
             <button
               className={cn(
                 "relative flex h-9 w-9 items-center justify-center rounded-lg transition-colors duration-150",
-                !aiPanelCollapsed
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-              )}
-              onClick={onToggleAIPanel}
-            >
-              <Bot className="h-4 w-4" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">{t("nav.ai")}</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              className={cn(
-                "relative flex h-9 w-9 items-center justify-center rounded-lg transition-colors duration-150",
                 activePage === "settings"
                   ? "bg-accent text-accent-foreground"
                   : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
@@ -183,17 +144,6 @@ export function Sidebar({
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">{t("nav.settings")}</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors duration-150"
-              onClick={onToggleSidebar}
-            >
-              {sidebarCollapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">{t("panel.toggleSidebar")}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,13 +2,13 @@ import {
   Home,
   Settings,
   KeyRound,
-  EyeOff,
   ScrollText,
   ArrowRightLeft,
   Server,
   LayoutList,
   FileCode,
 } from "lucide-react";
+import { IconEyeClosed } from "@tabler/icons-react";
 import logoLight from "@/assets/images/logo.png";
 import logoDark from "@/assets/images/logo-dark.png";
 import { useTranslation } from "react-i18next";
@@ -151,7 +151,7 @@ export function Sidebar({ activePage, onPageChange, onHideSidebar }: SidebarProp
               className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors duration-150"
               onClick={onHideSidebar}
             >
-              <EyeOff className="h-4 w-4" />
+              <IconEyeClosed className="h-4 w-4" stroke={1.75} />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">{t("panel.hideSidebar")}</TooltipContent>

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Search } from "lucide-react";
-import { Icon } from "@iconify/react";
+import {
+  IconLayoutSidebar,
+  IconLayoutSidebarFilled,
+  IconLayoutSidebarRight,
+  IconLayoutSidebarRightFilled,
+} from "@tabler/icons-react";
 import { Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipTrigger, cn } from "@opskat/ui";
 import { CommandPalette } from "@/components/command/CommandPalette";
 import { useFullscreen } from "@/hooks/useFullscreen";
@@ -112,10 +117,11 @@ export function TopBar({
                   assetTreeCollapsed ? "text-muted-foreground hover:text-foreground" : "text-foreground"
                 )}
               >
-                <Icon
-                  icon={assetTreeCollapsed ? "ph:panel-left" : "ph:panel-left-fill"}
-                  className="h-4 w-4"
-                />
+                {assetTreeCollapsed ? (
+                  <IconLayoutSidebar className="h-4 w-4" stroke={1.75} />
+                ) : (
+                  <IconLayoutSidebarFilled className="h-4 w-4" />
+                )}
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -135,10 +141,11 @@ export function TopBar({
                   aiPanelCollapsed ? "text-muted-foreground hover:text-foreground" : "text-foreground"
                 )}
               >
-                <Icon
-                  icon={aiPanelCollapsed ? "ph:panel-right" : "ph:panel-right-fill"}
-                  className="h-4 w-4"
-                />
+                {aiPanelCollapsed ? (
+                  <IconLayoutSidebarRight className="h-4 w-4" stroke={1.75} />
+                ) : (
+                  <IconLayoutSidebarRightFilled className="h-4 w-4" />
+                )}
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Search, PanelLeft, PanelLeftDashed, PanelRight, PanelRightDashed } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipTrigger, cn } from "@opskat/ui";
+import { CommandPalette } from "@/components/command/CommandPalette";
+import { useFullscreen } from "@/hooks/useFullscreen";
+import { Environment } from "../../../wailsjs/runtime/runtime";
+import type { asset_entity } from "../../../wailsjs/go/models";
+
+interface TopBarProps {
+  commandOpen: boolean;
+  onCommandOpenChange: (open: boolean) => void;
+  onConnectAsset: (asset: asset_entity.Asset) => void;
+  assetTreeCollapsed: boolean;
+  onToggleAssetTree: () => void;
+  aiPanelCollapsed: boolean;
+  onToggleAIPanel: () => void;
+}
+
+export function TopBar({
+  commandOpen,
+  onCommandOpenChange,
+  onConnectAsset,
+  assetTreeCollapsed,
+  onToggleAssetTree,
+  aiPanelCollapsed,
+  onToggleAIPanel,
+}: TopBarProps) {
+  const { t } = useTranslation();
+  const isFullscreen = useFullscreen();
+
+  const [platform, setPlatform] = useState<"darwin" | "windows" | "other">("other");
+  useEffect(() => {
+    Environment()
+      .then((env) => {
+        if (env.platform === "darwin") setPlatform("darwin");
+        else if (env.platform === "windows") setPlatform("windows");
+        else setPlatform("other");
+      })
+      .catch(() => {});
+  }, []);
+
+  // macOS 红绿灯位（非全屏时预留 80px）；Windows 把 WindowControls 区域让出来
+  const leftReserve = platform === "darwin" && !isFullscreen ? "pl-20" : "pl-2";
+  const rightReserve = platform === "windows" ? "pr-[140px]" : "pr-2";
+
+  return (
+    <div
+      className={cn(
+        "flex h-10 w-full shrink-0 items-center gap-2 border-b border-panel-divider bg-background",
+        leftReserve,
+        rightReserve
+      )}
+      style={{ "--wails-draggable": "drag" } as React.CSSProperties}
+    >
+      {/* 左侧占位，让中间搜索框居中 */}
+      <div className="flex-1" />
+
+      {/* 中间：搜索/命令框（按钮形态，点击打开 Popover） */}
+      <div
+        className="flex w-full max-w-md justify-center"
+        style={{ "--wails-draggable": "no-drag" } as React.CSSProperties}
+      >
+        <Popover open={commandOpen} onOpenChange={onCommandOpenChange}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                "flex h-7 w-full items-center gap-2 rounded-md border border-input/50 bg-background/60 px-2.5 text-xs",
+                "text-muted-foreground transition-colors hover:bg-background hover:text-foreground",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              )}
+            >
+              <Search className="h-4 w-4 shrink-0" />
+              <span className="flex-1 truncate text-left">{t("topBar.searchPlaceholder")}</span>
+              <kbd className="hidden shrink-0 rounded bg-muted px-1 py-0.5 font-mono text-[10px] sm:inline-block">
+                {platform === "darwin" ? "⌘P" : "Ctrl+P"}
+              </kbd>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="center"
+            sideOffset={4}
+            className="w-[min(640px,90vw)] p-0"
+            onOpenAutoFocus={(e) => {
+              // 让 CommandPalette 内部的 input 自己取焦
+              e.preventDefault();
+            }}
+          >
+            <CommandPalette
+              open={commandOpen}
+              onClose={() => onCommandOpenChange(false)}
+              onConnectAsset={onConnectAsset}
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      {/* 右侧占位 + 控制按钮 */}
+      <div className="flex flex-1 items-center justify-end gap-0.5">
+        <div style={{ "--wails-draggable": "no-drag" } as React.CSSProperties} className="flex items-center gap-0.5">
+          {/* 切换资产列表：实线 = 打开，虚线 = 隐藏 */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onToggleAssetTree}
+                aria-pressed={!assetTreeCollapsed}
+                className={cn(
+                  "flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-accent/50",
+                  assetTreeCollapsed ? "text-muted-foreground hover:text-foreground" : "text-foreground"
+                )}
+              >
+                {assetTreeCollapsed ? (
+                  <PanelLeftDashed className="h-4 w-4" />
+                ) : (
+                  <PanelLeft className="h-4 w-4" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {assetTreeCollapsed ? t("topBar.showAssetTree") : t("topBar.hideAssetTree")}
+            </TooltipContent>
+          </Tooltip>
+
+          {/* 切换 AI 对话：实线 = 打开，虚线 = 隐藏 */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onToggleAIPanel}
+                aria-pressed={!aiPanelCollapsed}
+                className={cn(
+                  "flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-accent/50",
+                  aiPanelCollapsed ? "text-muted-foreground hover:text-foreground" : "text-foreground"
+                )}
+              >
+                {aiPanelCollapsed ? (
+                  <PanelRightDashed className="h-4 w-4" />
+                ) : (
+                  <PanelRight className="h-4 w-4" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {aiPanelCollapsed ? t("topBar.showAIPanel") : t("topBar.hideAIPanel")}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Search, PanelLeft, PanelLeftDashed, PanelRight, PanelRightDashed } from "lucide-react";
+import { Search } from "lucide-react";
+import { Icon } from "@iconify/react";
 import { Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipTrigger, cn } from "@opskat/ui";
 import { CommandPalette } from "@/components/command/CommandPalette";
 import { useFullscreen } from "@/hooks/useFullscreen";
@@ -111,11 +112,10 @@ export function TopBar({
                   assetTreeCollapsed ? "text-muted-foreground hover:text-foreground" : "text-foreground"
                 )}
               >
-                {assetTreeCollapsed ? (
-                  <PanelLeftDashed className="h-4 w-4" />
-                ) : (
-                  <PanelLeft className="h-4 w-4" />
-                )}
+                <Icon
+                  icon={assetTreeCollapsed ? "ph:panel-left" : "ph:panel-left-fill"}
+                  className="h-4 w-4"
+                />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -135,11 +135,10 @@ export function TopBar({
                   aiPanelCollapsed ? "text-muted-foreground hover:text-foreground" : "text-foreground"
                 )}
               >
-                {aiPanelCollapsed ? (
-                  <PanelRightDashed className="h-4 w-4" />
-                ) : (
-                  <PanelRight className="h-4 w-4" />
-                )}
+                <Icon
+                  icon={aiPanelCollapsed ? "ph:panel-right" : "ph:panel-right-fill"}
+                  className="h-4 w-4"
+                />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -53,7 +53,7 @@ export function TopBar({
   return (
     <div
       className={cn(
-        "flex h-10 w-full shrink-0 items-center gap-2 border-b border-panel-divider bg-background",
+        "flex h-10 w-full shrink-0 items-center gap-2 border-b border-panel-divider bg-sidebar",
         leftReserve,
         rightReserve
       )}

--- a/frontend/src/components/layout/TopTabBar.tsx
+++ b/frontend/src/components/layout/TopTabBar.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { X, MessageSquare, Server, Folder } from "lucide-react";
-import { useFullscreen } from "@/hooks/useFullscreen";
 import { useTabDragAndDrop } from "@/hooks/useTabDragAndDrop";
 import { useTabStore, type Tab, type InfoTabMeta } from "@/stores/tabStore";
 import { useTerminalStore } from "@/stores/terminalStore";
@@ -138,7 +137,6 @@ function TabItem({
 
 export function TopTabBar() {
   const { t } = useTranslation();
-  const isFullscreen = useFullscreen();
 
   const tabs = useTabStore((s) => s.tabs);
   const activeTabId = useTabStore((s) => s.activeTabId);
@@ -281,7 +279,7 @@ export function TopTabBar() {
     <TabBarContext.Provider value={tabBarCtx}>
       <div
         data-top-tabbar
-        className={`flex items-center border-b overflow-hidden bg-background ${isFullscreen ? "pt-0" : "pt-8"}`}
+        className="flex items-center border-b overflow-hidden bg-background"
         style={{ "--wails-draggable": "drag" } as React.CSSProperties}
       >
         <div className="flex items-center min-w-0 flex-1">{tabs.map((tab) => renderTabItem(tab))}</div>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -943,6 +943,13 @@
     "showSidebar": "Show Toolbar",
     "showAIPanel": "Show AI Assistant"
   },
+  "topBar": {
+    "searchPlaceholder": "Search assets or commands...",
+    "hideAssetTree": "Hide Asset Tree",
+    "showAssetTree": "Show Asset Tree",
+    "hideAIPanel": "Hide AI Chat",
+    "showAIPanel": "Show AI Chat"
+  },
   "sideTabs": {
     "title": "Open Tabs",
     "filterPlaceholder": "Filter tabs...",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -928,6 +928,13 @@
     "showSidebar": "显示工具条",
     "showAIPanel": "显示 AI 助手"
   },
+  "topBar": {
+    "searchPlaceholder": "搜索资产或命令...",
+    "hideAssetTree": "隐藏资产列表",
+    "showAssetTree": "显示资产列表",
+    "hideAIPanel": "隐藏 AI 对话",
+    "showAIPanel": "显示 AI 对话"
+  },
   "sideTabs": {
     "title": "打开的 Tabs",
     "filterPlaceholder": "过滤 tab 名称...",


### PR DESCRIPTION
## Summary

参考 VSCode，把命令面板搬到顶栏，资产列表 / AI 对话的折叠按钮也归集到顶栏右侧。

- 新增 **TopBar**：居中搜索框（点击或 `⌘P` / `Ctrl+P` 触发），右侧两个面板切换按钮，使用 Tabler `IconLayoutSidebar(Right)` 空/实图标 —— **实心 = 展开，描边 = 折叠**，贴近 VSCode 风格
- **CommandPalette** 重构为 body 组件，在 TopBar 内挂为 Popover；当隐藏工具条（Sidebar 底部 `EyeOff` 按钮）时 TopBar 一并隐藏，新增 `CommandPaletteDialog` 作为居中 Dialog 回退，`Cmd+P` 仍可触发
- Sidebar 内的资产列表折叠按钮迁移到 TopBar，避免双入口；保留底部 `EyeOff`（隐藏整个工具条）
- 顶栏底色统一为 `bg-sidebar`，与左右侧边栏视觉一致；macOS 红绿灯位预留 80px，Windows WindowControls 让出 140px
- 清理 App 顶部冗余的拖拽预留区，由 TopBar 自身承担 `--wails-draggable: drag`
- i18n 新增 `topBar.*` 5 个 key（zh-CN / en）

## Test plan
- [ ] `make dev` 打开后顶栏出现 VSCode 风搜索框
- [ ] `⌘P` / `Ctrl+P` 或点击搜索框 → 下拉打开，键盘 ↑↓ Enter Esc 都能用
- [ ] 顶栏左按钮切换资产列表，**不**会隐藏工具条；图标在 实心/描边 之间切换
- [ ] 顶栏右按钮切换 AI 对话，图标在 实心/描边 之间切换
- [ ] 点 Sidebar 底部 `EyeOff` → 工具条 + 顶栏一起隐藏，出现 EdgeRevealStrip；此时 `Cmd+P` 仍能调出居中 Dialog 形态的命令面板
- [ ] macOS 上红绿灯不被顶栏遮挡；Windows 上 WindowControls 与顶栏不重叠
- [ ] 切换主题（亮/暗）顶栏颜色跟随，且与左右侧边栏底色一致