### PR TITLE
✨ macOS 快捷键支持 Ctrl 并提供 ⌘⇄⌃ 一键切换 #138

### DIFF
--- a/frontend/src/__tests__/shortcutMac.test.ts
+++ b/frontend/src/__tests__/shortcutMac.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+// These tests exercise the macOS code paths (isMac === true). `isMac` is derived
+// from navigator.userAgent at module load, so each test overrides just userAgent
+// (replacing the whole navigator breaks happy-dom's localStorage), resets the
+// module registry, and re-imports a fresh copy of the store.
+
+const MAC_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko)";
+
+async function importMac() {
+  Object.defineProperty(navigator, "userAgent", { value: MAC_UA, configurable: true });
+  vi.resetModules();
+  return import("../stores/shortcutStore");
+}
+
+function key(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  delete (navigator as { userAgent?: string }).userAgent; // expose happy-dom's default (non-Mac) UA again
+  vi.resetModules();
+});
+
+describe("matchShortcut on macOS", () => {
+  it("treats mod as Cmd: Cmd+1 matches, Ctrl+1 does not", async () => {
+    const { matchShortcut, DEFAULT_SHORTCUTS } = await importMac();
+    const shortcuts = {
+      ...DEFAULT_SHORTCUTS,
+      "tab.1": { code: "Digit1", mod: true, ctrl: false, shift: false, alt: false },
+    };
+    expect(matchShortcut(key({ code: "Digit1", metaKey: true }), shortcuts)).toBe("tab.1");
+    expect(matchShortcut(key({ code: "Digit1", ctrlKey: true }), shortcuts)).toBeNull();
+  });
+
+  it("treats ctrl as the Control key: Ctrl+1 matches a ctrl binding, Cmd+1 does not", async () => {
+    const { matchShortcut, DEFAULT_SHORTCUTS } = await importMac();
+    const shortcuts = {
+      ...DEFAULT_SHORTCUTS,
+      "tab.1": { code: "Digit1", mod: false, ctrl: true, shift: false, alt: false },
+    };
+    expect(matchShortcut(key({ code: "Digit1", ctrlKey: true }), shortcuts)).toBe("tab.1");
+    expect(matchShortcut(key({ code: "Digit1", metaKey: true }), shortcuts)).toBeNull();
+  });
+
+  it("supports a combined Cmd+Ctrl binding", async () => {
+    const { matchShortcut, DEFAULT_SHORTCUTS } = await importMac();
+    const shortcuts = {
+      ...DEFAULT_SHORTCUTS,
+      "tab.1": { code: "Digit1", mod: true, ctrl: true, shift: false, alt: false },
+    };
+    expect(matchShortcut(key({ code: "Digit1", metaKey: true, ctrlKey: true }), shortcuts)).toBe("tab.1");
+    expect(matchShortcut(key({ code: "Digit1", metaKey: true }), shortcuts)).toBeNull();
+  });
+});
+
+describe("formatBinding on macOS", () => {
+  it("renders the Control glyph for a ctrl binding", async () => {
+    const { formatBinding } = await importMac();
+    expect(formatBinding({ code: "Digit1", mod: false, ctrl: true, shift: false, alt: false })).toBe("⌃1");
+  });
+
+  it("orders modifiers ⌃⌥⇧⌘ per Apple convention", async () => {
+    const { formatBinding } = await importMac();
+    expect(formatBinding({ code: "KeyD", mod: true, ctrl: true, shift: true, alt: true })).toBe("⌃⌥⇧⌘D");
+  });
+});
+
+describe("legacy localStorage migration on macOS", () => {
+  it("fills ctrl=false for bindings saved before the ctrl field existed", async () => {
+    localStorage.setItem(
+      "keyboard_shortcuts",
+      JSON.stringify({ "tab.close": { code: "KeyQ", mod: true, shift: false, alt: false } })
+    );
+    const { useShortcutStore } = await importMac();
+    expect(useShortcutStore.getState().shortcuts["tab.close"]).toEqual({
+      code: "KeyQ",
+      mod: true,
+      ctrl: false,
+      shift: false,
+      alt: false,
+    });
+  });
+});

