### PR TITLE
🎨 优化右键菜单弹出方向

### DIFF
--- a/frontend/packages/ui/src/components/context-menu.tsx
+++ b/frontend/packages/ui/src/components/context-menu.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { createPortal } from "react-dom";
 import { Slot } from "radix-ui";
 
+import { computeContextMenuPosition } from "../lib/context-menu-position";
 import { cn } from "../lib/utils";
 
 // --- Custom ContextMenu with smart positioning ---
@@ -99,29 +100,23 @@ function ContextMenuContent({
     const rect = ref.current.getBoundingClientRect();
     const vw = window.innerWidth;
     const vh = window.innerHeight;
-    const GAP = alignToStylePosition ? 0 : 2;
+    const gap = alignToStylePosition ? 0 : 4;
 
     const style = styleProp as React.CSSProperties | undefined;
     const anchorX = alignToStylePosition && typeof style?.left === "number" ? style.left : ctx.position.x;
     const anchorY = alignToStylePosition && typeof style?.top === "number" ? style.top : ctx.position.y;
 
-    let left = anchorX + GAP;
-    let top = anchorY + GAP;
+    const next = computeContextMenuPosition({
+      anchorX,
+      anchorY,
+      width: rect.width,
+      height: rect.height,
+      viewportWidth: vw,
+      viewportHeight: vh,
+      gap,
+    });
 
-    // Flip horizontal if menu overflows right edge
-    if (left + rect.width > vw) {
-      left = anchorX - rect.width - GAP;
-    }
-    // Flip vertical if menu overflows bottom edge (往上弹)
-    if (top + rect.height > vh) {
-      top = anchorY - rect.height - GAP;
-    }
-
-    // Clamp to viewport bounds
-    left = Math.max(4, Math.min(left, vw - rect.width - 4));
-    top = Math.max(4, Math.min(top, vh - rect.height - 4));
-
-    setPos({ top, left });
+    setPos({ top: next.top, left: next.left });
     setVisible(true);
   }, [ctx.open, ctx.position, alignToStylePosition, styleProp]);
 
@@ -172,7 +167,7 @@ function ContextMenuContent({
       data-slot="context-menu-content"
       role="menu"
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "z-50 min-w-[8rem] overflow-visible rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
         visible && "animate-in fade-in-0 zoom-in-95",
         className
       )}

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -1,5 +1,7 @@
 export { cn } from "./lib/utils";
 export { pinyinMatch } from "./lib/pinyin";
+export { computeContextMenuPosition } from "./lib/context-menu-position";
+export type { ContextMenuPosition, ContextMenuPositionInput } from "./lib/context-menu-position";
 export { useIMEComposing } from "./hooks/useIMEComposing";
 export { useResizeHandle } from "./hooks/useResizeHandle";
 export * from "./components/alert-dialog";

--- a/frontend/packages/ui/src/lib/context-menu-position.ts
+++ b/frontend/packages/ui/src/lib/context-menu-position.ts
@@ -1,0 +1,48 @@
+export interface ContextMenuPositionInput {
+  anchorX: number;
+  anchorY: number;
+  width: number;
+  height: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  gap?: number;
+  padding?: number;
+}
+
+export interface ContextMenuPosition {
+  left: number;
+  top: number;
+  horizontal: "right" | "left";
+  vertical: "down" | "up";
+}
+
+export function computeContextMenuPosition({
+  anchorX,
+  anchorY,
+  width,
+  height,
+  viewportWidth,
+  viewportHeight,
+  gap = 4,
+  padding = 8,
+}: ContextMenuPositionInput): ContextMenuPosition {
+  const right = anchorX + gap;
+  const left = anchorX - width - gap;
+  const down = anchorY + gap;
+  const up = anchorY - height - gap;
+
+  const fitsRight = right + width <= viewportWidth - padding;
+  const fitsLeft = left >= padding;
+  const fitsDown = down + height <= viewportHeight - padding;
+  const fitsUp = up >= padding;
+
+  const horizontal = !fitsRight && fitsLeft ? "left" : "right";
+  const vertical = !fitsDown && fitsUp ? "up" : "down";
+
+  return {
+    left: horizontal === "left" ? left : right,
+    top: vertical === "up" ? up : down,
+    horizontal,
+    vertical,
+  };
+}

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -464,14 +464,16 @@ describe("QueryResultTable — cell context actions", () => {
     expect(screen.getByText("query.filterOperatorIsNot")).toBeVisible();
   });
 
