### PR TITLE
🐛 终端会话 ID 加随机实例段,修复多开同一连接后 tab 卡死 (#141)

### DIFF
--- a/internal/app/local/local.go
+++ b/internal/app/local/local.go
@@ -3,9 +3,9 @@ package local
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/opskat/opskat/internal/service/localterm_svc"
+	"github.com/opskat/opskat/internal/service/sessionid"
 )
 
 // LangProvider 由 system binder 实现。
@@ -15,16 +15,22 @@ type LangProvider interface {
 
 // Local binder。
 type Local struct {
-	appCtx      context.Context
-	ctx         context.Context
-	lang        LangProvider
-	manager     *localterm_svc.Manager
-	connCounter atomic.Int64
+	appCtx    context.Context
+	ctx       context.Context
+	lang      LangProvider
+	manager   *localterm_svc.Manager
+	connIDGen *sessionid.Generator
 }
 
 // New 构造 local binder。
 func New(appCtx context.Context, lang LangProvider, mgr *localterm_svc.Manager) *Local {
-	return &Local{appCtx: appCtx, lang: lang, manager: mgr}
+	return &Local{appCtx: appCtx, lang: lang, manager: mgr, connIDGen: sessionid.NewGenerator("local-conn")}
+}
+
+// nextConnectionID 生成跨重启唯一的连接中转 ID;保留 local- 前缀以兼容
+// restore 时的 transport 推断(issue #141)。
+func (l *Local) nextConnectionID() string {
+	return l.connIDGen.Next()
 }
 
 // Startup 保存 Wails ctx。

--- a/internal/app/local/local_ops.go
+++ b/internal/app/local/local_ops.go
@@ -50,7 +50,7 @@ func (l *Local) ConnectLocalAsync(req LocalConnectRequest) (string, error) {
 	}
 
 	// 生成 connectionId
-	connectionID := fmt.Sprintf("local-conn-%d", l.connCounter.Add(1))
+	connectionID := l.nextConnectionID()
 	eventName := "local:connect:" + connectionID
 
 	// 从 l.ctx 派生取消上下文：应用退出（Wails ctx 取消）时连接中途终止，

--- a/internal/app/local/restart_connid_test.go
+++ b/internal/app/local/restart_connid_test.go
@@ -1,0 +1,31 @@
+package local
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestConnectionIDsSurviveRestart is the local connecting-phase variant of
+// issue #141: a fresh binder (after an app restart) must not re-mint connection
+// IDs an earlier run already handed out. The "local-" prefix is preserved
+// because restore infers the transport from it (inferTransportFromSessionId).
+func TestConnectionIDsSurviveRestart(t *testing.T) {
+	before := New(context.TODO(), nil, nil)
+	after := New(context.TODO(), nil, nil)
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 50; i++ {
+		id := before.nextConnectionID()
+		if !strings.HasPrefix(id, "local-conn-") {
+			t.Fatalf("connection id %q lost the local-conn- prefix", id)
+		}
+		seen[id] = struct{}{}
+	}
+	for i := 0; i < 50; i++ {
+		id := after.nextConnectionID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("after-restart connection id %q collides with a pre-restart id (issue #141)", id)
+		}
+	}
+}

--- a/internal/app/serial/restart_connid_test.go
+++ b/internal/app/serial/restart_connid_test.go
@@ -1,0 +1,31 @@
+package serial
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestConnectionIDsSurviveRestart is the serial connecting-phase variant of
+// issue #141: a fresh binder (after an app restart) must not re-mint connection
+// IDs an earlier run already handed out, since a connecting tab's id is the
+// connection ID and can be persisted.
+func TestConnectionIDsSurviveRestart(t *testing.T) {
+	before := New(context.TODO(), nil, nil)
+	after := New(context.TODO(), nil, nil)
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 50; i++ {
+		id := before.nextConnectionID()
+		if !strings.HasPrefix(id, "conn-") {
+			t.Fatalf("connection id %q lost the conn- prefix", id)
+		}
+		seen[id] = struct{}{}
+	}
+	for i := 0; i < 50; i++ {
+		id := after.nextConnectionID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("after-restart connection id %q collides with a pre-restart id (issue #141)", id)
+		}
+	}
+}