--- a/frontend/src/__tests__/shortcutStore.test.ts
+++ b/frontend/src/__tests__/shortcutStore.test.ts
@@ -35,14 +35,14 @@ describe("shortcutStore", () => {
 
   describe("updateShortcut", () => {
     it("updates a single shortcut binding", () => {
-      const newBinding: ShortcutBinding = { code: "KeyQ", mod: true, shift: false, alt: false };
+      const newBinding: ShortcutBinding = { code: "KeyQ", mod: true, ctrl: false, shift: false, alt: false };
       useShortcutStore.getState().updateShortcut("tab.close", newBinding);
 
       expect(useShortcutStore.getState().shortcuts["tab.close"]).toEqual(newBinding);
     });
 
     it("persists custom shortcuts to localStorage", () => {
-      const newBinding: ShortcutBinding = { code: "KeyQ", mod: true, shift: false, alt: false };
+      const newBinding: ShortcutBinding = { code: "KeyQ", mod: true, ctrl: false, shift: false, alt: false };
       useShortcutStore.getState().updateShortcut("tab.close", newBinding);
 
       const stored = JSON.parse(localStorage.getItem("keyboard_shortcuts")!);
@@ -51,7 +51,7 @@ describe("shortcutStore", () => {
 
     it("does not persist shortcuts that match defaults", () => {
       // Set to non-default, then back to default
-      const custom: ShortcutBinding = { code: "KeyQ", mod: true, shift: false, alt: false };
+      const custom: ShortcutBinding = { code: "KeyQ", mod: true, ctrl: false, shift: false, alt: false };
       useShortcutStore.getState().updateShortcut("tab.close", custom);
       useShortcutStore.getState().updateShortcut("tab.close", DEFAULT_SHORTCUTS["tab.close"]);
 
@@ -61,7 +61,7 @@ describe("shortcutStore", () => {
 
   describe("resetShortcut", () => {
     it("resets a single shortcut to default", () => {
-      const custom: ShortcutBinding = { code: "KeyQ", mod: true, shift: false, alt: false };
+      const custom: ShortcutBinding = { code: "KeyQ", mod: true, ctrl: false, shift: false, alt: false };
       useShortcutStore.getState().updateShortcut("tab.close", custom);
       useShortcutStore.getState().resetShortcut("tab.close");
 
@@ -71,9 +71,11 @@ describe("shortcutStore", () => {
 
   describe("resetAll", () => {
     it("resets all shortcuts to defaults and clears localStorage", () => {
-      const custom: ShortcutBinding = { code: "KeyQ", mod: true, shift: false, alt: false };
+      const custom: ShortcutBinding = { code: "KeyQ", mod: true, ctrl: false, shift: false, alt: false };
       useShortcutStore.getState().updateShortcut("tab.close", custom);
-      useShortcutStore.getState().updateShortcut("tab.1", { code: "KeyA", mod: true, shift: false, alt: false });
+      useShortcutStore
+        .getState()
+        .updateShortcut("tab.1", { code: "KeyA", mod: true, ctrl: false, shift: false, alt: false });
 
       useShortcutStore.getState().resetAll();
 
@@ -81,6 +83,32 @@ describe("shortcutStore", () => {
       expect(shortcuts["tab.close"]).toEqual(DEFAULT_SHORTCUTS["tab.close"]);
       expect(shortcuts["tab.1"]).toEqual(DEFAULT_SHORTCUTS["tab.1"]);
       expect(localStorage.getItem("keyboard_shortcuts")).toBeNull();
+    });
+  });
+
+  describe("swapCmdCtrl", () => {
+    it("swaps mod and ctrl for every binding (Cmd defaults become Ctrl)", () => {
+      useShortcutStore.getState().swapCmdCtrl();
+
+      const { shortcuts } = useShortcutStore.getState();
+      expect(shortcuts["tab.1"]).toEqual({ ...DEFAULT_SHORTCUTS["tab.1"], mod: false, ctrl: true });
+      // shift/alt are untouched by the swap
+      expect(shortcuts["tab.prev"]).toEqual({ ...DEFAULT_SHORTCUTS["tab.prev"], mod: false, ctrl: true });
+    });
+
+    it("is reversible: swapping twice restores defaults and clears localStorage", () => {
+      useShortcutStore.getState().swapCmdCtrl();
+      useShortcutStore.getState().swapCmdCtrl();
+
+      expect(useShortcutStore.getState().shortcuts["tab.1"]).toEqual(DEFAULT_SHORTCUTS["tab.1"]);
+      expect(localStorage.getItem("keyboard_shortcuts")).toBeNull();
+    });
+
+    it("persists the swapped bindings to localStorage", () => {
+      useShortcutStore.getState().swapCmdCtrl();
+
+      const stored = JSON.parse(localStorage.getItem("keyboard_shortcuts")!);
+      expect(stored["tab.1"]).toEqual({ ...DEFAULT_SHORTCUTS["tab.1"], mod: false, ctrl: true });
     });
   });
 

--- a/frontend/src/__tests__/shortcutUtils.test.ts
+++ b/frontend/src/__tests__/shortcutUtils.test.ts
@@ -54,7 +54,7 @@ describe("matchShortcut", () => {
   it("works with custom shortcuts", () => {
     const custom = {
       ...DEFAULT_SHORTCUTS,
-      "tab.close": { code: "KeyQ", mod: true, shift: false, alt: false },
+      "tab.close": { code: "KeyQ", mod: true, ctrl: false, shift: false, alt: false },
     };
     const event = makeKeyboardEvent({ code: "KeyQ", ctrlKey: true });
     expect(matchShortcut(event, custom)).toBe("tab.close");
@@ -65,32 +65,32 @@ describe("formatBinding", () => {
   // In happy-dom, isMac = false, so we get Windows-style formatting
 
   it("formats Ctrl+key binding", () => {
-    const binding: ShortcutBinding = { code: "KeyW", mod: true, shift: false, alt: false };
+    const binding: ShortcutBinding = { code: "KeyW", mod: true, ctrl: false, shift: false, alt: false };
     expect(formatBinding(binding)).toBe("Ctrl+W");
   });
 
   it("formats Ctrl+Shift+key binding", () => {
-    const binding: ShortcutBinding = { code: "BracketLeft", mod: true, shift: true, alt: false };
+    const binding: ShortcutBinding = { code: "BracketLeft", mod: true, ctrl: false, shift: true, alt: false };
     expect(formatBinding(binding)).toBe("Ctrl+Shift+[");
   });
 
   it("formats Ctrl+Alt+key binding", () => {
-    const binding: ShortcutBinding = { code: "KeyD", mod: true, shift: false, alt: true };
+    const binding: ShortcutBinding = { code: "KeyD", mod: true, ctrl: false, shift: false, alt: true };
     expect(formatBinding(binding)).toBe("Ctrl+Alt+D");
   });
 
   it("formats digit keys correctly", () => {
-    const binding: ShortcutBinding = { code: "Digit1", mod: true, shift: false, alt: false };
+    const binding: ShortcutBinding = { code: "Digit1", mod: true, ctrl: false, shift: false, alt: false };
     expect(formatBinding(binding)).toBe("Ctrl+1");
   });
 
   it("formats special keys (Comma, Space, etc.)", () => {
-    const binding: ShortcutBinding = { code: "Comma", mod: true, shift: false, alt: false };
+    const binding: ShortcutBinding = { code: "Comma", mod: true, ctrl: false, shift: false, alt: false };
     expect(formatBinding(binding)).toBe("Ctrl+,");
   });
 
   it("formats key without modifiers", () => {
-    const binding: ShortcutBinding = { code: "F5", mod: false, shift: false, alt: false };
+    const binding: ShortcutBinding = { code: "F5", mod: false, ctrl: false, shift: false, alt: false };
     expect(formatBinding(binding)).toBe("F5");
   });
 });

--- a/frontend/src/__tests__/terminalInputBridge.test.ts
+++ b/frontend/src/__tests__/terminalInputBridge.test.ts
@@ -120,7 +120,7 @@ describe("terminalInputBridge", () => {
     // Remap panel.filter from KeyF to KeyG.
     bridge.setShortcuts({
       ...DEFAULT_SHORTCUTS,
-      "panel.filter": { code: "KeyG", mod: true, shift: false, alt: false },
+      "panel.filter": { code: "KeyG", mod: true, ctrl: false, shift: false, alt: false },
     });
     const isMac = /Macintosh|Mac OS/.test(navigator.userAgent);
     const mod = isMac ? { metaKey: true } : { ctrlKey: true };

--- a/frontend/src/components/settings/ShortcutSettings.tsx
+++ b/frontend/src/components/settings/ShortcutSettings.tsx
@@ -14,7 +14,7 @@ import {
 
 export function ShortcutSettings() {
   const { t } = useTranslation();
-  const { shortcuts, updateShortcut, resetShortcut, resetAll, setIsRecording } = useShortcutStore();
+  const { shortcuts, updateShortcut, resetShortcut, resetAll, swapCmdCtrl, setIsRecording } = useShortcutStore();
   const [recording, setRecording] = useState<ShortcutAction | null>(null);
 
   const startRecording = (action: ShortcutAction) => {
@@ -45,6 +45,7 @@ export function ShortcutSettings() {
       const binding: ShortcutBinding = {
         code: e.code,
         mod: isMac ? e.metaKey : e.ctrlKey,
+        ctrl: isMac ? e.ctrlKey : false,
         shift: e.shiftKey,
         alt: e.altKey,
       };
@@ -117,9 +118,16 @@ export function ShortcutSettings() {
           </div>
         ))}
       </div>
-      <Button variant="outline" size="sm" onClick={resetAll}>
-        {t("shortcut.resetAll")}
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={resetAll}>
+          {t("shortcut.resetAll")}
+        </Button>
+        {isMac && (
+          <Button variant="outline" size="sm" onClick={swapCmdCtrl} title={t("shortcut.swapCmdCtrlDesc")}>
+            {t("shortcut.swapCmdCtrl")}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -986,6 +986,8 @@
     "recording": "Press shortcut...",
     "reset": "Reset",
     "resetAll": "Reset All",
+    "swapCmdCtrl": "⌘ ⇄ ⌃",
+    "swapCmdCtrlDesc": "Swap ⌘ and ⌃ on every shortcut; click again to swap back",
     "tab.1": "Switch to Tab 1",
     "tab.2": "Switch to Tab 2",
     "tab.3": "Switch to Tab 3",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -986,6 +986,8 @@
     "recording": "请按下快捷键...",
     "reset": "恢复默认",
     "resetAll": "全部恢复默认",
+    "swapCmdCtrl": "⌘ ⇄ ⌃",
+    "swapCmdCtrlDesc": "将所有快捷键的 ⌘ 与 ⌃ 互换，再点一次换回",
     "tab.1": "切换到标签 1",
     "tab.2": "切换到标签 2",
     "tab.3": "切换到标签 3",

--- a/frontend/src/stores/shortcutStore.ts
+++ b/frontend/src/stores/shortcutStore.ts
@@ -4,7 +4,8 @@ export const isMac = /Macintosh|Mac OS/.test(navigator.userAgent);
 
 export interface ShortcutBinding {
   code: string; // KeyboardEvent.code, e.g. "Digit1", "KeyW", "BracketLeft"
-  mod: boolean; // Cmd (Mac) / Ctrl (Win)
+  mod: boolean; // primary modifier: Cmd (Mac) / Ctrl (Win)
+  ctrl: boolean; // Control key — Mac only (Win has no separate Cmd, so it's ignored there)
   shift: boolean;
   alt: boolean;
 }
@@ -59,28 +60,28 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
 ];
 
 export const DEFAULT_SHORTCUTS: Record<ShortcutAction, ShortcutBinding> = {
-  "tab.1": { code: "Digit1", mod: true, shift: false, alt: false },
-  "tab.2": { code: "Digit2", mod: true, shift: false, alt: false },
-  "tab.3": { code: "Digit3", mod: true, shift: false, alt: false },
-  "tab.4": { code: "Digit4", mod: true, shift: false, alt: false },
-  "tab.5": { code: "Digit5", mod: true, shift: false, alt: false },
-  "tab.6": { code: "Digit6", mod: true, shift: false, alt: false },
-  "tab.7": { code: "Digit7", mod: true, shift: false, alt: false },
-  "tab.8": { code: "Digit8", mod: true, shift: false, alt: false },
-  "tab.9": { code: "Digit9", mod: true, shift: false, alt: false },
-  "tab.close": { code: "KeyW", mod: true, shift: false, alt: false },
-  "tab.prev": { code: "BracketLeft", mod: true, shift: true, alt: false },
-  "tab.next": { code: "BracketRight", mod: true, shift: true, alt: false },
-  "split.vertical": { code: "KeyD", mod: true, shift: false, alt: false },
-  "split.horizontal": { code: "KeyD", mod: true, shift: true, alt: false },
-  "panel.ai": { code: "KeyB", mod: true, shift: false, alt: false },
-  "panel.sidebar": { code: "KeyE", mod: true, shift: false, alt: false },
-  "panel.switch": { code: "KeyE", mod: true, shift: true, alt: false },
-  "panel.filter": { code: "KeyF", mod: true, shift: false, alt: false },
-  "page.home": { code: "KeyH", mod: true, shift: true, alt: false },
-  "page.settings": { code: "Comma", mod: true, shift: false, alt: false },
-  "page.sshkeys": { code: "KeyK", mod: true, shift: true, alt: false },
-  "command.quickopen": { code: "KeyP", mod: true, shift: false, alt: false },
+  "tab.1": { code: "Digit1", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.2": { code: "Digit2", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.3": { code: "Digit3", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.4": { code: "Digit4", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.5": { code: "Digit5", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.6": { code: "Digit6", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.7": { code: "Digit7", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.8": { code: "Digit8", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.9": { code: "Digit9", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.close": { code: "KeyW", mod: true, ctrl: false, shift: false, alt: false },
+  "tab.prev": { code: "BracketLeft", mod: true, ctrl: false, shift: true, alt: false },
+  "tab.next": { code: "BracketRight", mod: true, ctrl: false, shift: true, alt: false },
+  "split.vertical": { code: "KeyD", mod: true, ctrl: false, shift: false, alt: false },
+  "split.horizontal": { code: "KeyD", mod: true, ctrl: false, shift: true, alt: false },
+  "panel.ai": { code: "KeyB", mod: true, ctrl: false, shift: false, alt: false },
+  "panel.sidebar": { code: "KeyE", mod: true, ctrl: false, shift: false, alt: false },
+  "panel.switch": { code: "KeyE", mod: true, ctrl: false, shift: true, alt: false },
+  "panel.filter": { code: "KeyF", mod: true, ctrl: false, shift: false, alt: false },
+  "page.home": { code: "KeyH", mod: true, ctrl: false, shift: true, alt: false },
+  "page.settings": { code: "Comma", mod: true, ctrl: false, shift: false, alt: false },
+  "page.sshkeys": { code: "KeyK", mod: true, ctrl: false, shift: true, alt: false },
+  "command.quickopen": { code: "KeyP", mod: true, ctrl: false, shift: false, alt: false },
 };
 
 const STORAGE_KEY = "keyboard_shortcuts";
@@ -88,7 +89,15 @@ const STORAGE_KEY = "keyboard_shortcuts";
 function loadCustom(): Partial<Record<ShortcutAction, ShortcutBinding>> {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : {};
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Partial<Record<ShortcutAction, ShortcutBinding>>;
+    // Normalize at the boundary: bindings persisted before `ctrl` existed lack the
+    // field, so default it to false here rather than re-defaulting at every consumer.
+    const normalized: Partial<Record<ShortcutAction, ShortcutBinding>> = {};
+    for (const [action, binding] of Object.entries(parsed)) {
+      normalized[action as ShortcutAction] = { ...binding, ctrl: binding.ctrl ?? false };
+    }
+    return normalized;
   } catch {
     return {};
   }
@@ -98,7 +107,14 @@ function saveCustom(shortcuts: Record<ShortcutAction, ShortcutBinding>) {
   const custom: Partial<Record<ShortcutAction, ShortcutBinding>> = {};
   for (const [key, val] of Object.entries(shortcuts)) {
     const def = DEFAULT_SHORTCUTS[key as ShortcutAction];
-    if (def && (val.code !== def.code || val.mod !== def.mod || val.shift !== def.shift || val.alt !== def.alt)) {
+    if (
+      def &&
+      (val.code !== def.code ||
+        val.mod !== def.mod ||
+        val.ctrl !== def.ctrl ||
+        val.shift !== def.shift ||
+        val.alt !== def.alt)
+    ) {
       custom[key as ShortcutAction] = val;
     }
   }
@@ -116,6 +132,7 @@ interface ShortcutState {
   updateShortcut: (action: ShortcutAction, binding: ShortcutBinding) => void;
   resetShortcut: (action: ShortcutAction) => void;
   resetAll: () => void;
+  swapCmdCtrl: () => void;
 }
 
 export const useShortcutStore = create<ShortcutState>((set) => ({
@@ -147,6 +164,21 @@ export const useShortcutStore = create<ShortcutState>((set) => ({
     localStorage.removeItem(STORAGE_KEY);
     set({ shortcuts: { ...DEFAULT_SHORTCUTS } });
   },
+
+  // macOS only: exchange the Cmd (mod) and Ctrl flags on every binding, so the user
+  // can flip the whole table between ⌘- and ⌃-based shortcuts with one click. The swap
+  // is its own inverse, so calling it again restores the previous state. Has no sensible
+  // meaning on Windows (no Cmd key), where the UI hides the trigger.
+  swapCmdCtrl: () => {
+    set((state) => {
+      const shortcuts = {} as Record<ShortcutAction, ShortcutBinding>;
+      for (const [action, binding] of Object.entries(state.shortcuts)) {
+        shortcuts[action as ShortcutAction] = { ...binding, mod: binding.ctrl, ctrl: binding.mod };
+      }
+      saveCustom(shortcuts);
+      return { shortcuts };
+    });
+  },
 }));
 
 // Match a KeyboardEvent against shortcuts
@@ -154,16 +186,16 @@ export function matchShortcut(
   e: KeyboardEvent,
   shortcuts: Record<ShortcutAction, ShortcutBinding>
 ): ShortcutAction | null {
-  const modPressed = isMac ? e.metaKey : e.ctrlKey;
   for (const [action, binding] of Object.entries(shortcuts)) {
-    if (
-      e.code === binding.code &&
-      modPressed === binding.mod &&
-      e.shiftKey === binding.shift &&
-      e.altKey === binding.alt
-    ) {
-      return action as ShortcutAction;
+    if (e.code !== binding.code || e.shiftKey !== binding.shift || e.altKey !== binding.alt) continue;
+    if (isMac) {
+      // Mac distinguishes both modifiers: mod = Cmd (metaKey), ctrl = Control (ctrlKey).
+      if (e.metaKey !== binding.mod || e.ctrlKey !== binding.ctrl) continue;
+    } else {
+      // Windows/Linux have no Cmd: mod = Ctrl (ctrlKey); the ctrl field is unused.
+      if (e.ctrlKey !== binding.mod) continue;
     }
+    return action as ShortcutAction;
   }
   return null;
 }
@@ -211,11 +243,20 @@ function codeToDisplay(code: string): string {
 
 export function formatBinding(binding: ShortcutBinding): string {
   const parts: string[] = [];
-  if (binding.mod) parts.push(isMac ? "⌘" : "Ctrl");
-  if (binding.shift) parts.push(isMac ? "⇧" : "Shift");
-  if (binding.alt) parts.push(isMac ? "⌥" : "Alt");
+  if (isMac) {
+    // Apple convention orders modifiers ⌃⌥⇧⌘ with the key last.
+    if (binding.ctrl) parts.push("⌃");
+    if (binding.alt) parts.push("⌥");
+    if (binding.shift) parts.push("⇧");
+    if (binding.mod) parts.push("⌘");
+    parts.push(codeToDisplay(binding.code));
+    return parts.join("");
+  }
+  if (binding.mod) parts.push("Ctrl");
+  if (binding.shift) parts.push("Shift");
+  if (binding.alt) parts.push("Alt");
   parts.push(codeToDisplay(binding.code));
-  return isMac ? parts.join("") : parts.join("+");
+  return parts.join("+");
 }
 
 // Platform-convention modifier shortcut (Cmd on Mac, Ctrl elsewhere) — for
@@ -223,5 +264,5 @@ export function formatBinding(binding: ShortcutBinding): string {
 // editor shortcuts, etc.). User-configurable shortcuts must use
 // formatBinding(shortcuts[action]) so the UI follows rebindings.
 export function formatModKey(code: string, options: { shift?: boolean; alt?: boolean } = {}): string {
-  return formatBinding({ code, mod: true, shift: options.shift ?? false, alt: options.alt ?? false });
+  return formatBinding({ code, mod: true, ctrl: false, shift: options.shift ?? false, alt: options.alt ?? false });
 }


### PR DESCRIPTION
## 背景

#138 请求把 Ctrl 加入组合快捷键。原因排查:`ShortcutBinding` 只有一个修饰键槽 `mod`(macOS=Cmd / Windows=Ctrl),macOS 下录制与匹配只读 `e.metaKey`、从不读 `e.ctrlKey`,所以 Ctrl 在数据模型里无法表达——录制时按 Ctrl 会被静默丢成无修饰键。这就是「Mac 下按 Ctrl 没用」。

## 改动

**`stores/shortcutStore.ts`**(所有路径都经过的 seam)
- `ShortcutBinding` 新增独立 `ctrl: boolean`;默认表保持 Cmd-based(`ctrl:false`)。
- `matchShortcut`:macOS 独立匹配 `metaKey→mod` 与 `ctrlKey→ctrl`(Cmd / Ctrl / Cmd+Ctrl 组合都可用);Windows 不变(`ctrlKey→mod`,无 Cmd 故忽略 `ctrl`)。
- `formatBinding`:macOS 按 Apple 约定顺序 `⌃⌥⇧⌘` 渲染 `⌃`。
- `loadCustom`:在 localStorage **边界**把旧数据补 `ctrl:false`(否则 `false === undefined` 会让升级后所有已自定义的 Mac 快捷键失配)。
- 新增 `swapCmdCtrl()`:互换每条绑定的 `mod`/`ctrl`,为自身逆操作(再点一次换回,等于默认值时清空存储)。

**`components/settings/ShortcutSettings.tsx`**:录制在 macOS 捕获 `ctrl`;新增仅 macOS 可见的 `⌘ ⇄ ⌃` 按钮(在「全部恢复默认」旁)。+ zh-CN / en 文案。

`terminalInputBridge` 无需改动——它直接委托 `matchShortcut`。

## 测试

TDD:先写失败用例再实现。新增 9 个用例(macOS Cmd/Ctrl 独立匹配、⌃ 显示与排序、旧数据迁移、可逆 swap)。

- `pnpm test` → 1076 passed (108 files)
- `tsc -b` → 0
- `eslint .` → clean

## 注意

全局快捷键目前在终端(xterm)内也会触发。切到 Ctrl 后,Ctrl+D / Ctrl+W / Ctrl+E / Ctrl+P 等会盖住终端自身的控制键——这是选择 Ctrl 的固有代价(与现在 Cmd 的拦截一致,只是 Ctrl 在终端里用得更多)。如需要可后续单独处理「终端聚焦时跳过全局快捷键」。

closes #138