### PR TITLE
🐛 修复启动首页偏好失效 #132

### DIFF
--- a/frontend/src/__tests__/tabStore.test.ts
+++ b/frontend/src/__tests__/tabStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useTabStore } from "../stores/tabStore";
+import { applyStartupPreference, useTabStore } from "../stores/tabStore";
 import type { Tab } from "../stores/tabStore";
 
 function makeTerminalTab(id: string, assetId: number): Tab {
@@ -37,6 +37,7 @@ function makeQueryTab(assetId: number): Tab {
 
 describe("tabStore", () => {
   beforeEach(() => {
+    localStorage.clear();
     useTabStore.setState({ tabs: [], activeTabId: null });
   });
 
@@ -189,6 +190,26 @@ describe("tabStore", () => {
 
       const ids = useTabStore.getState().tabs.map((t) => t.id);
       expect(ids).toEqual(["t1", "t2"]);
+    });
+  });
+
+  describe("startup preference", () => {
+    it("keeps restored tabs when startup_tab is not home", () => {
+      const tab = makeTerminalTab("t1", 1);
+
+      expect(applyStartupPreference({ tabs: [tab], activeTabId: "t1" })).toEqual({
+        tabs: [tab],
+        activeTabId: "t1",
+      });
+    });
+
+    it("skips restored tabs when startup_tab is home", () => {
+      localStorage.setItem("startup_tab", "home");
+
+      expect(applyStartupPreference({ tabs: [makeTerminalTab("t1", 1)], activeTabId: "t1" })).toEqual({
+        tabs: [],
+        activeTabId: null,
+      });
     });
   });
 });

--- a/frontend/src/stores/tabStore.ts
+++ b/frontend/src/stores/tabStore.ts
@@ -266,10 +266,18 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
 // === Persistence ===
 
 const STORAGE_KEY = "tab_store";
+const STARTUP_TAB_KEY = "startup_tab";
 
-interface SavedTabStore {
+export interface SavedTabStore {
   tabs: Tab[];
   activeTabId: string | null;
+}
+
+export function applyStartupPreference(data: SavedTabStore): SavedTabStore {
+  if (localStorage.getItem(STARTUP_TAB_KEY) === "home") {
+    return { tabs: [], activeTabId: null };
+  }
+  return data;
 }
 
 let _persistReady = false;
@@ -494,7 +502,12 @@ function _migrateOldKeys(): SavedTabStore | null {
     try {
       const data: SavedTabStore = JSON.parse(raw);
       if (data.tabs && Array.isArray(data.tabs)) {
-        useTabStore.setState({ tabs: data.tabs, activeTabId: data.activeTabId });
+        const normalized = { tabs: data.tabs, activeTabId: data.activeTabId };
+        const restored = applyStartupPreference(normalized);
+        useTabStore.setState(restored);
+        if (restored !== normalized) {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(restored));
+        }
         _persistReady = true;
         _fireRestoreHooks();
         return;
@@ -507,9 +520,10 @@ function _migrateOldKeys(): SavedTabStore | null {
   // Try migration from old format
   const migrated = _migrateOldKeys();
   if (migrated) {
-    useTabStore.setState(migrated);
+    const restored = applyStartupPreference(migrated);
+    useTabStore.setState(restored);
     // Save in new format immediately
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(migrated));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(restored));
   }
 
   _persistReady = true;


### PR DESCRIPTION
## Summary
- apply the startup page preference before restoring persisted tabs
- clear restored tab state when startup is configured to open Home
- add tab store coverage for the startup preference

## Tests
- cd frontend && pnpm exec prettier --check src/stores/tabStore.ts src/__tests__/tabStore.test.ts
- cd frontend && pnpm test -- tabStore.test.ts tabStoreRecent.test.ts

closes #132