--- a/internal/app/serial/serial.go
+++ b/internal/app/serial/serial.go
@@ -4,9 +4,9 @@ package serial
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	"github.com/opskat/opskat/internal/service/serial_svc"
+	"github.com/opskat/opskat/internal/service/sessionid"
 )
 
 // LangProvider 由 system binder 实现。
@@ -21,13 +21,18 @@ type Serial struct {
 	lang    LangProvider
 	manager *serial_svc.Manager
 
-	connCounter        atomic.Int64
+	connIDGen          *sessionid.Generator
 	pendingConnections sync.Map // map[string]context.CancelFunc 异步连接取消用
 }
 
 // New 构造 serial binder。
 func New(appCtx context.Context, lang LangProvider, mgr *serial_svc.Manager) *Serial {
-	return &Serial{appCtx: appCtx, lang: lang, manager: mgr}
+	return &Serial{appCtx: appCtx, lang: lang, manager: mgr, connIDGen: sessionid.NewGenerator("conn")}
+}
+
+// nextConnectionID 生成跨重启唯一的连接中转 ID(issue #141)。
+func (s *Serial) nextConnectionID() string {
+	return s.connIDGen.Next()
 }
 
 // Startup 保存 Wails ctx。

--- a/internal/app/serial/serial_ops.go
+++ b/internal/app/serial/serial_ops.go
@@ -51,8 +51,7 @@ func (s *Serial) ConnectSerialAsync(req SerialConnectRequest) (string, error) {
 	}
 
 	// 生成 connectionId
-	connID := s.connCounter.Add(1)
-	connectionID := fmt.Sprintf("conn-%d", connID)
+	connectionID := s.nextConnectionID()
 
 	connCtx, cancel := context.WithCancel(s.ctx)
 	s.pendingConnections.Store(connectionID, cancel)

--- a/internal/app/ssh/restart_connid_test.go
+++ b/internal/app/ssh/restart_connid_test.go
@@ -1,0 +1,33 @@
+package ssh
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestConnectionIDsSurviveRestart is the connecting-phase variant of issue #141:
+// a connection ID is the frontend tab id while a connection is establishing, so
+// it can be persisted and restored. A fresh binder (after an app restart) must
+// not re-mint connection IDs an earlier run already handed out, or a restored
+// connecting tab collides with a new one. Tests through New to also catch a
+// forgotten generator init (nil-deref in production).
+func TestConnectionIDsSurviveRestart(t *testing.T) {
+	before := New(context.TODO(), nil, nil, nil, nil)
+	after := New(context.TODO(), nil, nil, nil, nil) // models the process after a restart
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 50; i++ {
+		id := before.nextConnectionID()
+		if !strings.HasPrefix(id, "conn-") {
+			t.Fatalf("connection id %q lost the conn- prefix", id)
+		}
+		seen[id] = struct{}{}
+	}
+	for i := 0; i < 50; i++ {
+		id := after.nextConnectionID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("after-restart connection id %q collides with a pre-restart id (issue #141)", id)
+		}
+	}
+}

--- a/internal/app/ssh/ssh.go
+++ b/internal/app/ssh/ssh.go
@@ -4,8 +4,8 @@ package ssh
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
+	"github.com/opskat/opskat/internal/service/sessionid"
 	"github.com/opskat/opskat/internal/service/sftp_svc"
 	"github.com/opskat/opskat/internal/service/ssh_svc"
 	"github.com/opskat/opskat/internal/sshpool"
