### PR TITLE
🐛 避免审批激活还原最大化窗口 #148

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/cago-frame/agents v0.0.0-20260514070654-c98128a03c31
+	github.com/cago-frame/agents v0.0.0-20260606024835-82fac62b83ce
 	github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947
 	github.com/coder/websocket v1.8.14
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/bytedance/sonic v1.12.5/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKz
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.1 h1:1GgorWTqf12TA8mma4DDSbaQigE2wOgQo7iCjjJv3+E=
 github.com/bytedance/sonic/loader v0.2.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/cago-frame/agents v0.0.0-20260514070654-c98128a03c31 h1:wC/OkoAzm7Vvrj9DG8Shfy/j8jJIPnaN3GDJmF9Xe5M=
-github.com/cago-frame/agents v0.0.0-20260514070654-c98128a03c31/go.mod h1:Jy+CKjPkZCgu6jc06F+Fa0lj+/wxgnfyxmz1ey06/98=
+github.com/cago-frame/agents v0.0.0-20260606024835-82fac62b83ce h1:n0Tplxt67gOYxwdBLq3XZjtxlTMIXXhJnWV4Mp3fEe8=
+github.com/cago-frame/agents v0.0.0-20260606024835-82fac62b83ce/go.mod h1:s72XmeaSoa3ysdqSTc4qliGqLHH6iBBGW6b8bFi0QRk=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947 h1:JynA9XgnZAd8sXqdbxkBqp2RiBsQN8zV4ufANBvzrj4=
 github.com/cago-frame/cago v0.0.0-20260307042250-c4ff92923947/go.mod h1:a+0ZfDfiKrkIletlXDHbgsFZLGd1yo43waHfpfAIFs8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/internal/app/system/system.go
+++ b/internal/app/system/system.go
@@ -34,6 +34,20 @@ type System struct {
 	githubAuthCancel context.CancelFunc
 }
 
+type windowRuntimeOps struct {
+	IsMinimised    func(context.Context) bool
+	Unminimise     func(context.Context)
+	Show           func(context.Context)
+	SetAlwaysOnTop func(context.Context, bool)
+}
+
+var windowOps = windowRuntimeOps{
+	IsMinimised:    wailsRuntime.WindowIsMinimised,
+	Unminimise:     wailsRuntime.WindowUnminimise,
+	Show:           wailsRuntime.WindowShow,
+	SetAlwaysOnTop: wailsRuntime.WindowSetAlwaysOnTop,
+}
+
 // New 构造 System binder。appCtx 来自 main.go 的根 context（cancel 后所有 binder 退出）。
 func New(appCtx context.Context, skill SkillContent) *System {
 	return &System{
@@ -77,10 +91,12 @@ func (s *System) ActivateWindow() {
 	if s.ctx == nil {
 		return
 	}
-	wailsRuntime.WindowUnminimise(s.ctx)
-	wailsRuntime.WindowShow(s.ctx)
-	wailsRuntime.WindowSetAlwaysOnTop(s.ctx, true)
-	wailsRuntime.WindowSetAlwaysOnTop(s.ctx, false)
+	if windowOps.IsMinimised(s.ctx) {
+		windowOps.Unminimise(s.ctx)
+	}
+	windowOps.Show(s.ctx)
+	windowOps.SetAlwaysOnTop(s.ctx, true)
+	windowOps.SetAlwaysOnTop(s.ctx, false)
 }
 
 // OnSecondInstanceLaunch 第二个实例启动时激活当前窗口。

--- a/internal/app/system/system_window_test.go
+++ b/internal/app/system/system_window_test.go
@@ -1,0 +1,88 @@
+package system
+
+import (
+	"context"
+	"testing"
+)
+
+func TestActivateWindowOnlyUnminimisesMinimisedWindow(t *testing.T) {
+	orig := windowOps
+	t.Cleanup(func() { windowOps = orig })
+
+	var calls []string
+	windowOps = windowRuntimeOps{
+		IsMinimised: func(context.Context) bool {
+			calls = append(calls, "isMinimised")
+			return false
+		},
+		Unminimise: func(context.Context) {
+			calls = append(calls, "unminimise")
+		},
+		Show: func(context.Context) {
+			calls = append(calls, "show")
+		},
+		SetAlwaysOnTop: func(_ context.Context, onTop bool) {
+			if onTop {
+				calls = append(calls, "top")
+				return
+			}
+			calls = append(calls, "notTop")
+		},
+	}
+
+	s := New(context.Background(), SkillContent{})
+	s.ctx = context.Background()
+	s.ActivateWindow()
+
+	want := []string{"isMinimised", "show", "top", "notTop"}
+	if !equalStringSlices(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestActivateWindowRestoresMinimisedWindowBeforeShowing(t *testing.T) {
+	orig := windowOps
+	t.Cleanup(func() { windowOps = orig })
+
+	var calls []string
+	windowOps = windowRuntimeOps{
+		IsMinimised: func(context.Context) bool {
+			calls = append(calls, "isMinimised")
+			return true
+		},
+		Unminimise: func(context.Context) {
+			calls = append(calls, "unminimise")
+		},
+		Show: func(context.Context) {
+			calls = append(calls, "show")
+		},
+		SetAlwaysOnTop: func(_ context.Context, onTop bool) {
+			if onTop {
+				calls = append(calls, "top")
+				return
+			}
+			calls = append(calls, "notTop")
+		},
+	}
+
+	s := New(context.Background(), SkillContent{})
+	s.ctx = context.Background()
+	s.ActivateWindow()
+
+	want := []string{"isMinimised", "unminimise", "show", "top", "notTop"}
+	if !equalStringSlices(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- only unminimise the app window when it is actually minimised
- keep maximised Windows windows maximised when approval brings OpsKat to the foreground
- add focused tests for ActivateWindow call order

## Tests
- go test ./internal/app/system

closes #148