-  it("makes the long filter submenu scroll vertically", async () => {
+  it("does not force the long filter submenu into an internal scroll area", async () => {
     const user = userEvent.setup();
     openMenu({ onFilterByCellValue: vi.fn(), onClearFilterSort: vi.fn(), onAddColumnFilter: vi.fn() });
 
     await user.hover(screen.getByText("query.filter"));
 
     const submenu = screen.getByText("query.filterOperatorIsNotEmpty").parentElement;
-    expect(submenu).toHaveClass("max-h-80", "overflow-y-auto", "overscroll-contain");
+    expect(submenu).not.toHaveClass("max-h-80");
+    expect(submenu).not.toHaveClass("overflow-y-auto");
+    expect(submenu).not.toHaveClass("overscroll-contain");
     expect(submenu).not.toHaveClass("overflow-hidden");
   });
 

--- a/frontend/src/__tests__/contextMenuPosition.test.ts
+++ b/frontend/src/__tests__/contextMenuPosition.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { computeContextMenuPosition } from "@opskat/ui";
+
+describe("computeContextMenuPosition", () => {
+  it("opens down and right when there is space", () => {
+    expect(
+      computeContextMenuPosition({
+        anchorX: 20,
+        anchorY: 30,
+        width: 100,
+        height: 80,
+        viewportWidth: 500,
+        viewportHeight: 400,
+      })
+    ).toMatchObject({ left: 24, top: 34, horizontal: "right", vertical: "down" });
+  });
+
+  it("opens left when the right side would overflow and the left side fits", () => {
+    expect(
+      computeContextMenuPosition({
+        anchorX: 280,
+        anchorY: 30,
+        width: 100,
+        height: 80,
+        viewportWidth: 300,
+        viewportHeight: 400,
+      })
+    ).toMatchObject({ left: 176, top: 34, horizontal: "left", vertical: "down" });
+  });
+
+  it("opens up when the bottom would overflow and the top fits", () => {
+    expect(
+      computeContextMenuPosition({
+        anchorX: 20,
+        anchorY: 280,
+        width: 100,
+        height: 80,
+        viewportWidth: 500,
+        viewportHeight: 300,
+      })
+    ).toMatchObject({ left: 24, top: 196, horizontal: "right", vertical: "up" });
+  });
+
+  it("keeps the default direction when neither side fully fits", () => {
+    expect(
+      computeContextMenuPosition({
+        anchorX: 40,
+        anchorY: 40,
+        width: 100,
+        height: 100,
+        viewportWidth: 120,
+        viewportHeight: 120,
+      })
+    ).toMatchObject({ left: 44, top: 44, horizontal: "right", vertical: "down" });
+  });
+});

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useEffect, useCallback, useMemo, useTransition } from "react";
+import { memo, useState, useRef, useEffect, useCallback, useMemo, useTransition, useLayoutEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { createPortal } from "react-dom";
 import {
@@ -22,7 +22,7 @@ import {
   Hash,
   ChevronRight,
 } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@opskat/ui";
+import { Popover, PopoverContent, PopoverTrigger, computeContextMenuPosition } from "@opskat/ui";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { toast } from "sonner";
 import { notifyCopied } from "@/lib/notify";
@@ -370,8 +370,11 @@ function QueryResultTableImpl({
 
   // Context menu state
   const [ctxMenu, setCtxMenu] = useState<ContextMenuState | null>(null);
+  const [ctxMenuPosition, setCtxMenuPosition] = useState<{ top: number; left: number } | null>(null);
   const [copyAsSubOpen, setCopyAsSubOpen] = useState(false);
   const [filterSubOpen, setFilterSubOpen] = useState(false);
+  const [copyAsSubSide, setCopyAsSubSide] = useState<"right" | "left">("right");
+  const [filterSubSide, setFilterSubSide] = useState<"right" | "left">("right");
   const [dateEditor, setDateEditor] = useState<{
     rowIdx: number;
     col: string;
@@ -394,6 +397,10 @@ function QueryResultTableImpl({
     return () => document.removeEventListener("mousedown", handler);
   }, [dateEditor]);
   const ctxMenuRef = useRef<HTMLDivElement>(null);
+  const copyAsSubTriggerRef = useRef<HTMLDivElement>(null);
+  const copyAsSubMenuRef = useRef<HTMLDivElement>(null);
+  const filterSubTriggerRef = useRef<HTMLDivElement>(null);
+  const filterSubMenuRef = useRef<HTMLDivElement>(null);
 
   // Reset local sort and column widths when columns change
   useEffect(() => {
@@ -551,6 +558,7 @@ function QueryResultTableImpl({
     if (!ctxMenu) return;
     const close = () => {
       setCtxMenu(null);
+      setCtxMenuPosition(null);
       setCopyAsSubOpen(false);
       setFilterSubOpen(false);
     };
@@ -571,6 +579,38 @@ function QueryResultTableImpl({
       document.removeEventListener("keydown", onKey);
     };
   }, [ctxMenu]);
+
+  useLayoutEffect(() => {
+    if (!ctxMenu || !ctxMenuRef.current) return;
+    const rect = ctxMenuRef.current.getBoundingClientRect();
+    const next = computeContextMenuPosition({
+      anchorX: ctxMenu.x,
+      anchorY: ctxMenu.y,
+      width: rect.width,
+      height: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+    setCtxMenuPosition({ top: next.top, left: next.left });
+  }, [ctxMenu]);
+
+  useLayoutEffect(() => {
+    if (!copyAsSubOpen || !copyAsSubTriggerRef.current || !copyAsSubMenuRef.current) return;
+    const triggerRect = copyAsSubTriggerRef.current.getBoundingClientRect();
+    const menuRect = copyAsSubMenuRef.current.getBoundingClientRect();
+    const rightFits = triggerRect.right + menuRect.width <= window.innerWidth - 8;
+    const leftFits = triggerRect.left - menuRect.width >= 8;
+    setCopyAsSubSide(!rightFits && leftFits ? "left" : "right");
+  }, [copyAsSubOpen]);
+
+  useLayoutEffect(() => {
+    if (!filterSubOpen || !filterSubTriggerRef.current || !filterSubMenuRef.current) return;
+    const triggerRect = filterSubTriggerRef.current.getBoundingClientRect();
+    const menuRect = filterSubMenuRef.current.getBoundingClientRect();
+    const rightFits = triggerRect.right + menuRect.width <= window.innerWidth - 8;
+    const leftFits = triggerRect.left - menuRect.width >= 8;
+    setFilterSubSide(!rightFits && leftFits ? "left" : "right");
+  }, [filterSubOpen]);
 
   const commitEdit = useCallback(
     (rowIdx: number, col: string, newValue: string) => {
@@ -971,6 +1011,7 @@ function QueryResultTableImpl({
       } else {
         selectCell(origIdx, col);
       }
+      setCtxMenuPosition(null);
       setCtxMenu({ kind: "cell", x: e.clientX, y: e.clientY, rowIdx: origIdx, col, value });
     },
     [onSelectedCellChange, onSelectedRowsChange, selectCell, selectedRowIdxs, selectedColumns]
@@ -989,6 +1030,7 @@ function QueryResultTableImpl({
         onSelectedRowsChange?.([]);
         containerRef.current?.focus();
       }
+      setCtxMenuPosition(null);
       setCtxMenu({ kind: "column", variant: "context", x: e.clientX, y: e.clientY, col });
     },
     [onSelectedCellChange, onSelectedRowsChange, selectColumn, selectedColumns]
@@ -1000,6 +1042,7 @@ function QueryResultTableImpl({
       e.stopPropagation();
       selectColumn(col);
       const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      setCtxMenuPosition(null);
       setCtxMenu({ kind: "column", variant: "actions", x: rect.left, y: rect.bottom, col });
     },
     [selectColumn]
@@ -1448,7 +1491,12 @@ function QueryResultTableImpl({
           <div
             ref={ctxMenuRef}
             className="z-50 min-w-[8rem] overflow-visible rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95"
-            style={{ position: "fixed", top: ctxMenu.y + 2, left: ctxMenu.x + 2 }}
+            style={{
+              position: "fixed",
+              top: ctxMenuPosition?.top ?? ctxMenu.y,
+              left: ctxMenuPosition?.left ?? ctxMenu.x,
+              visibility: ctxMenuPosition ? "visible" : "hidden",
+            }}
             role="menu"
           >
             {ctxMenu.kind === "column" && ctxMenu.variant === "actions" ? (
@@ -1542,6 +1590,7 @@ function QueryResultTableImpl({
                 </button>
                 {onCopyAs && (
                   <div
+                    ref={copyAsSubTriggerRef}
                     className="group/submenu relative"
                     onPointerEnter={() => {
                       setCopyAsSubOpen(true);
@@ -1557,7 +1606,10 @@ function QueryResultTableImpl({
                       <ChevronRight className="h-3.5 w-3.5" />
                     </button>
                     <div
-                      className={`absolute left-full top-0 z-50 min-w-[14rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 ${copyAsSubOpen ? "block" : "hidden"}`}
+                      ref={copyAsSubMenuRef}
+                      className={`absolute top-0 z-50 min-w-[14rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 ${
+                        copyAsSubSide === "left" ? "right-full mr-1" : "left-full ml-1"
+                      } ${copyAsSubOpen ? "block" : "hidden"}`}
                     >
                       <button
                         type="button"
@@ -1720,6 +1772,7 @@ function QueryResultTableImpl({
                 {ctxMenu.kind === "cell" &&
                   (onFilterByCellValue || onAddColumnFilter || onRemoveColumnFilter || onRemoveAllFilters) && (
                     <div
+                      ref={filterSubTriggerRef}
                       className="group/submenu relative"
                       onPointerEnter={() => {
                         setFilterSubOpen(true);
@@ -1735,7 +1788,10 @@ function QueryResultTableImpl({
                         <ChevronRight className="h-3.5 w-3.5" />
                       </button>
                       <div
-                        className={`absolute left-full top-0 z-50 max-h-80 min-w-[13rem] overflow-x-hidden overflow-y-auto overscroll-contain rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 slide-in-from-top-1 zoom-in-95 ${filterSubOpen ? "block" : "hidden"}`}
+                        ref={filterSubMenuRef}
+                        className={`absolute top-0 z-50 min-w-[13rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 slide-in-from-top-1 zoom-in-95 ${
+                          filterSubSide === "left" ? "right-full mr-1" : "left-full ml-1"
+                        } ${filterSubOpen ? "block" : "hidden"}`}
                       >
                         {onFilterByCellValue &&
                           CELL_FILTER_OPTIONS.map((option) => (

--- a/frontend/src/components/query/RedisKeyBrowser.tsx
+++ b/frontend/src/components/query/RedisKeyBrowser.tsx
@@ -1,6 +1,7 @@
 import {
   useState,
   useEffect,
+  useLayoutEffect,
   useRef,
   useCallback,
   useMemo,
@@ -29,7 +30,7 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { toast } from "sonner";
 import { notifyCopied } from "@/lib/notify";
-import { Button, Input, ConfirmDialog } from "@opskat/ui";
+import { Button, Input, ConfirmDialog, computeContextMenuPosition } from "@opskat/ui";
 import { useQueryStore } from "@/stores/queryStore";
 import { useTabStore, type QueryTabMeta } from "@/stores/tabStore";
 import {
@@ -237,6 +238,7 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
 
   // Context menu state
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; key: string } | null>(null);
+  const [ctxMenuPosition, setCtxMenuPosition] = useState<{ top: number; left: number } | null>(null);
   const ctxMenuRef = useRef<HTMLDivElement>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -344,7 +346,10 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
   // Close context menu on outside click / escape
   useEffect(() => {
     if (!ctxMenu) return;
-    const close = () => setCtxMenu(null);
+    const close = () => {
+      setCtxMenu(null);
+      setCtxMenuPosition(null);
+    };
     const onKey = (e: globalThis.KeyboardEvent) => {
       if (e.key === "Escape") close();
     };
@@ -361,6 +366,20 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
       document.removeEventListener("pointerdown", onPointer, true);
       document.removeEventListener("keydown", onKey);
     };
+  }, [ctxMenu]);
+
+  useLayoutEffect(() => {
+    if (!ctxMenu || !ctxMenuRef.current) return;
+    const rect = ctxMenuRef.current.getBoundingClientRect();
+    const next = computeContextMenuPosition({
+      anchorX: ctxMenu.x,
+      anchorY: ctxMenu.y,
+      width: rect.width,
+      height: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+    setCtxMenuPosition({ top: next.top, left: next.left });
   }, [ctxMenu]);
 
   const handleDbChange = useCallback(
@@ -562,6 +581,7 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
                       ? (e) => {
                           e.preventDefault();
                           e.stopPropagation();
+                          setCtxMenuPosition(null);
                           setCtxMenu({ x: e.clientX, y: e.clientY, key: row.fullKey! });
                         }
                       : undefined
@@ -633,6 +653,7 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
                 onContextMenu={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
+                  setCtxMenuPosition(null);
                   setCtxMenu({ x: e.clientX, y: e.clientY, key });
                 }}
               >
@@ -679,7 +700,12 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
           <div
             ref={ctxMenuRef}
             className="z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95"
-            style={{ position: "fixed", top: ctxMenu.y + 2, left: ctxMenu.x + 2 }}
+            style={{
+              position: "fixed",
+              top: ctxMenuPosition?.top ?? ctxMenu.y,
+              left: ctxMenuPosition?.left ?? ctxMenu.x,
+              visibility: ctxMenuPosition ? "visible" : "hidden",
+            }}
           >
             <div
               role="menuitem"

--- a/frontend/src/components/query/TableFilterBuilder.tsx
+++ b/frontend/src/components/query/TableFilterBuilder.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   ArrowDown,
@@ -26,6 +26,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  computeContextMenuPosition,
 } from "@opskat/ui";
 import { cellValueToText } from "@/lib/cellValue";
 import {
@@ -128,6 +129,7 @@ export function TableFilterBuilder({
   const { t } = useTranslation();
   const [selectedFilterId, setSelectedFilterId] = useState<string | null>(null);
   const [ctxTarget, setCtxTarget] = useState<FilterContextTarget | null>(null);
+  const [ctxMenuPosition, setCtxMenuPosition] = useState<{ top: number; left: number } | null>(null);
   const [copiedFilterItems, setCopiedFilterItems] = useState<TableFilterItem[]>([]);
   const ctxMenuRef = useRef<HTMLDivElement>(null);
 
@@ -162,10 +164,28 @@ export function TableFilterBuilder({
 
   const openContextMenu = useCallback((target: FilterContextTarget) => {
     setSelectedFilterId(target.id);
+    setCtxMenuPosition(null);
     setCtxTarget(target);
   }, []);
 
-  const closeContextMenu = useCallback(() => setCtxTarget(null), []);
+  const closeContextMenu = useCallback(() => {
+    setCtxTarget(null);
+    setCtxMenuPosition(null);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!ctxTarget || !ctxMenuRef.current) return;
+    const rect = ctxMenuRef.current.getBoundingClientRect();
+    const next = computeContextMenuPosition({
+      anchorX: ctxTarget.x,
+      anchorY: ctxTarget.y,
+      width: rect.width,
+      height: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+    setCtxMenuPosition({ top: next.top, left: next.left });
+  }, [ctxTarget]);
 
   const handleDeleteFilterItem = useCallback(() => {
     if (!ctxTarget) return;
@@ -323,7 +343,12 @@ export function TableFilterBuilder({
           <div
             ref={ctxMenuRef}
             className="z-50 min-w-56 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg"
-            style={{ position: "fixed", top: ctxTarget.y + 2, left: ctxTarget.x + 2 }}
+            style={{
+              position: "fixed",
+              top: ctxMenuPosition?.top ?? ctxTarget.y,
+              left: ctxMenuPosition?.left ?? ctxTarget.x,
+              visibility: ctxMenuPosition ? "visible" : "hidden",
+            }}
             role="menu"
           >
             <button

--- a/frontend/src/components/terminal/file-manager/FloatingMenu.tsx
+++ b/frontend/src/components/terminal/file-manager/FloatingMenu.tsx
@@ -18,7 +18,7 @@ import {
   Terminal,
   Trash2,
 } from "lucide-react";
-import { cn } from "@opskat/ui";
+import { cn, computeContextMenuPosition } from "@opskat/ui";
 import { type CtxMenuState } from "./types";
 
 interface FloatingMenuProps {
@@ -38,15 +38,15 @@ export function FloatingMenu({ canPaste, ctx, onAction, onClose }: FloatingMenuP
   useLayoutEffect(() => {
     if (!ref.current) return;
     const rect = ref.current.getBoundingClientRect();
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    let left = ctx.x + 2;
-    let top = ctx.y + 2;
-    if (left + rect.width > vw) left = ctx.x - rect.width - 2;
-    if (top + rect.height > vh) top = ctx.y - rect.height - 2;
-    left = Math.max(4, Math.min(left, vw - rect.width - 4));
-    top = Math.max(4, Math.min(top, vh - rect.height - 4));
-    setPos({ top, left });
+    const next = computeContextMenuPosition({
+      anchorX: ctx.x,
+      anchorY: ctx.y,
+      width: rect.width,
+      height: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+    setPos({ top: next.top, left: next.left });
     setVisible(true);
   }, [ctx.x, ctx.y]);
 


### PR DESCRIPTION
## Summary
- add a shared context-menu positioning helper for right-click menus
- make shared and hand-written context menus flip left/up only when the alternate side has room
- update query result submenus to choose left/right without adding height limits or forced scrolling

## Tests
- `cd frontend && pnpm test QueryResultTable TableFilterBuilder contextMenuPosition`
- `cd frontend && pnpm lint`

## Notes
- `cd frontend && pnpm test` was attempted in the fresh worktree, but suites that import generated `frontend/wailsjs` files fail to resolve those files because they are absent in this worktree.
- `cd frontend && pnpm test RedisKeyBrowser FileManagerPanel` has the same generated-file resolution issue.