@@ -43,7 +43,7 @@ type SSH struct {
 	pool           *sshpool.Pool
 	forwardManager *ForwardManager
 
-	connCounter atomic.Int64
+	connIDGen *sessionid.Generator
 
 	pendingAuthResponses    sync.Map // map[string]chan []string
 	pendingHostKeyResponses sync.Map // map[string]chan ssh_svc.HostKeyAction
@@ -53,14 +53,21 @@ type SSH struct {
 // New 构造 ssh binder。manager/sftp/pool 由 main.go 创建后注入。
 func New(appCtx context.Context, lang LangProvider, mgr *ssh_svc.Manager, sftp *sftp_svc.Service, pool *sshpool.Pool) *SSH {
 	s := &SSH{
-		appCtx:  appCtx,
-		lang:    lang,
-		manager: mgr,
-		sftp:    sftp,
-		pool:    pool,
+		appCtx:    appCtx,
+		lang:      lang,
+		manager:   mgr,
+		sftp:      sftp,
+		pool:      pool,
+		connIDGen: sessionid.NewGenerator("conn"),
 	}
 	s.forwardManager = NewForwardManager(&poolDialer{})
 	return s
+}
+
+// nextConnectionID 生成跨重启唯一的连接中转 ID(连接中阶段的 tab id),
+// 避免与持久化的旧 connecting tab 撞号(issue #141)。
+func (s *SSH) nextConnectionID() string {
+	return s.connIDGen.Next()
 }
 
 // Startup 保存 Wails ctx，方便 EventsEmit 用。

--- a/internal/app/ssh/ssh_ops.go
+++ b/internal/app/ssh/ssh_ops.go
@@ -120,8 +120,7 @@ func (s *SSH) ConnectSSHAsync(req SSHConnectRequest) (string, error) {
 		return "", fmt.Errorf("资产不是SSH类型")
 	}
 
-	connID := s.connCounter.Add(1)
-	connectionID := fmt.Sprintf("conn-%d", connID)
+	connectionID := s.nextConnectionID()
 
 	// 创建可取消的 context
 	connCtx, cancel := context.WithCancel(s.ctx)

--- a/internal/service/localterm_svc/localterm.go
+++ b/internal/service/localterm_svc/localterm.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/opskat/opskat/internal/service/sessionid"
+
 	"github.com/cago-frame/cago/pkg/logger"
 	"go.uber.org/zap"
 )
@@ -129,12 +131,16 @@ func (s *Session) IsClosed() bool {
 // Manager 管理所有本地终端会话。
 type Manager struct {
 	sessions sync.Map // map[string]*Session
-	counter  int64
-	mu       sync.Mutex
+	idgen    *sessionid.Generator
 }
 
 // NewManager 创建本地终端会话管理器。
-func NewManager() *Manager { return &Manager{} }
+func NewManager() *Manager { return &Manager{idgen: sessionid.NewGenerator("local")} }
+
+// nextSessionID 生成进程内唯一、且跨重启不会与持久化旧会话 ID 冲突的会话 ID（issue #141）。
+func (m *Manager) nextSessionID() string {
+	return m.idgen.Next()
+}
 
 // Connect 启动一个本地 shell,返回 sessionID。调用方随后用 SetCallbacks 挂回调。
 func (m *Manager) Connect(cfg ConnectConfig) (string, error) {
@@ -145,10 +151,7 @@ func (m *Manager) Connect(cfg ConnectConfig) (string, error) {
 		return "", fmt.Errorf("start local pty: %w", err)
 	}
 
-	m.mu.Lock()
-	m.counter++
-	sessionID := fmt.Sprintf("local-%d", m.counter)
-	m.mu.Unlock()
+	sessionID := m.nextSessionID()
 
 	sess := &Session{
 		ID: sessionID, AssetID: cfg.AssetID, proc: proc,

--- a/internal/service/localterm_svc/restart_id_test.go
+++ b/internal/service/localterm_svc/restart_id_test.go
@@ -1,0 +1,30 @@
+package localterm_svc
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestManager_SessionIDsSurviveRestart is the local-transport regression for
+// issue #141: a fresh Manager (after an app restart) must not re-mint session
+// IDs an earlier Manager already handed out, since IDs are persisted as
+// frontend tab IDs.
+func TestManager_SessionIDsSurviveRestart(t *testing.T) {
+	before := NewManager()
+	after := NewManager()
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 50; i++ {
+		id := before.nextSessionID()
+		if !strings.HasPrefix(id, "local-") {
+			t.Fatalf("session id %q lost the local- prefix; breaks transport inference", id)
+		}
+		seen[id] = struct{}{}
+	}
+	for i := 0; i < 50; i++ {
+		id := after.nextSessionID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("after-restart id %q collides with a pre-restart id (issue #141)", id)
+		}
+	}
+}

--- a/internal/service/serial_svc/restart_id_test.go
+++ b/internal/service/serial_svc/restart_id_test.go
@@ -1,0 +1,30 @@
+package serial_svc
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestManager_SessionIDsSurviveRestart is the serial-transport regression for
+// issue #141: a fresh Manager (after an app restart) must not re-mint session
+// IDs an earlier Manager already handed out, since IDs are persisted as
+// frontend tab IDs.
+func TestManager_SessionIDsSurviveRestart(t *testing.T) {
+	before := NewManager()
+	after := NewManager()
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 50; i++ {
+		id := before.nextSessionID()
+		if !strings.HasPrefix(id, "serial-") {
+			t.Fatalf("session id %q lost the serial- prefix; breaks transport inference", id)
+		}
+		seen[id] = struct{}{}
+	}
+	for i := 0; i < 50; i++ {
+		id := after.nextSessionID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("after-restart id %q collides with a pre-restart id (issue #141)", id)
+		}
+	}
+}

--- a/internal/service/serial_svc/serial.go
+++ b/internal/service/serial_svc/serial.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/opskat/opskat/internal/service/sessionid"
+
 	"github.com/cago-frame/cago/pkg/logger"
 	"go.bug.st/serial"
 	"go.uber.org/zap"
@@ -274,13 +276,17 @@ type SerialPortInfo struct {
 // Manager 管理所有串口会话
 type Manager struct {
 	sessions sync.Map // map[string]*Session
-	counter  int64
-	mu       sync.Mutex
+	idgen    *sessionid.Generator
 }
 
 // NewManager 创建串口会话管理器
 func NewManager() *Manager {
-	return &Manager{}
+	return &Manager{idgen: sessionid.NewGenerator("serial")}
+}
+
+// nextSessionID 生成进程内唯一、且跨重启不会与持久化旧会话 ID 冲突的会话 ID（issue #141）。
+func (m *Manager) nextSessionID() string {
+	return m.idgen.Next()
 }
 
 // ListPorts 列出系统可用串口
@@ -345,10 +351,7 @@ func (m *Manager) Connect(cfg ConnectConfig) (string, error) {
 	}
 
 	// 生成 session ID
-	m.mu.Lock()
-	m.counter++
-	sessionID := fmt.Sprintf("serial-%d", m.counter)
-	m.mu.Unlock()
+	sessionID := m.nextSessionID()
 
 	sess := &Session{
 		ID:      sessionID,

--- a/internal/service/sessionid/sessionid.go
+++ b/internal/service/sessionid/sessionid.go
@@ -16,16 +16,15 @@ package sessionid
 import (
 	"fmt"
 	"math/rand/v2"
-	"sync"
+	"sync/atomic"
 )
 
 // Generator produces unique session IDs of the form "<kind>-<instance>-<n>".
-// It is safe for concurrent use.
+// It is safe for concurrent use. Must be used by pointer (atomic counter).
 type Generator struct {
 	kind     string
 	instance uint64
-	mu       sync.Mutex
-	counter  int64
+	counter  atomic.Int64
 }
 
 // NewGenerator returns a Generator whose IDs are prefixed with kind (e.g.
@@ -37,9 +36,5 @@ func NewGenerator(kind string) *Generator {
 
 // Next returns the next unique session ID.
 func (g *Generator) Next() string {
-	g.mu.Lock()
-	g.counter++
-	n := g.counter
-	g.mu.Unlock()
-	return fmt.Sprintf("%s-%x-%d", g.kind, g.instance, n)
+	return fmt.Sprintf("%s-%x-%d", g.kind, g.instance, g.counter.Add(1))
 }

--- a/internal/service/sessionid/sessionid.go
+++ b/internal/service/sessionid/sessionid.go
@@ -1,0 +1,45 @@
+// Package sessionid mints process-unique terminal session IDs.
+//
+// Session IDs are persisted by the frontend (they become tab IDs in the tab
+// store), so an ID must stay unique across app restarts — not just within a
+// single Manager's lifetime. A plain incrementing counter resets to 0 on every
+// launch, which makes a fresh process re-mint IDs an earlier run already
+// persisted, producing two tabs that share one ID (issue #141).
+//
+// Each Generator carries a random per-instance segment, so IDs minted by
+// different processes (or different Managers) never collide regardless of
+// counter value. The ID format is "<kind>-<instance>-<n>"; the kind prefix is
+// preserved because the frontend infers the transport from it
+// (inferTransportFromSessionId keys off "ssh-" / "serial-" / "local-").
+package sessionid
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"sync"
+)
+
+// Generator produces unique session IDs of the form "<kind>-<instance>-<n>".
+// It is safe for concurrent use.
+type Generator struct {
+	kind     string
+	instance uint64
+	mu       sync.Mutex
+	counter  int64
+}
+
+// NewGenerator returns a Generator whose IDs are prefixed with kind (e.g.
+// "ssh"). The random instance segment is drawn once per Generator, giving every
+// process its own ID namespace.
+func NewGenerator(kind string) *Generator {
+	return &Generator{kind: kind, instance: rand.Uint64()}
+}
+
+// Next returns the next unique session ID.
+func (g *Generator) Next() string {
+	g.mu.Lock()
+	g.counter++
+	n := g.counter
+	g.mu.Unlock()
+	return fmt.Sprintf("%s-%x-%d", g.kind, g.instance, n)
+}

--- a/internal/service/sessionid/sessionid.go
+++ b/internal/service/sessionid/sessionid.go
@@ -1,4 +1,4 @@
-// Package sessionid mints process-unique terminal session IDs.
+// Package sessionid mints terminal session IDs with a random instance segment.
 //
 // Session IDs are persisted by the frontend (they become tab IDs in the tab
 // store), so an ID must stay unique across app restarts — not just within a
@@ -7,9 +7,9 @@
 // persisted, producing two tabs that share one ID (issue #141).
 //
 // Each Generator carries a random per-instance segment, so IDs minted by
-// different processes (or different Managers) never collide regardless of
-// counter value. The ID format is "<kind>-<instance>-<n>"; the kind prefix is
-// preserved because the frontend infers the transport from it
+// different processes (or different Managers) are extremely unlikely to collide
+// even when their counters match. The ID format is "<kind>-<instance>-<n>"; the
+// kind prefix is preserved because the frontend infers the transport from it
 // (inferTransportFromSessionId keys off "ssh-" / "serial-" / "local-").
 package sessionid
 
@@ -28,8 +28,8 @@ type Generator struct {
 }
 
 // NewGenerator returns a Generator whose IDs are prefixed with kind (e.g.
-// "ssh"). The random instance segment is drawn once per Generator, giving every
-// process its own ID namespace.
+// "ssh"). The random instance segment is drawn once per Generator, giving each
+// generator an ID namespace with negligible collision risk.
 func NewGenerator(kind string) *Generator {
 	return &Generator{kind: kind, instance: rand.Uint64()}
 }

--- a/internal/service/sessionid/sessionid_test.go
+++ b/internal/service/sessionid/sessionid_test.go
@@ -1,0 +1,59 @@
+package sessionid
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerator_IDsDisjointAcrossInstances is the regression for issue #141:
+// terminal session IDs are persisted into the frontend tab store, but the
+// generating counter lives in process memory and resets on every app restart.
+// Two independently-created generators model "before restart" and "after
+// restart"; their IDs must never overlap, otherwise a freshly minted session ID
+// collides with a stale persisted tab ID and two tabs end up sharing one ID.
+func TestGenerator_IDsDisjointAcrossInstances(t *testing.T) {
+	prev := NewGenerator("ssh") // previous app run
+	next := NewGenerator("ssh") // after restart — counter is back at 0
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 100; i++ {
+		id := prev.Next()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("previous-run generator produced duplicate id %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+	for i := 0; i < 100; i++ {
+		id := next.Next()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("after-restart id %q collides with a previous-run id", id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestGenerator_IDsUniqueWithinInstance guards the basic monotonic-counter
+// contract: a single generator never repeats an id.
+func TestGenerator_IDsUniqueWithinInstance(t *testing.T) {
+	g := NewGenerator("ssh")
+	seen := make(map[string]struct{})
+	for i := 0; i < 1000; i++ {
+		id := g.Next()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("generator repeated id %q at iteration %d", id, i)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestGenerator_PreservesKindPrefix protects the frontend's transport inference,
+// which keys off the "ssh-" / "serial-" / "local-" prefix
+// (inferTransportFromSessionId). The kind must remain the leading segment.
+func TestGenerator_PreservesKindPrefix(t *testing.T) {
+	for _, kind := range []string{"ssh", "serial", "local"} {
+		id := NewGenerator(kind).Next()
+		if !strings.HasPrefix(id, kind+"-") {
+			t.Errorf("kind %q: id %q does not start with %q-", kind, id, kind)
+		}
+	}
+}

--- a/internal/service/sessionid/sessionid_test.go
+++ b/internal/service/sessionid/sessionid_test.go
@@ -9,8 +9,9 @@ import (
 // terminal session IDs are persisted into the frontend tab store, but the
 // generating counter lives in process memory and resets on every app restart.
 // Two independently-created generators model "before restart" and "after
-// restart"; their IDs must never overlap, otherwise a freshly minted session ID
-// collides with a stale persisted tab ID and two tabs end up sharing one ID.
+// restart"; their IDs should not overlap unless the random instance segment
+// collides, otherwise a freshly minted session ID collides with a stale
+// persisted tab ID and two tabs end up sharing one ID.
 func TestGenerator_IDsDisjointAcrossInstances(t *testing.T) {
 	prev := NewGenerator("ssh") // previous app run
 	next := NewGenerator("ssh") // after restart — counter is back at 0

--- a/internal/service/ssh_svc/restart_id_test.go
+++ b/internal/service/ssh_svc/restart_id_test.go
@@ -1,0 +1,30 @@
+package ssh_svc
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestManager_SessionIDsSurviveRestart is the manager-level regression for
+// issue #141: session IDs are persisted as frontend tab IDs, so IDs from a
+// fresh Manager (after an app restart, counter back at 0) must not collide with
+// IDs an earlier Manager already handed out.
+func TestManager_SessionIDsSurviveRestart(t *testing.T) {
+	before := NewManager()
+	after := NewManager() // models the process after a restart
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 50; i++ {
+		id := before.nextSessionID()
+		if !strings.HasPrefix(id, "ssh-") {
+			t.Fatalf("session id %q lost the ssh- prefix; breaks transport inference", id)
+		}
+		seen[id] = struct{}{}
+	}
+	for i := 0; i < 50; i++ {
+		id := after.nextSessionID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("after-restart id %q collides with a pre-restart id (issue #141)", id)
+		}
+	}
+}

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opskat/opskat/internal/model/entity/asset_entity"
 	"github.com/opskat/opskat/internal/pkg/dirsync"
 	"github.com/opskat/opskat/internal/pkg/sshkeepalive"
+	"github.com/opskat/opskat/internal/service/sessionid"
 
 	"github.com/cago-frame/cago/pkg/logger"
 	"go.uber.org/zap"
@@ -232,13 +233,17 @@ func (s *Session) writeInternalTempScript(tempPath string, script string) error 
 // Manager 管理所有 SSH 会话
 type Manager struct {
 	sessions sync.Map // map[string]*Session
-	counter  int64
-	mu       sync.Mutex
+	idgen    *sessionid.Generator
 }
 
 // NewManager 创建会话管理器
 func NewManager() *Manager {
-	return &Manager{}
+	return &Manager{idgen: sessionid.NewGenerator("ssh")}
+}
+
+// nextSessionID 生成进程内唯一、且跨重启不会与持久化旧会话 ID 冲突的会话 ID（issue #141）。
+func (m *Manager) nextSessionID() string {
+	return m.idgen.Next()
 }
 
 // ConnectConfig SSH 连接配置
@@ -388,10 +393,7 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 		return "", fmt.Errorf("获取stdout失败: %w", err)
 	}
 
-	m.mu.Lock()
-	m.counter++
-	sessionID := fmt.Sprintf("ssh-%d", m.counter)
-	m.mu.Unlock()
+	sessionID := m.nextSessionID()
 
 	sess := &Session{
 		ID:       sessionID,


### PR DESCRIPTION
Closes #141

## 现象

同一个 SSH「在新标签打开」多开几个后,前面的 tab 会卡死:点第 2 个会让第 1、2 个**同时高亮**,第 1 个**关不掉**,只能从最后一个往前关。

## 根因

终端会话 ID(`ssh-N` / `serial-N` / `local-N`)来自各 manager 进程内的 `counter int64`,`NewManager()` 每次启动都从 0 开始、**不持久化**;而 tab(含这些 ID)会被持久化到前端 localStorage(`tab_store`)并在重启后原样恢复。

重启后计数器归零,新连接重新发号 `ssh-1`、`ssh-2`…,正好撞上 localStorage 里残留的旧 tab id。`replaceTabId` 把新 tab 的 id 改成 `ssh-1`,与恢复的旧 `ssh-1` tab **同 id** → tab 栏按 `tab.id === activeTabId` 判定选中、按 `key={tab.id}` 渲染,于是两个 tab 一起高亮且无法单独关闭。

> 这也解释了为何"同一次运行内连开多少个都不复现"(计数器单调递增不会重号),**必须经过重启 + 有持久化的旧终端 tab** 才触发——所以之前快速试一下复现不出来。

## 改动

**1. 会话 ID(主因,造成永久卡死)**
- 新增 `internal/service/sessionid` 包:`Generator` 给**每个进程实例**生成一段随机前缀,ID 变为 `<kind>-<instance>-<n>`。
  - 跨重启绝不重号(随机段必然不同于上一进程持久化的裸号);
  - 进程内仍单调唯一;
  - **保留 `ssh-`/`serial-`/`local-` 前缀**,前端 `inferTransportFromSessionId` 的 transport 推断不受影响(全仓无任何代码解析 ID 里的数字,只看前缀)。
- `ssh_svc` / `serial_svc` / `localterm_svc` 三个 manager 统一改用 `m.nextSessionID() → idgen.Next()`,删除各自重复的 `counter + mu` 发号逻辑(与 `sftp_svc` 既有防撞号思路一致)。

**2. 连接中转 ID(同病、更窄的一类)**
- 中转 ID `conn-N` / `local-conn-N`(`internal/app/{ssh,serial,local}`)同样来自归零的 `connCounter`,且在"连接中"阶段就是 tab id,可被持久化 → 同样能跨重启撞号(只是短暂、连上即自愈)。
- 三个 binder 改用同一个 `sessionid.Generator`,各自保留原前缀(ssh/serial 用 `conn`;local 用 `local-conn` 以兼容 restore 的 transport 推断),删除 `connCounter`。
- 至此"会话 ID + 连接中转 ID"两类撞号彻底关闭。

## 测试(TDD)

- `internal/service/sessionid`:跨实例不撞号 / 同实例唯一 / 保留 kind 前缀。
- 三个 manager 各 `TestManager_SessionIDsSurviveRestart`、三个 binder 各 `TestConnectionIDsSurviveRestart`:模拟"重启前/后两个实例",断言 ID 不相交——直接复刻 #141 场景;binder 测试经由 `New(...)` 构造以同时验证生成器被正确初始化(防 nil-deref)。
- 先红后绿:把生成逻辑临时退回旧的 counter-only 时,disjoint 测试如期失败并报 `after-restart id "ssh-1" collides with a previous-run id`。

`internal/service/...`、`internal/app/...` 全部通过;`golangci-lint` 0 issues;`gofmt` 干净。前端测试不受影响(它们 mock 的是 binding 返回值,与后端格式无关)。