### PR TITLE
🐛 修复 Tabby 密钥认证导入

### DIFF
--- a/internal/service/import_svc/tabby.go
+++ b/internal/service/import_svc/tabby.go
@@ -3,6 +3,7 @@ package import_svc
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -95,6 +96,7 @@ type tabbyOptions struct {
 	Port           int                  `yaml:"port"`
 	User           string               `yaml:"user"`
 	Auth           string               `yaml:"auth"`
+	PrivateKey     string               `yaml:"privateKey"`
 	PrivateKeys    []string             `yaml:"privateKeys"`
 	ForwardedPorts []tabbyForwardedPort `yaml:"forwardedPorts"`
 	SocksProxyHost string               `yaml:"socksProxyHost"`
@@ -174,7 +176,7 @@ func PreviewTabbyConfig(ctx context.Context, data []byte) (*PreviewResult, error
 			Host:        host,
 			Port:        port,
 			Username:    username,
-			AuthType:    mapAuthType(p.Options.Auth),
+			AuthType:    tabbyAuthType(p.Options),
 			GroupID:     p.Group,
 			Exists:      exists,
 			HasPassword: hasVault, // vault 存在时所有 profile 可能有密码
@@ -305,14 +307,8 @@ func ImportTabbySelected(ctx context.Context, data []byte, selectedIndexes []int
 			}
 		}
 
-		authType := mapAuthType(profile.Options.Auth)
-		var privateKeys []string
-		for _, pk := range profile.Options.PrivateKeys {
-			pk = strings.TrimPrefix(pk, "file://")
-			if pk != "" {
-				privateKeys = append(privateKeys, pk)
-			}
-		}
+		privateKeys := tabbyPrivateKeys(profile.Options)
+		authType := tabbyAuthType(profile.Options)
 
 		var proxyCfg *asset_entity.ProxyConfig
 		if profile.Options.SocksProxyHost != "" {
@@ -425,14 +421,52 @@ func encryptPassword(password string) (string, error) {
 }
 
 func mapAuthType(tabbyAuth string) string {
-	switch strings.ToLower(tabbyAuth) {
-	case "publickey":
+	switch strings.ToLower(strings.TrimSpace(tabbyAuth)) {
+	case "key", "privatekey", "private_key", "publickey", "public_key":
 		return asset_entity.AuthTypeKey
 	case "password":
 		return asset_entity.AuthTypePassword
 	default:
 		return asset_entity.AuthTypePassword
 	}
+}
+
+func tabbyAuthType(opts tabbyOptions) string {
+	authType := mapAuthType(opts.Auth)
+	if authType == asset_entity.AuthTypePassword && strings.TrimSpace(opts.Auth) == "" && len(tabbyPrivateKeys(opts)) > 0 {
+		return asset_entity.AuthTypeKey
+	}
+	return authType
+}
+
+func tabbyPrivateKeys(opts tabbyOptions) []string {
+	keys := make([]string, 0, 1+len(opts.PrivateKeys))
+	keys = append(keys, opts.PrivateKey)
+	keys = append(keys, opts.PrivateKeys...)
+
+	privateKeys := make([]string, 0, len(keys))
+	for _, pk := range keys {
+		pk = normalizeTabbyPrivateKey(pk)
+		if pk != "" {
+			privateKeys = append(privateKeys, pk)
+		}
+	}
+	return privateKeys
+}
+
+func normalizeTabbyPrivateKey(path string) string {
+	path = strings.TrimPrefix(strings.TrimSpace(path), "file://")
+	if decoded, err := url.PathUnescape(path); err == nil {
+		path = decoded
+	}
+	if len(path) >= 3 && path[0] == '/' && path[2] == ':' && isASCIIAlpha(path[1]) {
+		path = path[1:]
+	}
+	return path
+}
+
+func isASCIIAlpha(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
 func groupCacheKey(parentID int64, name string) string {

--- a/internal/service/import_svc/tabby_test.go
+++ b/internal/service/import_svc/tabby_test.go
@@ -233,18 +233,6 @@ groups: []
 
 func TestImportTabbySelected(t *testing.T) {
 	Convey("ImportTabbySelected", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mockAssetRepo := mock_asset_repo.NewMockAssetRepo(ctrl)
-		mockGroupRepo := mock_group_repo.NewMockGroupRepo(ctrl)
-		asset_repo.RegisterAsset(mockAssetRepo)
-		group_repo.RegisterGroup(mockGroupRepo)
-		t.Cleanup(func() {
-			asset_repo.RegisterAsset(asset_repo.NewAsset())
-			group_repo.RegisterGroup(group_repo.NewGroup())
-		})
-
 		Convey("key 文件认证导入为 SSH key 认证", func() {
 			data := []byte(`
 profiles:
@@ -258,29 +246,73 @@ profiles:
       privateKey: "file:///C:/Users/me/.ssh/id_rsa"
 `)
 
-			var created *asset_entity.Asset
-			mockAssetRepo.EXPECT().
-				List(gomock.Any(), asset_repo.ListOptions{Type: asset_entity.AssetTypeSSH, GroupID: 0}).
-				Return(nil, nil)
-			mockGroupRepo.EXPECT().List(gomock.Any()).Return(nil, nil)
-			mockAssetRepo.EXPECT().
-				Create(gomock.Any(), gomock.AssignableToTypeOf(&asset_entity.Asset{})).
-				DoAndReturn(func(_ context.Context, asset *asset_entity.Asset) error {
-					created = asset
-					asset.ID = 1
-					return nil
-				})
-
-			result, err := ImportTabbySelected(context.Background(), data, []int{0}, ImportOptions{})
-			So(err, ShouldBeNil)
-			So(result.Success, ShouldEqual, 1)
-			So(created, ShouldNotBeNil)
-
-			sshCfg, err := created.GetSSHConfig()
-			So(err, ShouldBeNil)
+			sshCfg := importSingleTabbySSHProfile(t, data)
 			So(sshCfg.AuthType, ShouldEqual, asset_entity.AuthTypeKey)
 			So(sshCfg.PrivateKeys, ShouldResemble, []string{"C:/Users/me/.ssh/id_rsa"})
 			So(sshCfg.Password, ShouldEqual, "")
 		})
+
+		Convey("Tabby publicKey + privateKeys 数组导入为 SSH key 认证", func() {
+			data := []byte(`
+profiles:
+  - type: ssh
+    name: 测试ssh-key
+    icon: fas fa-desktop
+    options:
+      host: 192.168.8.144
+      algorithms: {}
+      input: {}
+      privateKeys:
+        - file:///Users/codfrm/.ssh/id_rsa
+      auth: publicKey
+    weight: -1
+    id: ssh:custom:ssh-key:dd6e0510-06d2-4f59-9c9c-5f97ed250d8a
+`)
+
+			sshCfg := importSingleTabbySSHProfile(t, data)
+			So(sshCfg.Host, ShouldEqual, "192.168.8.144")
+			So(sshCfg.Username, ShouldEqual, "root")
+			So(sshCfg.AuthType, ShouldEqual, asset_entity.AuthTypeKey)
+			So(sshCfg.PrivateKeys, ShouldResemble, []string{"/Users/codfrm/.ssh/id_rsa"})
+			So(sshCfg.Password, ShouldEqual, "")
+		})
 	})
+}
+
+func importSingleTabbySSHProfile(t *testing.T, data []byte) *asset_entity.SSHConfig {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAssetRepo := mock_asset_repo.NewMockAssetRepo(ctrl)
+	mockGroupRepo := mock_group_repo.NewMockGroupRepo(ctrl)
+	asset_repo.RegisterAsset(mockAssetRepo)
+	group_repo.RegisterGroup(mockGroupRepo)
+	t.Cleanup(func() {
+		asset_repo.RegisterAsset(asset_repo.NewAsset())
+		group_repo.RegisterGroup(group_repo.NewGroup())
+	})
+
+	var created *asset_entity.Asset
+	mockAssetRepo.EXPECT().
+		List(gomock.Any(), asset_repo.ListOptions{Type: asset_entity.AssetTypeSSH, GroupID: 0}).
+		Return(nil, nil)
+	mockGroupRepo.EXPECT().List(gomock.Any()).Return(nil, nil)
+	mockAssetRepo.EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&asset_entity.Asset{})).
+		DoAndReturn(func(_ context.Context, asset *asset_entity.Asset) error {
+			created = asset
+			asset.ID = 1
+			return nil
+		})
+
+	result, err := ImportTabbySelected(context.Background(), data, []int{0}, ImportOptions{})
+	So(err, ShouldBeNil)
+	So(result.Success, ShouldEqual, 1)
+	So(created, ShouldNotBeNil)
+
+	sshCfg, err := created.GetSSHConfig()
+	So(err, ShouldBeNil)
+	return sshCfg
 }

--- a/internal/service/import_svc/tabby_test.go
+++ b/internal/service/import_svc/tabby_test.go
@@ -256,24 +256,24 @@ profiles:
 			data := []byte(`
 profiles:
   - type: ssh
-    name: 测试ssh-key
+    name: tabby-key-profile
     icon: fas fa-desktop
     options:
-      host: 192.168.8.144
+      host: example.internal
       algorithms: {}
       input: {}
       privateKeys:
-        - file:///Users/codfrm/.ssh/id_rsa
+        - file:///home/user/.ssh/id_rsa
       auth: publicKey
     weight: -1
-    id: ssh:custom:ssh-key:dd6e0510-06d2-4f59-9c9c-5f97ed250d8a
+    id: ssh:custom:key-profile:00000000-0000-0000-0000-000000000000
 `)
 
 			sshCfg := importSingleTabbySSHProfile(t, data)
-			So(sshCfg.Host, ShouldEqual, "192.168.8.144")
+			So(sshCfg.Host, ShouldEqual, "example.internal")
 			So(sshCfg.Username, ShouldEqual, "root")
 			So(sshCfg.AuthType, ShouldEqual, asset_entity.AuthTypeKey)
-			So(sshCfg.PrivateKeys, ShouldResemble, []string{"/Users/codfrm/.ssh/id_rsa"})
+			So(sshCfg.PrivateKeys, ShouldResemble, []string{"/home/user/.ssh/id_rsa"})
 			So(sshCfg.Password, ShouldEqual, "")
 		})
 	})

