### PR TITLE
✨ 支持 AI 助手选择资产上下文

### DIFF
--- a/frontend/src/__tests__/AIChatInput.test.tsx
+++ b/frontend/src/__tests__/AIChatInput.test.tsx
@@ -350,6 +350,41 @@ describe("AIChatInput", () => {
     expect(content).toMatch(/check <mention asset-id="42"[^>]*>@prod-db<\/mention> disk/);
   });
 
+  it("提交表 mention 时保留 database/table 上下文属性", async () => {
+    const onSubmit = vi.fn();
+    const editorRef = { current: null as Editor | null };
+    const handleRef = createRef<AIChatInputHandle>();
+    render(<AIChatInput ref={handleRef} onSubmit={onSubmit} sendOnEnter={true} editorRef={editorRef} />);
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+
+    editorRef
+      .current!.chain()
+      .focus()
+      .insertContent("explain ")
+      .insertContent({
+        type: "mention",
+        attrs: {
+          id: "42",
+          label: "app.users",
+          kind: "table",
+          database: "app",
+          table: "users",
+          driver: "mysql",
+        },
+      })
+      .run();
+
+    handleRef.current?.submit();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const [content] = onSubmit.mock.calls[0];
+    expect(content).toContain('target="table"');
+    expect(content).toContain('database="app"');
+    expect(content).toContain('table="users"');
+    expect(content).toContain('driver="mysql"');
+    expect(content).toMatch(/@app\.users<\/mention>/);
+  });
+
   it("输入 `/` 打开 snippet 弹窗并请求 prompt 分类的列表", async () => {
     vi.mocked(ListSnippets).mockResolvedValueOnce([
       {

--- a/frontend/src/__tests__/MentionList.test.tsx
+++ b/frontend/src/__tests__/MentionList.test.tsx
@@ -4,6 +4,8 @@ import { render, screen } from "@testing-library/react";
 import { createRef } from "react";
 import { MentionList, type MentionListRef, type MentionItem } from "@/components/ai/MentionList";
 import { useAssetStore } from "@/stores/assetStore";
+import { useQueryStore } from "@/stores/queryStore";
+import { useTabStore } from "@/stores/tabStore";
 
 function seed(assets: any[], groups: any[] = []) {
   useAssetStore.setState({
@@ -14,9 +16,11 @@ function seed(assets: any[], groups: any[] = []) {
 
 describe("MentionList", () => {
   beforeEach(() => {
+    useTabStore.setState({ tabs: [], activeTabId: null });
+    useQueryStore.setState({ dbStates: {}, redisStates: {}, mongoStates: {} } as any);
     seed(
       [
-        { ID: 42, Name: "prod-db", Type: "mysql", GroupID: 0 },
+        { ID: 42, Name: "prod-db", Type: "database", Icon: "mysql", GroupID: 0 },
         { ID: 43, Name: "prod-web", Type: "ssh", GroupID: 1 },
         { ID: 44, Name: "cache-1", Type: "redis", GroupID: 0 },
       ],
@@ -61,5 +65,332 @@ describe("MentionList", () => {
     ref.current?.onKeyDown({ event: { key: "ArrowDown" } as any });
     const items = screen.getAllByRole("option");
     expect(items[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("当前 tab 是数据库时，保持单列样式并按上下文、默认库、资产、表排序", () => {
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          icon: "mysql",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "app",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app", "audit"],
+          tables: { app: ["users", "orders"], audit: [] },
+          loadingTables: {},
+          expandedDbs: ["app"],
+          loadingDbs: false,
+          innerTabs: [{ id: "table:app.users", type: "table", database: "app", table: "users" }],
+          activeInnerTabId: "table:app.users",
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList query="" command={() => {}} />);
+
+    expect(screen.queryByText("ai.mentionGroupContext")).not.toBeInTheDocument();
+    const items = screen.getAllByRole("option");
+    expect(items[0]).toHaveTextContent("prod-db/app.users");
+    expect(items[1]).toHaveTextContent("prod-db/app");
+    expect(items[2]).toHaveTextContent("prod-db");
+    expect(items.at(-1)).toHaveTextContent("prod-db/app.orders");
+    expect(items.map((item) => item.textContent)).not.toContain("prod-db/audit");
+  });
+
+  it("空查询时大量表排在资产之后，避免表名挤掉资产结果", () => {
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "app",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app"],
+          tables: { app: ["users", "orders", "sessions", "events", "audit_logs", "user_profiles"] },
+          loadingTables: {},
+          expandedDbs: ["app"],
+          loadingDbs: false,
+          innerTabs: [],
+          activeInnerTabId: null,
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList query="" command={() => {}} />);
+
+    const itemTexts = screen.getAllByRole("option").map((item) => item.textContent ?? "");
+    expect(itemTexts).toHaveLength(8);
+    expect(itemTexts).toEqual(expect.arrayContaining(["prod-db", "生产/prod-web", "cache-1"]));
+    expect(itemTexts.indexOf("prod-db")).toBeLessThan(itemTexts.findIndex((text) => text.includes("app.users")));
+  });
+
+  it("键盘选择按单列排序结果移动", () => {
+    const ref = createRef<MentionListRef>();
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "app",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app"],
+          tables: { app: ["users"] },
+          loadingTables: {},
+          expandedDbs: ["app"],
+          loadingDbs: false,
+          innerTabs: [{ id: "table:app.users", type: "table", database: "app", table: "users" }],
+          activeInnerTabId: "table:app.users",
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList ref={ref} query="" command={() => {}} />);
+
+    ref.current?.onKeyDown({ event: { key: "ArrowDown" } as any });
+    const items = screen.getAllByRole("option");
+    expect(items[1]).toHaveAttribute("aria-selected", "true");
+    expect(items[1]).toHaveTextContent("prod-db/app");
+  });
+
+  it("查询表名时，表级主字段匹配优先于同名资产", () => {
+    seed([
+      { ID: 42, Name: "prod-db", Type: "database", Icon: "mysql", GroupID: 0 },
+      { ID: 45, Name: "users-api", Type: "ssh", GroupID: 0 },
+    ]);
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "app",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app"],
+          tables: { app: ["users"] },
+          loadingTables: {},
+          expandedDbs: ["app"],
+          loadingDbs: false,
+          innerTabs: [],
+          activeInnerTabId: null,
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList query="users" command={() => {}} />);
+
+    const items = screen.getAllByRole("option");
+    expect(items[0]).toHaveTextContent("prod-db/app.users");
+    expect(items[1]).toHaveTextContent("users-api");
+  });
+
+  it("查询库名时，库匹配优先于该库下的表", () => {
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "app",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app"],
+          tables: { app: ["users"] },
+          loadingTables: {},
+          expandedDbs: ["app"],
+          loadingDbs: false,
+          innerTabs: [],
+          activeInnerTabId: null,
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList query="app" command={() => {}} />);
+
+    const items = screen.getAllByRole("option");
+    expect(items[0]).toHaveTextContent("prod-db/app");
+    expect(items[1]).toHaveTextContent("prod-db/app.users");
+  });
+
+  it("查询非默认的已加载库名时，不把库列表项作为候选", () => {
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "app",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app", "audit"],
+          tables: { app: ["users"], audit: [] },
+          loadingTables: {},
+          expandedDbs: ["app", "audit"],
+          loadingDbs: false,
+          innerTabs: [],
+          activeInnerTabId: null,
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList query="audit" command={() => {}} />);
+
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    expect(screen.getByText("ai.mentionNotFound")).toBeInTheDocument();
+  });
+
+  it("选择表 mention 时返回资产 ID 和库表上下文", () => {
+    const ref = createRef<MentionListRef>();
+    const received: MentionItem[] = [];
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app"],
+          tables: { app: ["users"] },
+          loadingTables: {},
+          expandedDbs: ["app"],
+          loadingDbs: false,
+          innerTabs: [],
+          activeInnerTabId: null,
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList ref={ref} query="users" command={(item) => received.push(item)} />);
+    ref.current?.onKeyDown({ event: { key: "Enter" } as any });
+
+    expect(received[0]).toMatchObject({
+      id: 42,
+      kind: "table",
+      label: "app.users",
+      type: "database",
+      database: "app",
+      table: "users",
+      driver: "mysql",
+    });
   });
 });

--- a/frontend/src/__tests__/MentionList.test.tsx
+++ b/frontend/src/__tests__/MentionList.test.tsx
@@ -161,6 +161,53 @@ describe("MentionList", () => {
     expect(itemTexts.indexOf("prod-db")).toBeLessThan(itemTexts.findIndex((text) => text.includes("app.users")));
   });
 
+  it("空查询时打开过的表排在打开库和默认库之前", () => {
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "app",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app", "audit"],
+          tables: { app: ["users", "orders"], audit: [] },
+          loadingTables: {},
+          expandedDbs: ["app", "audit"],
+          loadingDbs: false,
+          innerTabs: [
+            { id: "table:app.users", type: "table", database: "app", table: "users" },
+            { id: "table:app.orders", type: "table", database: "app", table: "orders" },
+            { id: "sql:1", type: "sql", title: "SQL 1", selectedDb: "audit" },
+          ],
+          activeInnerTabId: "sql:1",
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList query="" command={() => {}} />);
+
+    const itemTexts = screen.getAllByRole("option").map((item) => item.textContent ?? "");
+    expect(itemTexts.slice(0, 4)).toEqual(["prod-db/app.users", "prod-db/app.orders", "prod-db/audit", "prod-db/app"]);
+  });
+
   it("键盘选择按单列排序结果移动", () => {
     const ref = createRef<MentionListRef>();
     useTabStore.setState({
@@ -299,7 +346,51 @@ describe("MentionList", () => {
     expect(items[1]).toHaveTextContent("prod-db/app.users");
   });
 
-  it("查询非默认的已加载库名时，不把库列表项作为候选", () => {
+  it("查询同时命中库名和表名时，库候选排在表候选前", () => {
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "users",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["users", "app"],
+          tables: { app: ["users"] },
+          loadingTables: {},
+          expandedDbs: ["app"],
+          loadingDbs: false,
+          innerTabs: [],
+          activeInnerTabId: null,
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList query="users" command={() => {}} />);
+
+    const items = screen.getAllByRole("option");
+    expect(items[0]).toHaveTextContent("prod-db/users");
+    expect(items[1]).toHaveTextContent("prod-db/app.users");
+  });
+
+  it("查询展开的非默认库名时显示库候选", () => {
     useTabStore.setState({
       activeTabId: "query-42",
       tabs: [
@@ -326,6 +417,50 @@ describe("MentionList", () => {
           tables: { app: ["users"], audit: [] },
           loadingTables: {},
           expandedDbs: ["app", "audit"],
+          loadingDbs: false,
+          innerTabs: [],
+          activeInnerTabId: null,
+          error: null,
+        },
+      },
+      redisStates: {},
+      mongoStates: {},
+    } as any);
+
+    render(<MentionList query="audit" command={() => {}} />);
+
+    const items = screen.getAllByRole("option");
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent("prod-db/audit");
+  });
+
+  it("查询未展开的非默认已加载库名时，不把库列表项作为候选", () => {
+    useTabStore.setState({
+      activeTabId: "query-42",
+      tabs: [
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+            defaultDatabase: "app",
+          },
+        },
+      ],
+    } as any);
+    useQueryStore.setState({
+      dbStates: {
+        "query-42": {
+          databases: ["app", "audit"],
+          tables: { app: ["users"], audit: [] },
+          loadingTables: {},
+          expandedDbs: ["app"],
           loadingDbs: false,
           innerTabs: [],
           activeInnerTabId: null,

--- a/frontend/src/__tests__/UserMessage.test.tsx
+++ b/frontend/src/__tests__/UserMessage.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import i18n from "@/i18n";
 import { UserMessage } from "@/components/ai/UserMessage";
 import { useAssetStore } from "@/stores/assetStore";
+import { useQueryStore } from "@/stores/queryStore";
 import { useTabStore } from "@/stores/tabStore";
 
 const editButtonName = /ai\.editMessage|编辑消息|Edit message/i;
@@ -15,9 +16,18 @@ describe("UserMessage", () => {
     await i18n.changeLanguage("zh-CN");
     localStorage.setItem("language", "zh-CN");
     useAssetStore.setState({
-      assets: [{ ID: 42, Name: "prod-db", Type: "mysql", Icon: "mysql" } as any],
+      assets: [
+        {
+          ID: 42,
+          Name: "prod-db",
+          Type: "database",
+          Icon: "mysql",
+          Config: JSON.stringify({ driver: "mysql", database: "app" }),
+        } as any,
+      ],
       groups: [],
     } as any);
+    useQueryStore.setState({ dbStates: {}, redisStates: {}, mongoStates: {} } as any);
     useTabStore.setState({ tabs: [], activeTabId: null } as any);
   });
 
@@ -48,6 +58,42 @@ describe("UserMessage", () => {
     render(<UserMessage msg={msg} />);
     await userEvent.click(screen.getByRole("button", { name: /prod-db/ }));
     expect(useTabStore.getState().tabs.some((t) => t.id === "info-asset-42")).toBe(true);
+  });
+
+  it("点击表 mention chip 跳转到对应数据库表 tab", async () => {
+    const msg = {
+      role: "user",
+      content:
+        '<mention asset-id="42" type="database" target="table" database="app" table="users" driver="mysql">@app.users</mention>',
+      blocks: [],
+    } as any;
+
+    render(<UserMessage msg={msg} />);
+    await userEvent.click(screen.getByRole("button", { name: /app\.users/ }));
+
+    expect(useTabStore.getState().activeTabId).toBe("query-42");
+    const dbState = useQueryStore.getState().dbStates["query-42"];
+    expect(dbState.activeInnerTabId).toBe("table:app.users");
+    expect(dbState.innerTabs).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "table", database: "app", table: "users" })])
+    );
+  });
+
+  it("点击库 mention chip 跳转到对应数据库 SQL tab 并展开库", async () => {
+    const msg = {
+      role: "user",
+      content: '<mention asset-id="42" type="database" target="database" database="app" driver="mysql">@app</mention>',
+      blocks: [],
+    } as any;
+
+    render(<UserMessage msg={msg} />);
+    await userEvent.click(screen.getByRole("button", { name: /app/ }));
+
+    expect(useTabStore.getState().activeTabId).toBe("query-42");
+    const dbState = useQueryStore.getState().dbStates["query-42"];
+    expect(dbState.expandedDbs).toContain("app");
+    const activeInnerTab = dbState.innerTabs.find((tab) => tab.id === dbState.activeInnerTabId);
+    expect(activeInnerTab).toMatchObject({ type: "sql", selectedDb: "app" });
   });
 
   it("keeps the copy button when edit is available and triggers onEdit", async () => {

--- a/frontend/src/__tests__/aiStore.mention.test.ts
+++ b/frontend/src/__tests__/aiStore.mention.test.ts
@@ -74,6 +74,41 @@ describe("aiStore mentions (XML inline)", () => {
     expect(Array.isArray(ctx.openTabs)).toBe(true);
   });
 
+  it("SendAIMessage 的 AIContext 把 query tab 映射成真实资产类型", async () => {
+    useTabStore.setState((state) => ({
+      tabs: [
+        ...state.tabs,
+        {
+          id: "query-42",
+          type: "query",
+          label: "prod-db",
+          meta: {
+            type: "query",
+            assetId: 42,
+            assetName: "prod-db",
+            assetIcon: "mysql",
+            assetType: "database",
+            driver: "mysql",
+          },
+        } as any,
+      ],
+      activeTabId: state.activeTabId,
+    }));
+
+    await useAIStore.getState().sendToTab("t1", `check ${mentionXml}`);
+
+    const [, , ctx] = vi.mocked(SendAIMessage).mock.calls[0] as any[];
+    expect(ctx.openTabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "database",
+          assetId: 42,
+          assetName: "prod-db",
+        }),
+      ])
+    );
+  });
+
   it("生成中时 sendToTab 把 content 入队并调用 QueueAIMessage(convId, queueId, content)", () => {
     useAIStore.setState((s) => ({
       conversationStreaming: {

--- a/frontend/src/components/ai/MentionList.tsx
+++ b/frontend/src/components/ai/MentionList.tsx
@@ -1,10 +1,13 @@
 import { forwardRef, useImperativeHandle, useMemo, useState } from "react";
 import { flushSync } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { Server } from "lucide-react";
+import { Database, Server, Table2 } from "lucide-react";
 import { useAssetStore } from "@/stores/assetStore";
+import { useQueryStore, type DatabaseTabState } from "@/stores/queryStore";
+import { useTabStore, type QueryTabMeta, type Tab } from "@/stores/tabStore";
 import { filterAssets } from "@/lib/assetSearch";
 import { getIconComponent, getIconColor } from "@/components/asset/IconPicker";
+import { pinyinMatch } from "@/lib/pinyin";
 
 export interface MentionItem {
   id: number;
@@ -12,6 +15,10 @@ export interface MentionItem {
   type: string;
   icon: string;
   groupPath: string;
+  kind: "asset" | "database" | "table";
+  database?: string;
+  table?: string;
+  driver?: string;
 }
 
 export interface MentionListProps {
@@ -25,22 +32,193 @@ export interface MentionListRef {
 
 const MAX_ITEMS = 8;
 
+interface ActiveDatabaseTab {
+  id: string;
+  meta: QueryTabMeta;
+}
+
+interface RankedMentionItem {
+  item: MentionItem;
+  sourceRank: number;
+  matchRank: number;
+  order: number;
+}
+
+function resolveActiveDatabaseTab(tabs: Tab[], activeTabId: string | null): ActiveDatabaseTab | null {
+  const tab = tabs.find((item) => item.id === activeTabId);
+  if (!tab || tab.type !== "query") return null;
+  const meta = tab.meta as QueryTabMeta;
+  if (meta.assetType !== "database") return null;
+  return { id: tab.id, meta };
+}
+
+function itemKey(item: MentionItem) {
+  return `${item.kind}:${item.id}:${item.database ?? ""}:${item.table ?? ""}`;
+}
+
+function fieldMatchRank(value: string | undefined, query: string): number | null {
+  if (!value) return null;
+  const lowerValue = value.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  if (lowerValue.startsWith(lowerQuery)) return 0;
+  if (lowerValue.includes(lowerQuery)) return 1;
+  if (pinyinMatch(value, query)) return 2;
+  return null;
+}
+
+function bestRank(values: Array<string | undefined>, query: string): number | null {
+  let best: number | null = null;
+  for (const value of values) {
+    const rank = fieldMatchRank(value, query);
+    if (rank === null) continue;
+    best = best === null ? rank : Math.min(best, rank);
+  }
+  return best;
+}
+
+function mentionMatchRank(item: MentionItem, query: string): number | null {
+  const q = query.trim();
+  if (!q) return 0;
+  const primary =
+    item.kind === "table" ? [item.table] : item.kind === "database" ? [item.database, item.label] : [item.label];
+  const primaryRank = bestRank(primary, q);
+  if (primaryRank !== null) return primaryRank;
+
+  const path = [item.groupPath, item.database, item.table].filter(Boolean).join(" ");
+  const contextRank = bestRank([item.label, item.groupPath, item.database, item.driver, item.type, path], q);
+  return contextRank === null ? null : contextRank + 3;
+}
+
+function queryKindRank(item: MentionItem, sourceRank: number) {
+  if (sourceRank === 0) return 0;
+  if (item.kind === "table") return 1;
+  if (item.kind === "database") return 2;
+  return 3;
+}
+
+function buildDatabaseMentionItems(activeTab: ActiveDatabaseTab | null, dbState: DatabaseTabState | undefined) {
+  if (!activeTab || !dbState) return [];
+  const out: Array<{ item: MentionItem; sourceRank: number }> = [];
+  const seen = new Set<string>();
+  const meta = activeTab.meta;
+  const base = {
+    id: meta.assetId,
+    type: meta.assetType,
+    icon: meta.assetIcon,
+    groupPath: meta.assetName,
+    driver: meta.driver,
+  };
+  const push = (item: MentionItem, sourceRank: number) => {
+    const key = itemKey(item);
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({ item, sourceRank });
+  };
+  const databaseItem = (database: string): MentionItem => ({ ...base, kind: "database", label: database, database });
+  const tableItem = (database: string, table: string): MentionItem => ({
+    ...base,
+    kind: "table",
+    label: `${database}.${table}`,
+    database,
+    table,
+  });
+  const pushDatabase = (database: string | undefined) => {
+    if (!database) return;
+    push(databaseItem(database), database === meta.defaultDatabase ? 1 : 2);
+  };
+  const pushTable = (database: string | undefined, table: string | undefined) => {
+    if (!database || !table) return;
+    push(tableItem(database, table), 5);
+  };
+  const activeInner = dbState.innerTabs.find((tab) => tab.id === dbState.activeInnerTabId);
+  if (activeInner?.type === "table") {
+    push(tableItem(activeInner.database, activeInner.table), 0);
+  } else if (activeInner?.type === "sql") {
+    if (activeInner.selectedDb) push(databaseItem(activeInner.selectedDb), 0);
+  }
+  pushDatabase(meta.defaultDatabase);
+  for (const tab of dbState.innerTabs) {
+    if (tab.type === "table") {
+      const item = tableItem(tab.database, tab.table);
+      push(item, 4);
+    }
+  }
+  for (const db of dbState.databases) {
+    const tables = dbState.tables[db] ?? [];
+    for (const table of tables) {
+      pushTable(db, table);
+    }
+  }
+  for (const [db, tables] of Object.entries(dbState.tables)) {
+    if (dbState.databases.includes(db)) continue;
+    for (const table of tables) {
+      pushTable(db, table);
+    }
+  }
+  return out;
+}
+
 export const MentionList = forwardRef<MentionListRef, MentionListProps>(function MentionList({ query, command }, ref) {
   const { t } = useTranslation();
   const { assets, groups } = useAssetStore();
+  const tabs = useTabStore((s) => s.tabs);
+  const activeTabId = useTabStore((s) => s.activeTabId);
+  const dbStates = useQueryStore((s) => s.dbStates);
   const [selection, setSelection] = useState({ itemCount: 0, index: 0 });
 
-  const items: MentionItem[] = useMemo(() => {
-    if (assets.length === 0) return [];
-    return filterAssets(assets, groups, { query, limit: MAX_ITEMS }).map(({ asset, groupPath }) => ({
-      id: asset.ID,
-      label: asset.Name,
-      type: asset.Type,
-      icon: asset.Icon,
-      groupPath,
-    }));
-  }, [assets, groups, query]);
+  const activeDatabaseTab = useMemo(() => resolveActiveDatabaseTab(tabs, activeTabId), [activeTabId, tabs]);
+  const activeDbState = activeDatabaseTab ? dbStates[activeDatabaseTab.id] : undefined;
 
+  const items: MentionItem[] = useMemo(() => {
+    let order = 0;
+    const ranked: RankedMentionItem[] = [];
+    const addItem = (item: MentionItem, sourceRank: number) => {
+      const matchRank = mentionMatchRank(item, query);
+      if (matchRank === null) return;
+      ranked.push({ item, sourceRank, matchRank, order });
+      order += 1;
+    };
+
+    for (const { item, sourceRank } of buildDatabaseMentionItems(activeDatabaseTab, activeDbState)) {
+      addItem(item, sourceRank);
+    }
+    for (const { asset, groupPath } of filterAssets(assets, groups, { query, limit: MAX_ITEMS })) {
+      addItem(
+        {
+          id: asset.ID,
+          label: asset.Name,
+          type: asset.Type,
+          icon: asset.Icon,
+          groupPath,
+          kind: "asset",
+        },
+        3
+      );
+    }
+
+    const hasQuery = query.trim().length > 0;
+    ranked.sort((a, b) => {
+      if (hasQuery) {
+        if (a.matchRank !== b.matchRank) return a.matchRank - b.matchRank;
+        const aKindRank = queryKindRank(a.item, a.sourceRank);
+        const bKindRank = queryKindRank(b.item, b.sourceRank);
+        if (aKindRank !== bKindRank) return aKindRank - bKindRank;
+      }
+      if (a.sourceRank !== b.sourceRank) return a.sourceRank - b.sourceRank;
+      return a.order - b.order;
+    });
+
+    const seen = new Set<string>();
+    const out: MentionItem[] = [];
+    for (const rankedItem of ranked) {
+      const key = itemKey(rankedItem.item);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(rankedItem.item);
+      if (out.length >= MAX_ITEMS) break;
+    }
+    return out;
+  }, [activeDatabaseTab, activeDbState, assets, groups, query]);
   const selectedIndex = selection.itemCount === items.length ? selection.index : 0;
 
   useImperativeHandle(ref, () => ({
@@ -72,7 +250,7 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(function
     },
   }));
 
-  if (assets.length === 0) return null;
+  if (assets.length === 0 && !activeDbState) return null;
 
   if (items.length === 0) {
     return (
@@ -88,12 +266,19 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(function
       className="bg-popover text-popover-foreground rounded-md border shadow-md overflow-hidden min-w-[240px] max-w-[360px]"
     >
       {items.map((item, idx) => {
-        const Icon = item.icon ? getIconComponent(item.icon) : Server;
+        const Icon =
+          item.kind === "database"
+            ? Database
+            : item.kind === "table"
+              ? Table2
+              : item.icon
+                ? getIconComponent(item.icon)
+                : Server;
         return (
           <button
             role="option"
             aria-selected={idx === selectedIndex}
-            key={item.id}
+            key={itemKey(item)}
             onClick={() => command(item)}
             className={
               "flex items-center gap-2 w-full px-2.5 py-1.5 text-xs text-left " +
@@ -102,7 +287,7 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(function
           >
             <Icon
               className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
-              style={item.icon ? { color: getIconColor(item.icon) } : undefined}
+              style={item.kind === "asset" && item.icon ? { color: getIconColor(item.icon) } : undefined}
             />
             <span className="flex-1 min-w-0 truncate">
               {item.groupPath && <span className="text-muted-foreground">{item.groupPath}/</span>}

--- a/frontend/src/components/ai/MentionList.tsx
+++ b/frontend/src/components/ai/MentionList.tsx
@@ -89,10 +89,9 @@ function mentionMatchRank(item: MentionItem, query: string): number | null {
   return contextRank === null ? null : contextRank + 3;
 }
 
-function queryKindRank(item: MentionItem, sourceRank: number) {
-  if (sourceRank === 0) return 0;
-  if (item.kind === "table") return 1;
-  if (item.kind === "database") return 2;
+function queryKindRank(item: MentionItem) {
+  if (item.kind === "database") return 1;
+  if (item.kind === "table") return 2;
   return 3;
 }
 
@@ -122,9 +121,9 @@ function buildDatabaseMentionItems(activeTab: ActiveDatabaseTab | null, dbState:
     database,
     table,
   });
-  const pushDatabase = (database: string | undefined) => {
+  const pushDatabase = (database: string | undefined, sourceRank = database === meta.defaultDatabase ? 3 : 2) => {
     if (!database) return;
-    push(databaseItem(database), database === meta.defaultDatabase ? 1 : 2);
+    push(databaseItem(database), sourceRank);
   };
   const pushTable = (database: string | undefined, table: string | undefined) => {
     if (!database || !table) return;
@@ -134,13 +133,16 @@ function buildDatabaseMentionItems(activeTab: ActiveDatabaseTab | null, dbState:
   if (activeInner?.type === "table") {
     push(tableItem(activeInner.database, activeInner.table), 0);
   } else if (activeInner?.type === "sql") {
-    if (activeInner.selectedDb) push(databaseItem(activeInner.selectedDb), 0);
+    if (activeInner.selectedDb) push(databaseItem(activeInner.selectedDb), 2);
+  }
+  for (const database of dbState.expandedDbs) {
+    pushDatabase(database, 2);
   }
   pushDatabase(meta.defaultDatabase);
   for (const tab of dbState.innerTabs) {
     if (tab.type === "table") {
       const item = tableItem(tab.database, tab.table);
-      push(item, 4);
+      push(item, 1);
     }
   }
   for (const db of dbState.databases) {
@@ -200,8 +202,8 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(function
     ranked.sort((a, b) => {
       if (hasQuery) {
         if (a.matchRank !== b.matchRank) return a.matchRank - b.matchRank;
-        const aKindRank = queryKindRank(a.item, a.sourceRank);
-        const bKindRank = queryKindRank(b.item, b.sourceRank);
+        const aKindRank = queryKindRank(a.item);
+        const bKindRank = queryKindRank(b.item);
         if (aKindRank !== bKindRank) return aKindRank - bKindRank;
       }
       if (a.sourceRank !== b.sourceRank) return a.sourceRank - b.sourceRank;

--- a/frontend/src/components/ai/UserMessage.tsx
+++ b/frontend/src/components/ai/UserMessage.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@opskat/ui";
 import type { ChatMessage } from "@/stores/aiStore";
 import { useCompact } from "@/components/ai/AIChatContentContext";
-import { openAssetInfoTab } from "@/lib/openAssetInfoTab";
+import { openMentionTarget } from "@/lib/openMentionTarget";
 import { parseMentionContent } from "@/lib/mentionXml";
 
 // 单独控制用户消息选中态，保证主色气泡里也能明确看到选区范围。
@@ -68,7 +68,7 @@ export const UserMessage = memo(function UserMessage({ msg, index, onEdit }: Use
                 <button
                   key={i}
                   type="button"
-                  onClick={() => openAssetInfoTab(s.attrs.assetId)}
+                  onClick={() => openMentionTarget(s.attrs)}
                   className="inline-flex items-center rounded bg-primary-foreground/20 px-1 py-0.5 text-xs font-medium hover:bg-primary-foreground/30 hover:underline cursor-pointer"
                 >
                   {s.text}

--- a/frontend/src/components/ai/input/content.ts
+++ b/frontend/src/components/ai/input/content.ts
@@ -23,6 +23,18 @@ export function extractContentXml(doc: ProseMirrorLikeNode): string {
       return undefined;
     }
   };
+  const driverFromConfig = (cfg: string | undefined) => {
+    if (!cfg) return undefined;
+    try {
+      const parsed = JSON.parse(cfg) as { driver?: string };
+      return parsed.driver || undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  const stringAttr = (value: unknown) => (typeof value === "string" && value ? value : undefined);
+  const mentionTarget = (value: unknown) =>
+    value === "database" || value === "table" || value === "asset" ? value : undefined;
 
   let out = "";
   doc.descendants((node) => {
@@ -34,12 +46,17 @@ export function extractContentXml(doc: ProseMirrorLikeNode): string {
       const id = Number(node.attrs.id);
       const label = String(node.attrs.label ?? "");
       const asset = Number.isFinite(id) ? lookupAsset(id) : undefined;
+      const target = mentionTarget(node.attrs.kind);
       out += buildMentionXml({
         assetId: id,
         name: label,
         type: asset?.Type,
         host: asset ? hostFromConfig(asset.Config) : undefined,
         groupPath: asset?.GroupID ? groupPathMap.get(asset.GroupID) : undefined,
+        target,
+        database: stringAttr(node.attrs.database),
+        table: stringAttr(node.attrs.table),
+        driver: stringAttr(node.attrs.driver) ?? (asset ? driverFromConfig(asset.Config) : undefined),
       });
     } else if (node.type.name === "paragraph" && out.length > 0) {
       out += "\n";
@@ -94,6 +111,10 @@ export function buildEditorDocFromMessage(message: string | AIChatInputDraft): T
         attrs: {
           id: String(seg.attrs.assetId),
           label: seg.attrs.name,
+          kind: seg.attrs.target,
+          database: seg.attrs.database,
+          table: seg.attrs.table,
+          driver: seg.attrs.driver,
         },
       });
     }

--- a/frontend/src/components/ai/input/extensions.ts
+++ b/frontend/src/components/ai/input/extensions.ts
@@ -14,6 +14,27 @@ import {
   type SnippetSuggestionListRef,
 } from "../SnippetSuggestionList";
 
+const ContextMention = Mention.extend({
+  addAttributes() {
+    const parentAttributes = this.parent?.() ?? {};
+    return {
+      ...parentAttributes,
+      kind: {
+        default: "asset",
+      },
+      database: {
+        default: null,
+      },
+      table: {
+        default: null,
+      },
+      driver: {
+        default: null,
+      },
+    };
+  },
+});
+
 function firstLine(s: string): string {
   const index = s.indexOf("\n");
   return index === -1 ? s.trim() : s.slice(0, index).trim();
@@ -71,7 +92,7 @@ function createSuggestionPopup<TItem>(props: SuggestionProps<TItem>, content: El
 }
 
 export function createMentionExtension(activeRef: MutableRefObject<boolean>) {
-  return Mention.configure({
+  return ContextMention.configure({
     HTMLAttributes: {
       class: "ai-mention inline-flex items-center rounded bg-primary/10 text-primary px-1 py-0.5 text-xs font-medium",
     },
@@ -84,7 +105,14 @@ export function createMentionExtension(activeRef: MutableRefObject<boolean>) {
         const makeProps = (props: SuggestionProps<MentionItem>) => ({
           query: props.query,
           command: (item: MentionItem) => {
-            props.command({ id: String(item.id), label: item.label } as unknown as MentionItem);
+            props.command({
+              id: String(item.id),
+              label: item.label,
+              kind: item.kind,
+              database: item.database,
+              table: item.table,
+              driver: item.driver,
+            } as unknown as MentionItem);
           },
         });
         return {

--- a/frontend/src/components/ai/input/types.ts
+++ b/frontend/src/components/ai/input/types.ts
@@ -29,6 +29,10 @@ export interface TipTapMentionNode {
   attrs: {
     id: string;
     label: string;
+    kind?: "asset" | "database" | "table";
+    database?: string;
+    table?: string;
+    driver?: string;
   };
 }
 

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -842,7 +842,7 @@
     "chars": "chars",
     "pendingMessages": "Pending messages",
     "clearQueue": "Clear",
-    "mentionNotFound": "No assets found",
+    "mentionNotFound": "No assets, databases, or tables found",
     "mentionAssetDeleted": "Asset deleted",
     "editMessage": "Edit message",
     "editingMessage": "Editing message",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -827,7 +827,7 @@
     "chars": "字",
     "pendingMessages": "等待发送",
     "clearQueue": "清空",
-    "mentionNotFound": "未找到资产",
+    "mentionNotFound": "未找到资产、库或表",
     "mentionAssetDeleted": "资产已删除",
     "editMessage": "编辑消息",
     "editingMessage": "正在编辑消息",

--- a/frontend/src/lib/__tests__/mentionXml.test.ts
+++ b/frontend/src/lib/__tests__/mentionXml.test.ts
@@ -25,6 +25,21 @@ describe("mentionXml", () => {
     expect(xml).toBe('<mention asset-id="1">@x</mention>');
   });
 
+  it("buildMentionXml 渲染数据库/表 mention 上下文", () => {
+    const xml = buildMentionXml({
+      assetId: 42,
+      name: "app.users",
+      type: "database",
+      target: "table",
+      database: "app",
+      table: "users",
+      driver: "mysql",
+    });
+    expect(xml).toBe(
+      '<mention asset-id="42" type="database" target="table" database="app" table="users" driver="mysql">@app.users</mention>'
+    );
+  });
+
   it('escapeXmlText 转义 & < >，不动 "', () => {
     expect(escapeXmlText('a < b & c > d"')).toBe('a &lt; b &amp; c &gt; d"');
   });
@@ -50,6 +65,27 @@ describe("mentionXml", () => {
       },
     });
     expect(segs[2]).toEqual({ type: "text", text: " then ls" });
+  });
+
+  it("parseMentionContent 解析数据库/表 mention 上下文", () => {
+    const content =
+      'check <mention asset-id="42" type="database" target="table" database="app" table="users" driver="mysql">@app.users</mention>';
+    const segs = parseMentionContent(content);
+    expect(segs[1]).toEqual({
+      type: "mention",
+      text: "@app.users",
+      attrs: {
+        assetId: 42,
+        name: "app.users",
+        type: "database",
+        host: undefined,
+        groupPath: undefined,
+        target: "table",
+        database: "app",
+        table: "users",
+        driver: "mysql",
+      },
+    });
   });
 
   it("parseMentionContent 对缺 asset-id 的标签当作文本", () => {
@@ -81,8 +117,28 @@ describe("mentionXml", () => {
     const c = '<mention asset-id="1">@a</mention> <mention asset-id="2" type="redis">@b</mention>';
     const mentions = extractMentions(c);
     expect(mentions).toEqual([
-      { assetId: 1, name: "a", type: undefined, host: undefined, groupPath: undefined },
-      { assetId: 2, name: "b", type: "redis", host: undefined, groupPath: undefined },
+      {
+        assetId: 1,
+        name: "a",
+        type: undefined,
+        host: undefined,
+        groupPath: undefined,
+        target: undefined,
+        database: undefined,
+        table: undefined,
+        driver: undefined,
+      },
+      {
+        assetId: 2,
+        name: "b",
+        type: "redis",
+        host: undefined,
+        groupPath: undefined,
+        target: undefined,
+        database: undefined,
+        table: undefined,
+        driver: undefined,
+      },
     ]);
   });
 

--- a/frontend/src/lib/mentionXml.ts
+++ b/frontend/src/lib/mentionXml.ts
@@ -2,9 +2,12 @@
 //
 // 输入文本中只允许出现两类内容：
 //   - 普通文本（< > & 必须按 XML 规则转义为 &lt; &gt; &amp;）
-//   - <mention asset-id="..." [type=...] [host=...] [group=...]>@name</mention>
+//   - <mention asset-id="..." [type=...] [host=...] [group=...] [target=...] [database=...] [table=...]>
+//     @name</mention>
 //
 // 标签 attr 用双引号，名字里的 & < > " 同样转义。
+
+export type MentionTarget = "asset" | "database" | "table";
 
 export interface MentionAttrs {
   assetId: number;
@@ -12,6 +15,10 @@ export interface MentionAttrs {
   type?: string;
   host?: string;
   groupPath?: string;
+  target?: MentionTarget;
+  database?: string;
+  table?: string;
+  driver?: string;
 }
 
 export type MentionSegment = { type: "text"; text: string } | { type: "mention"; text: string; attrs: MentionAttrs };
@@ -37,10 +44,20 @@ function unescapeXml(s: string): string {
 
 export function buildMentionXml(attrs: MentionAttrs): string {
   const parts = [`asset-id="${attrs.assetId}"`];
+  const target = attrs.target ?? (attrs.table ? "table" : attrs.database ? "database" : undefined);
   if (attrs.type) parts.push(`type="${escapeXmlAttr(attrs.type)}"`);
   if (attrs.host) parts.push(`host="${escapeXmlAttr(attrs.host)}"`);
   if (attrs.groupPath) parts.push(`group="${escapeXmlAttr(attrs.groupPath)}"`);
+  if (target && target !== "asset") parts.push(`target="${escapeXmlAttr(target)}"`);
+  if (attrs.database) parts.push(`database="${escapeXmlAttr(attrs.database)}"`);
+  if (attrs.table) parts.push(`table="${escapeXmlAttr(attrs.table)}"`);
+  if (attrs.driver) parts.push(`driver="${escapeXmlAttr(attrs.driver)}"`);
   return `<mention ${parts.join(" ")}>@${escapeXmlText(attrs.name)}</mention>`;
+}
+
+function parseMentionTarget(value: string): MentionTarget | undefined {
+  if (value === "asset" || value === "database" || value === "table") return value;
+  return undefined;
 }
 
 function parseAttrs(raw: string): Partial<MentionAttrs> {
@@ -64,6 +81,18 @@ function parseAttrs(raw: string): Partial<MentionAttrs> {
         break;
       case "group":
         out.groupPath = value;
+        break;
+      case "target":
+        out.target = parseMentionTarget(value);
+        break;
+      case "database":
+        out.database = value;
+        break;
+      case "table":
+        out.table = value;
+        break;
+      case "driver":
+        out.driver = value;
         break;
     }
   }
@@ -95,6 +124,10 @@ export function parseMentionContent(content: string): MentionSegment[] {
           type: attrs.type,
           host: attrs.host,
           groupPath: attrs.groupPath,
+          target: attrs.target ?? (attrs.table ? "table" : attrs.database ? "database" : undefined),
+          database: attrs.database,
+          table: attrs.table,
+          driver: attrs.driver,
         },
       });
     } else {

--- a/frontend/src/lib/openMentionTarget.ts
+++ b/frontend/src/lib/openMentionTarget.ts
@@ -1,0 +1,52 @@
+import { toast } from "sonner";
+import i18n from "../i18n";
+import type { MentionAttrs } from "./mentionXml";
+import { useAssetStore } from "@/stores/assetStore";
+import { useQueryStore } from "@/stores/queryStore";
+import { openAssetInfoTab } from "./openAssetInfoTab";
+
+function queryTabId(assetId: number) {
+  return `query-${assetId}`;
+}
+
+function openDatabaseMention(attrs: MentionAttrs) {
+  const asset = useAssetStore.getState().assets.find((item) => item.ID === attrs.assetId);
+  if (!asset) {
+    toast.error(i18n.t("common.mentionAssetDeleted"));
+    return;
+  }
+  if (asset.Type !== "database") {
+    openAssetInfoTab(attrs.assetId);
+    return;
+  }
+
+  const store = useQueryStore.getState();
+  const tabId = queryTabId(attrs.assetId);
+  store.openQueryTab(asset);
+
+  const database = attrs.database;
+  if (!database) return;
+
+  const nextStore = useQueryStore.getState();
+  const dbState = nextStore.dbStates[tabId];
+  if (dbState && !dbState.expandedDbs.includes(database)) {
+    nextStore.toggleDbExpand(tabId, database);
+  } else if (dbState && !dbState.tables[database] && !dbState.loadingTables[database]) {
+    void nextStore.loadTables(tabId, database);
+  }
+
+  if (attrs.target === "table" && attrs.table) {
+    useQueryStore.getState().openTableTab(tabId, database, attrs.table);
+    return;
+  }
+
+  useQueryStore.getState().openSqlTab(tabId, database);
+}
+
+export function openMentionTarget(attrs: MentionAttrs): void {
+  if (attrs.target === "database" || attrs.target === "table") {
+    openDatabaseMention(attrs);
+    return;
+  }
+  openAssetInfoTab(attrs.assetId);
+}

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -17,7 +17,14 @@ import {
 import { ai, conversation_entity, app } from "../../wailsjs/go/models";
 import { EventsOn, EventsEmit } from "../../wailsjs/runtime/runtime";
 import i18n from "../i18n";
-import { useTabStore, registerTabCloseHook, registerTabRestoreHook, type AITabMeta, type Tab } from "./tabStore";
+import {
+  useTabStore,
+  registerTabCloseHook,
+  registerTabRestoreHook,
+  type AITabMeta,
+  type QueryTabMeta,
+  type Tab,
+} from "./tabStore";
 import { stripMentionTags } from "@/lib/mentionXml";
 import { classifyError, type ErrorKind } from "@/lib/aiError";
 
@@ -1570,14 +1577,14 @@ async function _sendForConversation(convId: number, content: string) {
       (t): t is Tab & { meta: { assetId: number; assetName?: string } } =>
         t.type !== "ai" && t.type !== "page" && t.meta != null && "assetId" in t.meta
     )
-    .map(
-      (t) =>
-        new ai.TabInfo({
-          type: t.type,
-          assetId: t.meta.assetId || 0,
-          assetName: t.meta.assetName || t.label || "",
-        })
-    );
+    .map((t) => {
+      const type = t.type === "query" ? (t.meta as QueryTabMeta).assetType : t.type === "terminal" ? "ssh" : t.type;
+      return new ai.TabInfo({
+        type,
+        assetId: t.meta.assetId || 0,
+        assetName: t.meta.assetName || t.label || "",
+      });
+    });
 
   const aiContext = new ai.AIContext({ openTabs });
 

--- a/internal/ai/prompt_builder.go
+++ b/internal/ai/prompt_builder.go
@@ -53,22 +53,25 @@ func (b *PromptBuilder) Build() string {
 		parts = append(parts, tabContext)
 	}
 
-	// 3. 资产知识引导
+	// 3. 内联 mention 引导
+	parts = append(parts, b.buildMentionGuidance())
+
+	// 4. 资产知识引导
 	parts = append(parts, b.buildKnowledgeGuidance())
 
-	// 4. 多资产 / 批量操作引导
+	// 5. 多资产 / 批量操作引导
 	parts = append(parts, b.buildMultiAssetGuidance())
 
-	// 5. 凭据与敏感信息引导
+	// 6. 凭据与敏感信息引导
 	parts = append(parts, b.buildSecretsGuidance())
 
-	// 6. 错误恢复引导
+	// 7. 错误恢复引导
 	parts = append(parts, b.buildErrorRecoveryGuidance())
 
-	// 7. 用户拒绝操作引导
+	// 8. 用户拒绝操作引导
 	parts = append(parts, b.buildUserDenialGuidance())
 
-	// 8. Extension tools guide
+	// 9. Extension tools guide
 	if len(b.extensionSkillMDs) > 0 {
 		names := make([]string, 0, len(b.extensionSkillMDs))
 		for name := range b.extensionSkillMDs {
@@ -116,6 +119,12 @@ func (b *PromptBuilder) buildTabContext() string {
 		lines = append(lines, fmt.Sprintf("- %s: \"%s\" (ID: %d)", typeName, tab.AssetName, tab.AssetID))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (b *PromptBuilder) buildMentionGuidance() string {
+	return `User messages may contain inline XML mention tags such as <mention asset-id="42" type="database" target="table" database="app" table="users" driver="mysql">@app.users</mention>. Treat these tags as authoritative user-selected context, not as prose to quote back verbatim.
+
+Use asset-id for tool calls. When target="database", scope SQL work to the database attribute. When target="table", scope SQL work to both database and table attributes, and qualify table names as needed for the driver. If you execute SQL for a mentioned database or table, keep the exact SQL visible to the user in your response or tool-call explanation so they can verify what ran.`
 }
 
 func (b *PromptBuilder) buildKnowledgeGuidance() string {

--- a/internal/ai/prompt_builder_test.go
+++ b/internal/ai/prompt_builder_test.go
@@ -27,6 +27,14 @@ func TestPromptBuilderBuild(t *testing.T) {
 			So(got, ShouldContainSubstring, "metrics")
 		})
 
+		Convey("输出内联 mention 语义提示", func() {
+			got := NewPromptBuilder("en", AIContext{}).Build()
+			So(got, ShouldContainSubstring, "<mention")
+			So(got, ShouldContainSubstring, "asset-id")
+			So(got, ShouldContainSubstring, "database")
+			So(got, ShouldContainSubstring, "table")
+		})
+
 		Convey("Extension SKILL.md 被注入", func() {
 			b := NewPromptBuilder("en", AIContext{})
 			b.SetExtensionSkillMDs(map[string]string{"k8s": "k8s skill body"})


### PR DESCRIPTION
## 变更说明 / Summary

- 在 AI 输入框 mention 列表中支持从当前数据库查询页选择数据库和表，同时保留资产搜索。
- mention XML 增加 target、database、table、driver 属性，消息渲染和点击可打开对应资产、库或表上下文。
- 后端 prompt 增加内联 mention 语义提示，要求 AI 使用 asset-id 和库表上下文，并在执行 SQL 时向用户展示 SQL。

## 关联 Issue / Related Issue

Close #34

## 截图 / Screenshots

未附：本次为桌面端输入框交互和消息渲染改动，已通过组件测试覆盖。

## 自检 / Checklist

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

测试：
- pnpm test -- src/__tests__/AIChatInput.test.tsx src/__tests__/MentionList.test.tsx src/__tests__/UserMessage.test.tsx src/__tests__/aiStore.mention.test.ts src/lib/__tests__/mentionXml.test.ts
- pnpm lint
- go test ./internal/ai -run TestPromptBuilderBuild
- go test ./internal/ai/...
