### PR TITLE
🎨 设置页改用 scrollbar-gutter 预留滚动条槽位,消除切 Tab 抖动

### DIFF
--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -43,7 +43,7 @@ export function SettingsPage() {
       <div className="px-4 py-3 border-b">
         <h2 className="font-semibold">{t("nav.settings")}</h2>
       </div>
-      <div className="flex-1 overflow-y-scroll p-4">
+      <div className="flex-1 overflow-y-auto p-4 scroll-stable">
         <Tabs
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as SettingsTab)}

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -43,7 +43,7 @@ export function SettingsPage() {
       <div className="px-4 py-3 border-b">
         <h2 className="font-semibold">{t("nav.settings")}</h2>
       </div>
-      <div className="flex-1 overflow-y-auto p-4">
+      <div className="flex-1 overflow-y-scroll p-4">
         <Tabs
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as SettingsTab)}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -174,6 +174,14 @@
   .dark .query-table-scroll::-webkit-scrollbar-track {
     background: oklch(0.7 0.01 250 / 5%);
   }
+
+  /* Reserve the scrollbar gutter so toggling scrollability (e.g. switching
+     between settings tabs of differing height) doesn't shift centered content
+     horizontally. The scrollbar still only appears when needed — no empty
+     always-visible track. (#167) */
+  .scroll-stable {
+    scrollbar-gutter: stable;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
优化：Tab 切换导致导致滚动条出现/消失的页面抖动

<img width="998" height="892" alt="PixPin_2026-06-09_02-17-54" src="https://github.com/user-attachments/assets/a80c1d44-dda2-4eed-9825-c090b3b62e60" />
