### PR TITLE
🎨 增加文件管理器上传按钮 #147

### DIFF
--- a/frontend/src/__tests__/FileManagerPanel.test.tsx
+++ b/frontend/src/__tests__/FileManagerPanel.test.tsx
@@ -7,7 +7,7 @@ import { useTerminalStore, type TerminalDirectorySyncState } from "../stores/ter
 import { useSFTPStore, type SFTPTransfer } from "../stores/sftpStore";
 import { useExternalEditStore } from "../stores/externalEditStore";
 import { type ExternalEditMergePrepareResult, type ExternalEditSession } from "../lib/externalEditApi";
-import { ChangeSSHDirectory, SFTPListDir, SFTPRename } from "../../wailsjs/go/ssh/SSH";
+import { ChangeSSHDirectory, SFTPListDir, SFTPRename, SFTPUpload, SFTPUploadDir } from "../../wailsjs/go/ssh/SSH";
 import { OpenExternalEdit, PrepareExternalEditMerge } from "../../wailsjs/go/external_edit/ExternalEdit";
 
 const { toastError, toastSuccess } = vi.hoisted(() => ({
@@ -288,10 +288,17 @@ describe("FileManagerPanel", () => {
 
     useTerminalStore.getState().setSessionSyncState("s1", makeSyncState({ cwd: "/srv/releases" }));
 
-    await user.click(screen.getByRole("button", { name: "sftp.sync.panelFromTerminal" }));
+    await user.click(screen.getByRole("button", { name: "sftp.sync.followShort" }));
+    await user.click(await screen.findByRole("menuitemcheckbox", { name: "sftp.sync.panelFromTerminal" }));
 
     await waitFor(() => expect(SFTPListDir).toHaveBeenCalledWith("s1", "/srv/releases"));
     expect(useSFTPStore.getState().fileManagerPaths.tab1).toBe("/srv/releases");
+
+    await user.click(screen.getByRole("button", { name: "sftp.sync.followShort" }));
+    expect(await screen.findByRole("menuitemcheckbox", { name: "sftp.sync.panelFromTerminal" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
   });
 
   it("changes the active terminal directory to the current file manager path", async () => {
@@ -301,9 +308,46 @@ describe("FileManagerPanel", () => {
     await waitFor(() => expect(SFTPListDir).toHaveBeenCalledWith("s1", "/srv/app"));
     vi.clearAllMocks();
 
-    await user.click(screen.getByRole("button", { name: "sftp.sync.terminalFromPanel" }));
+    await user.click(screen.getByRole("button", { name: "sftp.sync.followShort" }));
+    await user.click(await screen.findByRole("menuitemcheckbox", { name: "sftp.sync.terminalFromPanel" }));
 
     expect(ChangeSSHDirectory).toHaveBeenCalledWith("s1", "/srv/app");
+
+    await user.click(screen.getByRole("button", { name: "sftp.sync.followShort" }));
+    expect(await screen.findByRole("menuitemcheckbox", { name: "sftp.sync.terminalFromPanel" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("starts file and folder uploads from the file manager status bar", async () => {
+    const user = userEvent.setup();
+    vi.mocked(SFTPUpload).mockResolvedValue("upload-file");
+    vi.mocked(SFTPUploadDir).mockResolvedValue("upload-folder");
+
+    render(<FileManagerPanel tabId="tab1" sessionId="s1" isOpen width={280} onWidthChange={vi.fn()} />);
+
+    await waitFor(() => expect(SFTPListDir).toHaveBeenCalledWith("s1", "/srv/app"));
+
+    const statusBar = screen.getByTestId("sftp-status-bar");
+    await user.click(within(statusBar).getByRole("button", { name: "sftp.uploadTo" }));
+    await user.click(await screen.findByRole("menuitem", { name: "sftp.upload" }));
+    expect(SFTPUpload).toHaveBeenCalledWith("s1", "/srv/app/");
+
+    await user.click(within(statusBar).getByRole("button", { name: "sftp.uploadTo" }));
+    await user.click(await screen.findByRole("menuitem", { name: "sftp.uploadDir" }));
+    expect(SFTPUploadDir).toHaveBeenCalledWith("s1", "/srv/app/");
+  });
+
+  it("opens the new folder dialog from the file manager status bar", async () => {
+    const user = userEvent.setup();
+    render(<FileManagerPanel tabId="tab1" sessionId="s1" isOpen width={280} onWidthChange={vi.fn()} />);
+
+    await waitFor(() => expect(SFTPListDir).toHaveBeenCalledWith("s1", "/srv/app"));
+
+    await user.click(within(screen.getByTestId("sftp-status-bar")).getByRole("button", { name: "sftp.newFolder" }));
+
+    expect(await screen.findByText("sftp.newFolder")).toBeInTheDocument();
   });
 
   it("keeps panel navigation aligned with the terminal when follow mode is enabled", async () => {
@@ -317,6 +361,13 @@ describe("FileManagerPanel", () => {
     render(<FileManagerPanel tabId="tab1" sessionId="s1" isOpen width={280} onWidthChange={vi.fn()} />);
 
     await waitFor(() => expect(screen.getByText("logs")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "sftp.sync.followShort" })).toHaveTextContent("sftp.sync.followActive");
+    await user.click(screen.getByRole("button", { name: "sftp.sync.followShort" }));
+    expect(await screen.findByRole("menuitemcheckbox", { name: "sftp.sync.followToggle" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    await user.keyboard("{Escape}");
     vi.clearAllMocks();
 
     await user.dblClick(screen.getByText("logs"));
@@ -333,7 +384,8 @@ describe("FileManagerPanel", () => {
 
     render(<FileManagerPanel tabId="tab1" sessionId="s1" isOpen width={280} onWidthChange={vi.fn()} />);
 
-    await user.click(screen.getByRole("button", { name: "sftp.sync.followToggle" }));
+    await user.click(screen.getByRole("button", { name: "sftp.sync.followShort" }));
+    await user.click(await screen.findByRole("menuitemcheckbox", { name: "sftp.sync.followToggle" }));
 
     expect(toastError).toHaveBeenCalledWith("sftp.sync.busy");
     expect(useTerminalStore.getState().tabData.tab1.directoryFollowMode).toBe("off");

--- a/frontend/src/components/terminal/FileManagerPanel.tsx
+++ b/frontend/src/components/terminal/FileManagerPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
-import { AlertTriangle, Upload } from "lucide-react";
+import { AlertTriangle, FolderPlus, FolderUp, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { notifyCopied } from "@/lib/notify";
 import {
@@ -12,6 +12,10 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
 } from "@opskat/ui";
 import { SFTPCreateFile, SFTPDelete, SFTPGetwd, SFTPMkdir, SFTPPaste, SFTPRename } from "../../../wailsjs/go/ssh/SSH";
 import { sftp_svc } from "../../../wailsjs/go/models";
@@ -28,7 +32,7 @@ import { ExternalEditPendingDialog, type ExternalEditPendingItem } from "./exter
 import { FileList } from "./file-manager/FileList";
 import { FloatingMenu } from "./file-manager/FloatingMenu";
 import { NameDialog } from "./file-manager/NameDialog";
-import { PathToolbar } from "./file-manager/PathToolbar";
+import { PathToolbar, type DirectorySyncMenuMode } from "./file-manager/PathToolbar";
 import { PermissionDialog } from "./file-manager/PermissionDialog";
 import { PropertiesDialog } from "./file-manager/PropertiesDialog";
 import { TransferSection } from "./file-manager/TransferSection";
@@ -138,6 +142,7 @@ export function FileManagerPanel({
   const [mergePrepareErrors, setMergePrepareErrors] = useState<Record<string, string>>({});
   const [preparedMergeResult, setPreparedMergeResult] = useState<ExternalEditMergePrepareResult | null>(null);
   const [pendingDialogOpen, setPendingDialogOpen] = useState(false);
+  const [activeSyncMode, setActiveSyncMode] = useState<DirectorySyncMenuMode>(null);
 
   const startUpload = useSFTPStore((s) => s.startUpload);
   const startUploadDir = useSFTPStore((s) => s.startUploadDir);
@@ -349,6 +354,21 @@ export function FileManagerPanel({
       .then((home) => navigateToPath(home || "/"))
       .catch(() => navigateToPath("/"));
   }, [navigateToPath, sessionId]);
+
+  const handleSyncPanelFromTerminal = useCallback(async () => {
+    const synced = await syncPanelFromTerminal();
+    if (synced) setActiveSyncMode("panel-from-terminal");
+  }, [syncPanelFromTerminal]);
+
+  const handleSyncTerminalToCurrentPath = useCallback(async () => {
+    const synced = await syncTerminalToPath(currentPathRef.current);
+    if (synced) setActiveSyncMode("terminal-from-panel");
+  }, [currentPathRef, syncTerminalToPath]);
+
+  const handleFollowToggle = useCallback(async () => {
+    await toggleFollowMode();
+    setActiveSyncMode((current) => (directoryFollowMode === "always" ? null : current));
+  }, [directoryFollowMode, toggleFollowMode]);
 
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return;
@@ -711,6 +731,7 @@ export function FileManagerPanel({
 
   const totalWidth = width + HANDLE_PX;
   const selectedTotalSize = selectedEntries.reduce((sum, entry) => sum + (entry.isDir ? 0 : entry.size), 0);
+  const uploadTargetDir = currentPath.endsWith("/") ? currentPath : currentPath + "/";
 
   return (
     <>
@@ -741,17 +762,17 @@ export function FileManagerPanel({
               </div>
             )}
             <PathToolbar
+              activeSyncMode={activeSyncMode}
               currentPath={currentPath}
               directoryFollowMode={directoryFollowMode}
-              onFollowToggle={() => void toggleFollowMode()}
+              onFollowToggle={() => void handleFollowToggle()}
               onGoHome={goHome}
               onGoUp={goUp}
               onPathInputChange={setPathInput}
               onPathSubmit={(nextPath) => void navigateToPath(nextPath)}
               onRefresh={() => void loadDir(currentPathRef.current)}
-              onNewFolder={() => setNameDialog("folder")}
-              onSyncPanelFromTerminal={() => void syncPanelFromTerminal()}
-              onSyncTerminalToPath={() => void syncTerminalToPath(currentPath)}
+              onSyncPanelFromTerminal={() => void handleSyncPanelFromTerminal()}
+              onSyncTerminalToPath={() => void handleSyncTerminalToCurrentPath()}
               paneConnected={paneConnected}
               pathInput={pathInput}
             />
@@ -812,14 +833,46 @@ export function FileManagerPanel({
               selected={selected}
               setSelected={setSelected}
             />
-            <div className="border-t px-2 py-1 text-[11px] text-muted-foreground">
-              {selected.length > 1
-                ? t("sftp.selectedItems", { count: selected.length, size: formatBytes(selectedTotalSize) })
-                : clipboard?.items.length
-                  ? clipboard.mode === "cut"
-                    ? t("sftp.clipboardCut", { count: clipboard.items.length })
-                    : t("sftp.clipboardCopy", { count: clipboard.items.length })
-                  : t("sftp.ready")}
+            <div
+              className="flex items-center justify-between gap-2 border-t px-2 py-1 text-[11px] text-muted-foreground"
+              data-testid="sftp-status-bar"
+            >
+              <span className="min-w-0 truncate">
+                {selected.length > 1
+                  ? t("sftp.selectedItems", { count: selected.length, size: formatBytes(selectedTotalSize) })
+                  : clipboard?.items.length
+                    ? clipboard.mode === "cut"
+                      ? t("sftp.clipboardCut", { count: clipboard.items.length })
+                      : t("sftp.clipboardCopy", { count: clipboard.items.length })
+                    : t("sftp.ready")}
+              </span>
+              <span className="flex shrink-0 items-center gap-0.5">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon-xs" title={t("sftp.uploadTo")} aria-label={t("sftp.uploadTo")}>
+                      <Upload className="h-3.5 w-3.5" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => void startUpload(transferTarget, uploadTargetDir)}>
+                      <Upload className="h-4 w-4" />
+                      {t("sftp.upload")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => void startUploadDir(transferTarget, uploadTargetDir)}>
+                      <FolderUp className="h-4 w-4" />
+                      {t("sftp.uploadDir")}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => setNameDialog("folder")}
+                  title={t("sftp.newFolder")}
+                >
+                  <FolderPlus className="h-3.5 w-3.5" />
+                </Button>
+              </span>
             </div>
             <TransferSection tabId={tabId} transfers={tabTransfers} />
           </div>

--- a/frontend/src/components/terminal/file-manager/PathToolbar.tsx
+++ b/frontend/src/components/terminal/file-manager/PathToolbar.tsx
@@ -1,9 +1,20 @@
 import { useTranslation } from "react-i18next";
-import { ArrowUp, FolderPlus, Home, RefreshCw } from "lucide-react";
-import { Button, Input } from "@opskat/ui";
+import { ArrowUp, FolderSync, Home, RefreshCw } from "lucide-react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+} from "@opskat/ui";
 import { type TerminalDirectoryFollowMode } from "@/stores/terminalStore";
 
+export type DirectorySyncMenuMode = "panel-from-terminal" | "terminal-from-panel" | "follow" | null;
+
 interface PathToolbarProps {
+  activeSyncMode: DirectorySyncMenuMode;
   currentPath: string;
   directoryFollowMode: TerminalDirectoryFollowMode;
   onFollowToggle: () => void;
@@ -12,7 +23,6 @@ interface PathToolbarProps {
   onPathInputChange: (path: string) => void;
   onPathSubmit: (path: string) => void;
   onRefresh: () => void;
-  onNewFolder: () => void;
   onSyncPanelFromTerminal: () => void;
   onSyncTerminalToPath: () => void;
   paneConnected: boolean;
@@ -20,6 +30,7 @@ interface PathToolbarProps {
 }
 
 export function PathToolbar({
+  activeSyncMode,
   currentPath,
   directoryFollowMode,
   onFollowToggle,
@@ -28,49 +39,49 @@ export function PathToolbar({
   onPathInputChange,
   onPathSubmit,
   onRefresh,
-  onNewFolder,
   onSyncPanelFromTerminal,
   onSyncTerminalToPath,
   paneConnected,
   pathInput,
 }: PathToolbarProps) {
   const { t } = useTranslation();
+  const followEnabled = directoryFollowMode === "always";
 
   return (
     <div className="flex items-center gap-0.5 px-1 py-1 border-b shrink-0">
-      <Button
-        variant="ghost"
-        size="xs"
-        className="px-1.5 text-[10px] font-mono"
-        onClick={onSyncPanelFromTerminal}
-        title={t("sftp.sync.panelFromTerminal")}
-        aria-label={t("sftp.sync.panelFromTerminal")}
-        disabled={!paneConnected}
-      >
-        {"T→F"}
-      </Button>
-      <Button
-        variant="ghost"
-        size="xs"
-        className="px-1.5 text-[10px] font-mono"
-        onClick={onSyncTerminalToPath}
-        title={t("sftp.sync.terminalFromPanel")}
-        aria-label={t("sftp.sync.terminalFromPanel")}
-        disabled={!paneConnected}
-      >
-        {"F→T"}
-      </Button>
-      <Button
-        variant={directoryFollowMode === "always" ? "secondary" : "ghost"}
-        size="xs"
-        className="px-1.5 text-[10px] font-medium"
-        onClick={onFollowToggle}
-        title={t("sftp.sync.followToggle")}
-        aria-label={t("sftp.sync.followToggle")}
-        disabled={!paneConnected}
-      >
-        {t("sftp.sync.followShort")}
-      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant={followEnabled ? "secondary" : "ghost"}
+            size="xs"
+            className="px-1.5 text-[10px] font-medium"
+            title={t("sftp.sync.followToggle")}
+            aria-label={t("sftp.sync.followShort")}
+            disabled={!paneConnected}
+          >
+            <FolderSync className="h-3.5 w-3.5" />
+            {followEnabled ? t("sftp.sync.followActive") : t("sftp.sync.followShort")}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuCheckboxItem
+            checked={!followEnabled && activeSyncMode === "panel-from-terminal"}
+            onCheckedChange={onSyncPanelFromTerminal}
+          >
+            {t("sftp.sync.panelFromTerminal")}
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={!followEnabled && activeSyncMode === "terminal-from-panel"}
+            onCheckedChange={onSyncTerminalToPath}
+          >
+            {t("sftp.sync.terminalFromPanel")}
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem checked={followEnabled} onCheckedChange={onFollowToggle}>
+            {t("sftp.sync.followToggle")}
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <Button
         variant="ghost"
         size="icon-xs"
@@ -93,9 +104,6 @@ export function PathToolbar({
       />
       <Button variant="ghost" size="icon-xs" onClick={onRefresh} title={t("sftp.refresh")}>
         <RefreshCw className="h-3.5 w-3.5" />
-      </Button>
-      <Button variant="ghost" size="icon-xs" onClick={onNewFolder} title={t("sftp.newFolder")}>
-        <FolderPlus className="h-3.5 w-3.5" />
       </Button>
     </div>
   );

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1532,10 +1532,11 @@
       "approximate": "(approx)"
     },
     "sync": {
-      "panelFromTerminal": "Sync file manager to terminal directory",
-      "terminalFromPanel": "Change terminal directory to current file manager directory",
-      "followToggle": "Keep terminal and file manager directories in sync for this tab",
+      "panelFromTerminal": "Panel ← Terminal",
+      "terminalFromPanel": "Terminal ← Panel",
+      "followToggle": "Auto follow",
       "followShort": "Sync",
+      "followActive": "Following",
       "markerOverflow": "Directory sync marker output was too large",
       "invalidTarget": "Choose a directory before syncing",
       "sessionClosed": "The terminal session was closed",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1532,10 +1532,11 @@
       "approximate": "(近似)"
     },
     "sync": {
-      "panelFromTerminal": "让当前目录跟随当前终端目录",
-      "terminalFromPanel": "让当前终端切换到当前目录",
-      "followToggle": "在当前终端标签页内保持终端与当前目录始终同步",
+      "panelFromTerminal": "面板 ← 终端",
+      "terminalFromPanel": "终端 ← 面板",
+      "followToggle": "自动跟随",
       "followShort": "同步",
+      "followActive": "跟随中",
       "markerOverflow": "目录同步标记输出过大",
       "invalidTarget": "请先选择要同步的目录",
       "sessionClosed": "终端会话已关闭",


### PR DESCRIPTION
## Summary
- Move upload and new folder actions into the file manager status bar
- Collapse directory sync controls into a checked dropdown with visible direction/follow state
- Support uploading files and folders into the current remote directory
- Cover status-bar upload/new-folder actions and sync menu checked states with FileManagerPanel tests

## Tests
- pnpm test FileManagerPanel.test.tsx -- --runInBand
- pnpm lint
- pnpm build

closes #147