--- a/internal/service/import_svc/tabby_test.go
+++ b/internal/service/import_svc/tabby_test.go
@@ -1,9 +1,16 @@
 package import_svc
 
 import (
+	"context"
 	"testing"
 
+	"github.com/opskat/opskat/internal/model/entity/asset_entity"
+	"github.com/opskat/opskat/internal/repository/asset_repo"
+	"github.com/opskat/opskat/internal/repository/asset_repo/mock_asset_repo"
+	"github.com/opskat/opskat/internal/repository/group_repo"
+	"github.com/opskat/opskat/internal/repository/group_repo/mock_group_repo"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
 	"gopkg.in/yaml.v3"
 )
 
@@ -220,6 +227,60 @@ groups: []
 			So(err, ShouldBeNil)
 			So(cfg.Profiles, ShouldBeEmpty)
 			So(cfg.Groups, ShouldBeEmpty)
+		})
+	})
+}
+
+func TestImportTabbySelected(t *testing.T) {
+	Convey("ImportTabbySelected", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockAssetRepo := mock_asset_repo.NewMockAssetRepo(ctrl)
+		mockGroupRepo := mock_group_repo.NewMockGroupRepo(ctrl)
+		asset_repo.RegisterAsset(mockAssetRepo)
+		group_repo.RegisterGroup(mockGroupRepo)
+		t.Cleanup(func() {
+			asset_repo.RegisterAsset(asset_repo.NewAsset())
+			group_repo.RegisterGroup(group_repo.NewGroup())
+		})
+
+		Convey("key 文件认证导入为 SSH key 认证", func() {
+			data := []byte(`
+profiles:
+  - type: ssh
+    name: key-server
+    options:
+      host: 10.0.0.1
+      port: 2222
+      user: admin
+      auth: privateKey
+      privateKey: "file:///C:/Users/me/.ssh/id_rsa"
+`)
+
+			var created *asset_entity.Asset
+			mockAssetRepo.EXPECT().
+				List(gomock.Any(), asset_repo.ListOptions{Type: asset_entity.AssetTypeSSH, GroupID: 0}).
+				Return(nil, nil)
+			mockGroupRepo.EXPECT().List(gomock.Any()).Return(nil, nil)
+			mockAssetRepo.EXPECT().
+				Create(gomock.Any(), gomock.AssignableToTypeOf(&asset_entity.Asset{})).
+				DoAndReturn(func(_ context.Context, asset *asset_entity.Asset) error {
+					created = asset
+					asset.ID = 1
+					return nil
+				})
+
+			result, err := ImportTabbySelected(context.Background(), data, []int{0}, ImportOptions{})
+			So(err, ShouldBeNil)
+			So(result.Success, ShouldEqual, 1)
+			So(created, ShouldNotBeNil)
+
+			sshCfg, err := created.GetSSHConfig()
+			So(err, ShouldBeNil)
+			So(sshCfg.AuthType, ShouldEqual, asset_entity.AuthTypeKey)
+			So(sshCfg.PrivateKeys, ShouldResemble, []string{"C:/Users/me/.ssh/id_rsa"})
+			So(sshCfg.Password, ShouldEqual, "")
 		})
 	})
 }


### PR DESCRIPTION
## Summary
- 支持 Tabby 的 privateKey 单字段和 privateKey/private_key/publicKey 等认证值
- auth 为空但存在密钥路径时推断为 SSH key 认证
- 归一化 file:// 私钥路径，避免 Windows 路径保存为 /C:/...
- 增加 Tabby key 文件认证导入回归测试

## Tests
- go test ./internal/service/import_svc -run TestImportTabbySelected -count=1 -v
- go test ./internal/service/import_svc -count=1

Closes #159