### PR TITLE
✨ 支持 lrzsz (ZMODEM rz/sz) 终端文件传输

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.0.0",
     "tippy.js": "^6.3.7",
+    "zmodem.js": "^0.1.10",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7
+      zmodem.js:
+        specifier: ^0.1.10
+        version: 0.1.10
       zustand:
         specifier: ^5.0.0
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -2028,6 +2031,11 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
@@ -3222,6 +3230,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zmodem.js@0.1.10:
+    resolution: {integrity: sha512-Z1DWngunZ/j3BmIzSJpFZVNV73iHkj89rxXX4IciJdU9ga3nZ7rJ5LkfjV/QDsKhc7bazDWTTJCLJ+iRXD82dw==}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -4953,6 +4964,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  crc-32@1.2.2: {}
+
   crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
@@ -6412,6 +6425,10 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zmodem.js@0.1.10:
+    dependencies:
+      crc-32: 1.2.2
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/frontend/src/__tests__/zmodemSession.test.ts
+++ b/frontend/src/__tests__/zmodemSession.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createZmodemController } from "../components/terminal/zmodem/zmodemSession";
+import { useSFTPStore } from "../stores/sftpStore";
+import { useTerminalStore } from "../stores/terminalStore";
+import { bytesToBase64 } from "../lib/terminalEncode";
+import {
+  ZmodemBeginDownload,
+  ZmodemAppendChunk,
+  ZmodemFinishDownload,
+  ZmodemPickUploadFiles,
+  ZmodemReadChunk,
+  ZmodemFinishUpload,
+} from "../../wailsjs/go/ssh/SSH";
+import { SFTPCancelTransfer } from "../../wailsjs/go/ssh/SSH";
+import { notifySuccess } from "../lib/notify";
+
+// 用可控的假 Sentry 捕获其 options，便于在测试里驱动 on_detect / to_terminal。
+const hoisted = vi.hoisted(() => ({ sentryOpts: null as unknown as Record<string, (...a: unknown[]) => void> }));
+vi.mock("zmodem.js", () => {
+  class FakeSentry {
+    consume = vi.fn();
+    constructor(opts: Record<string, (...a: unknown[]) => void>) {
+      hoisted.sentryOpts = opts;
+    }
+  }
+  return { default: { Sentry: FakeSentry } };
+});
+
+vi.mock("../lib/notify", () => ({ notifySuccess: vi.fn(), notifyCopied: vi.fn() }));
+vi.mock("../i18n", () => ({ default: { t: (k: string) => k } }));
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function makeReceiveSession() {
+  const handlers: Record<string, (arg?: unknown) => void> = {};
+  return {
+    type: "receive" as const,
+    on: (ev: string, fn: (arg?: unknown) => void) => {
+      handlers[ev] = fn;
+    },
+    start: vi.fn(),
+    abort: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    send_offer: vi.fn(),
+    fire: (ev: string, arg?: unknown) => handlers[ev]?.(arg),
+  };
+}
+
+function makeOffer(details: { name: string; size: number }) {
+  const inputHandlers: Array<(p: number[]) => void> = [];
+  let resolveAccept!: () => void;
+  return {
+    get_details: () => details,
+    on: (ev: string, fn: (p: number[]) => void) => {
+      if (ev === "input") inputHandlers.push(fn);
+    },
+    accept: vi.fn().mockImplementation(() => new Promise<void>((res) => (resolveAccept = res))),
+    skip: vi.fn().mockResolvedValue(undefined),
+    pushInput: (p: number[]) => inputHandlers.forEach((f) => f(p)),
+    finishAccept: () => resolveAccept(),
+  };
+}
+
+function makeSendSession() {
+  return {
+    type: "send" as const,
+    on: vi.fn(),
+    start: vi.fn(),
+    abort: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    send_offer: vi.fn(),
+  };
+}
+
+function makeController() {
+  return createZmodemController({
+    sessionId: "s1",
+    write: vi.fn().mockResolvedValue(undefined),
+    toTerminal: vi.fn(),
+  });
+}
+
+describe("zmodemSession controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.sentryOpts = null as unknown as Record<string, (...a: unknown[]) => void>;
+    useSFTPStore.setState({ transfers: {}, fileManagerOpenTabs: {}, fileManagerPaths: {} });
+    // resolveTarget 用 tabData 把 sessionId 反查 tabId。
+    useTerminalStore.setState({ tabData: { tab1: { panes: { s1: { sessionId: "s1" } } } } } as never);
+  });
+
+  it("forwards bytes to the Sentry and routes Sentry's to_terminal to toTerminal", () => {
+    const toTerminal = vi.fn();
+    const ctrl = createZmodemController({ sessionId: "s1", write: vi.fn().mockResolvedValue(undefined), toTerminal });
+
+    const bytes = new Uint8Array([1, 2, 3]);
+    ctrl.consume(bytes);
+    // consume 透传到假 Sentry。
+    // (FakeSentry.consume 是实例方法 spy，无法直接取，但 to_terminal 路由可验)
+    hoisted.sentryOpts.to_terminal([9, 9]);
+    expect(toTerminal).toHaveBeenCalledWith(new Uint8Array([9, 9]));
+  });
+
+  it("on detect of a receive session: opens file manager and becomes active", () => {
+    const ctrl = makeController();
+    const session = makeReceiveSession();
+    hoisted.sentryOpts.on_detect({ confirm: () => session, deny: vi.fn() });
+
+    expect(ctrl.isActive()).toBe(true);
+    expect(useSFTPStore.getState().fileManagerOpenTabs["tab1"]).toBe(true);
+    expect(session.start).toHaveBeenCalled();
+  });
+
+  it("download: Begin → input→AppendChunk → accept→Finish → notify", async () => {
+    vi.mocked(ZmodemBeginDownload).mockResolvedValue("z-1");
+    makeController();
+    const session = makeReceiveSession();
+    hoisted.sentryOpts.on_detect({ confirm: () => session, deny: vi.fn() });
+
+    const offer = makeOffer({ name: "a.bin", size: 6 });
+    session.fire("offer", offer);
+    await flush();
+
+    expect(ZmodemBeginDownload).toHaveBeenCalledWith("s1", "a.bin", 6);
+    // 进度订阅复用 sftpStore：store 里已建条目。
+    expect(useSFTPStore.getState().transfers["z-1"]).toBeDefined();
+    expect(useSFTPStore.getState().transfers["z-1"].direction).toBe("download");
+
+    offer.pushInput([10, 20, 30]);
+    expect(ZmodemAppendChunk).toHaveBeenCalledWith("z-1", bytesToBase64(new Uint8Array([10, 20, 30])));
+
+    offer.finishAccept();
+    await flush();
+    expect(ZmodemFinishDownload).toHaveBeenCalledWith("z-1");
+    expect(notifySuccess).toHaveBeenCalled();
+  });
+
+  it("download offer skipped when user cancels the save dialog", async () => {
+    vi.mocked(ZmodemBeginDownload).mockResolvedValue(""); // 用户取消
+    makeController();
+    const session = makeReceiveSession();
+    hoisted.sentryOpts.on_detect({ confirm: () => session, deny: vi.fn() });
+
+    const offer = makeOffer({ name: "a.bin", size: 6 });
+    session.fire("offer", offer);
+    await flush();
+
+    expect(offer.skip).toHaveBeenCalled();
+    expect(ZmodemFinishDownload).not.toHaveBeenCalled();
+  });
+
+  it("cancel routing: registered ZMODEM transfer aborts the session, not SFTPCancelTransfer", async () => {
+    vi.mocked(ZmodemBeginDownload).mockResolvedValue("z-1");
+    makeController();
+    const session = makeReceiveSession();
+    hoisted.sentryOpts.on_detect({ confirm: () => session, deny: vi.fn() });
+    const offer = makeOffer({ name: "a.bin", size: 6 });
+    session.fire("offer", offer);
+    await flush();
+
+    useSFTPStore.getState().cancelTransfer("z-1");
+    expect(session.abort).toHaveBeenCalled();
+    expect(SFTPCancelTransfer).not.toHaveBeenCalled();
+
+    // 未注册的 transferId 回落到 SFTP 默认取消。
+    useSFTPStore.getState().cancelTransfer("sftp-x");
+    expect(SFTPCancelTransfer).toHaveBeenCalledWith("sftp-x");
+  });
+
+  it("upload: pick → send_offer → ReadChunk loop → end → Finish", async () => {
+    vi.mocked(ZmodemPickUploadFiles).mockResolvedValue([
+      { transferId: "u-1", name: "f.txt", size: 3, mtime: 0 },
+    ] as never);
+    vi.mocked(ZmodemReadChunk)
+      .mockResolvedValueOnce({ data: bytesToBase64(new Uint8Array([1, 2, 3])), eof: false } as never)
+      .mockResolvedValueOnce({ data: "", eof: true } as never);
+
+    const xfer = { send: vi.fn(), end: vi.fn().mockResolvedValue(undefined) };
+    const session = makeSendSession();
+    session.send_offer.mockResolvedValue(xfer);
+
+    makeController();
+    hoisted.sentryOpts.on_detect({ confirm: () => session, deny: vi.fn() });
+
+    await vi.waitFor(() => expect(ZmodemFinishUpload).toHaveBeenCalledWith("u-1"));
+    expect(session.send_offer).toHaveBeenCalledWith({ name: "f.txt", size: 3, mtime: undefined });
+    expect(xfer.send).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+    expect(xfer.end).toHaveBeenCalled();
+    expect(useSFTPStore.getState().transfers["u-1"]?.direction).toBe("upload");
+  });
+});

--- a/frontend/src/components/terminal/terminalRegistry.ts
+++ b/frontend/src/components/terminal/terminalRegistry.ts
@@ -12,6 +12,7 @@ import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 import { withTerminalFontFallback, withTerminalFontIsolation } from "@/data/terminalFonts";
 import i18n from "@/i18n";
 import { createTerminalInputBridge, type TerminalInputBridge } from "./terminalInputBridge";
+import { createZmodemController, type ZmodemController } from "./zmodem/zmodemSession";
 import { attachXtermRolloverGuard } from "./xtermRolloverGuard";
 import { attachTerminalUrlHighlighter, type TerminalUrlHighlighterController } from "./terminalUrlHighlighter";
 import { normalizeHttpUrl } from "./terminalUrlScan";
@@ -155,8 +156,26 @@ export function getOrCreateTerminal(
     }
   }
 
-  const writeData = (data: string) =>
-    writeFn(sessionId, bytesToBase64(new TextEncoder().encode(data))).catch(console.error);
+  // ZMODEM(lrzsz) 仅在 SSH 终端启用：协议跑在前端 Sentry，截获 sz/rz 字节流并驱动
+  // 上传/下载，进度复用 sftpStore 的传输 UI。serial/local 不启用，保持原样直写终端。
+  const zmodem: ZmodemController | null =
+    transport === "ssh"
+      ? createZmodemController({
+          sessionId,
+          write: writeFn,
+          toTerminal: (bytes) => term.write(bytes),
+        })
+      : null;
+
+  const writeData = (data: string): Promise<void> => {
+    // ZMODEM 传输进行中抑制键盘：协议出站字节走 Sentry 的 sender，不经 onData，
+    // 所以抑制 onData 只挡用户、不挡协议。Ctrl-C 翻译成中止传输。
+    if (zmodem?.isActive()) {
+      if (data === "\x03") zmodem.abort();
+      return Promise.resolve();
+    }
+    return writeFn(sessionId, bytesToBase64(new TextEncoder().encode(data))).catch(console.error);
+  };
 
   const onDataDispose = term.onData(writeData);
 
@@ -167,7 +186,14 @@ export function getOrCreateTerminal(
     const binary = atob(dataB64);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-    term.write(bytes);
+    // SSH 走 ZMODEM Sentry：空闲时它把字节透传到终端（等价 term.write），探测到 sz/rz
+    // 才截获。filterOutput 对 ZMODEM 二进制帧是非破坏性的（仅剥 token 匹配的 OSC，且只在
+    // 提示符渲染时出现），故无需后端改动。详见 internal/service/ssh_svc/dirsync.go:filterOutput。
+    if (zmodem) {
+      zmodem.consume(bytes);
+    } else {
+      term.write(bytes);
+    }
   });
 
   const closedEvent = `${eventPrefix}:closed:${sessionId}`;
@@ -191,6 +217,7 @@ export function getOrCreateTerminal(
       bridge.dispose();
       urlHighlighter.dispose();
       rolloverGuard.dispose();
+      zmodem?.dispose();
       onDataDispose.dispose();
       onKeyDispose.dispose();
       EventsOff(dataEvent);
@@ -217,6 +244,8 @@ export function getOrCreateTerminal(
   });
 
   EventsOn(closedEvent, () => {
+    // 会话中途断开：中止在途 ZMODEM 传输并删除半截下载文件。
+    zmodem?.abort();
     const hint = i18n.t("ssh.session.closedHint");
     term.write(`\r\n\x1b[31m${hint}\x1b[0m\r\n`);
     useTerminalStore.getState().markClosed(sessionId);

--- a/frontend/src/components/terminal/zmodem/zmodemSession.ts
+++ b/frontend/src/components/terminal/zmodem/zmodemSession.ts
@@ -1,0 +1,265 @@
+import Zmodem, { type ZmodemSentry, type ZmodemDetection, type ZmodemSession, type ZmodemOffer } from "zmodem.js";
+import {
+  ZmodemBeginDownload,
+  ZmodemAppendChunk,
+  ZmodemFinishDownload,
+  ZmodemAbortDownload,
+  ZmodemPickUploadFiles,
+  ZmodemReadChunk,
+  ZmodemFinishUpload,
+  ZmodemAbortUpload,
+} from "../../../../wailsjs/go/ssh/SSH";
+import { bytesToBase64 } from "@/lib/terminalEncode";
+import { useSFTPStore, type SFTPTransferTarget } from "@/stores/sftpStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+import { notifySuccess } from "@/lib/notify";
+import i18n from "@/i18n";
+
+// 每次从后端拉取/下发的分块大小。ZMODEM 子包不大，瓶颈在跨 Wails 边界的 base64，
+// 8KB 兼顾内存与事件量。
+const UPLOAD_CHUNK = 8 * 1024;
+
+export interface ZmodemController {
+  /** 把一段终端入站字节喂给 Sentry：非 ZMODEM 透传到终端，ZMODEM 帧被截获驱动协议。 */
+  consume: (bytes: Uint8Array) => void;
+  /** 是否有 ZMODEM 会话进行中（terminalRegistry 据此抑制键盘输入）。 */
+  isActive: () => boolean;
+  /** 主动中止当前会话与在途文件（Ctrl-C / 取消按钮）。 */
+  abort: () => void;
+  /** 终端销毁/会话关闭时调用：中止并清理。 */
+  dispose: () => void;
+}
+
+export interface ZmodemControllerOptions {
+  sessionId: string;
+  write: (sessionId: string, dataB64: string) => Promise<void>;
+  toTerminal: (bytes: Uint8Array) => void;
+}
+
+function toUint8(octets: Uint8Array | number[]): Uint8Array {
+  return octets instanceof Uint8Array ? octets : new Uint8Array(octets);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export function createZmodemController(opts: ZmodemControllerOptions): ZmodemController {
+  const { sessionId, write, toTerminal } = opts;
+
+  let active = false;
+  let currentSession: ZmodemSession | null = null;
+  // 当前在途文件的后端清理回调（下载→AbortDownload 删残file / 上传→AbortUpload 关句柄）。
+  let currentAbort: (() => void) | null = null;
+
+  const sentry: ZmodemSentry = new Zmodem.Sentry({
+    to_terminal: (octets) => toTerminal(toUint8(octets)),
+    sender: (octets) => {
+      write(sessionId, bytesToBase64(toUint8(octets))).catch(console.error);
+    },
+    on_retract: () => {
+      // 握手被收回（探测到的 ZMODEM 其实不是）：无在途状态可清，留待下次。
+    },
+    on_detect: (detection) => handleDetect(detection),
+  });
+
+  function consume(bytes: Uint8Array) {
+    try {
+      sentry.consume(bytes);
+    } catch (e) {
+      // ZMODEM 解析异常：兜底把原始字节写回终端，避免终端因协议错误而卡死。
+      console.error("zmodem sentry consume error", e);
+      toTerminal(bytes);
+    }
+  }
+
+  function resolveTarget(): SFTPTransferTarget {
+    const { tabData } = useTerminalStore.getState();
+    const tabId = Object.keys(tabData).find((id) => Boolean(tabData[id]?.panes[sessionId])) ?? sessionId;
+    return { tabId, sessionId };
+  }
+
+  function cleanup() {
+    active = false;
+    currentSession = null;
+    currentAbort = null;
+  }
+
+  function abort() {
+    // 先捕获再清空，避免 session.abort() 同步触发 session_end→cleanup 把 currentAbort 抢先置空，
+    // 导致后端残file 清理被跳过。
+    const backendAbort = currentAbort;
+    const session = currentSession;
+    currentAbort = null;
+    if (session) {
+      try {
+        session.abort();
+      } catch (e) {
+        console.error("zmodem session abort error", e);
+      }
+    }
+    if (backendAbort) backendAbort();
+  }
+
+  function handleDetect(detection: ZmodemDetection) {
+    let session: ZmodemSession;
+    try {
+      session = detection.confirm();
+    } catch (e) {
+      console.error("zmodem confirm failed", e);
+      return;
+    }
+    active = true;
+    currentSession = session;
+
+    // 传输开始即打开文件管理面板，复用其中的 TransferSection 显示进度。
+    const target = resolveTarget();
+    useSFTPStore.getState().openFileManager(target.tabId);
+
+    session.on("session_end", () => cleanup());
+
+    if (session.type === "receive") {
+      startReceive(session, target);
+    } else {
+      void startSend(session, target);
+    }
+  }
+
+  // --- 下载：远端 sz ---
+
+  function startReceive(session: ZmodemSession, target: SFTPTransferTarget) {
+    session.on("offer", (offer) => {
+      void handleOffer(offer, target);
+    });
+    session.start();
+  }
+
+  async function handleOffer(offer: ZmodemOffer, target: SFTPTransferTarget) {
+    const details = offer.get_details();
+    const name = details.name;
+    const size = Number(details.size ?? 0);
+
+    let transferId = "";
+    try {
+      // 弹原生 Save 对话框并创建文件；用户取消时返回空串。
+      transferId = await ZmodemBeginDownload(sessionId, name, size);
+    } catch (e) {
+      console.error("zmodem begin download failed", e);
+    }
+    if (!transferId) {
+      await offer.skip();
+      return;
+    }
+
+    useSFTPStore.getState().subscribeExternalTransfer(transferId, target, "download", () => abort());
+    currentAbort = () => {
+      ZmodemAbortDownload(transferId).catch(console.error);
+    };
+
+    offer.on("input", (payload) => {
+      ZmodemAppendChunk(transferId, bytesToBase64(toUint8(payload))).catch(console.error);
+    });
+
+    try {
+      await offer.accept();
+      await ZmodemFinishDownload(transferId);
+      notifySuccess(i18n.t("zmodem.downloadComplete", { name }));
+    } catch (e) {
+      console.error("zmodem receive offer failed", e);
+      await ZmodemAbortDownload(transferId).catch(console.error);
+    } finally {
+      currentAbort = null;
+    }
+  }
+
+  // --- 上传：远端 rz ---
+
+  async function startSend(session: ZmodemSession, target: SFTPTransferTarget) {
+    let files: Array<{ transferId: string; name: string; size: number; mtime: number }> = [];
+    try {
+      // 弹原生多选对话框并逐个打开句柄；用户取消返回空列表。
+      files = await ZmodemPickUploadFiles(sessionId);
+    } catch (e) {
+      console.error("zmodem pick upload files failed", e);
+    }
+    if (!files || files.length === 0) {
+      try {
+        await session.close();
+      } catch (e) {
+        console.error("zmodem session close error", e);
+      }
+      return;
+    }
+
+    for (const f of files) {
+      await sendOne(session, f, target);
+    }
+
+    try {
+      await session.close();
+    } catch (e) {
+      console.error("zmodem session close error", e);
+    }
+  }
+
+  async function sendOne(
+    session: ZmodemSession,
+    f: { transferId: string; name: string; size: number; mtime: number },
+    target: SFTPTransferTarget
+  ) {
+    const transferId = f.transferId;
+    let xfer;
+    try {
+      xfer = await session.send_offer({
+        name: f.name,
+        size: Number(f.size ?? 0),
+        mtime: f.mtime ? Number(f.mtime) : undefined,
+      });
+    } catch (e) {
+      console.error("zmodem send_offer failed", e);
+      await ZmodemAbortUpload(transferId).catch(console.error);
+      return;
+    }
+    if (!xfer) {
+      // 对端跳过该文件：关闭句柄，不计入传输列表。
+      await ZmodemAbortUpload(transferId).catch(console.error);
+      return;
+    }
+
+    useSFTPStore.getState().subscribeExternalTransfer(transferId, target, "upload", () => abort());
+    currentAbort = () => {
+      ZmodemAbortUpload(transferId).catch(console.error);
+    };
+
+    try {
+      let eof = false;
+      while (!eof) {
+        const chunk = await ZmodemReadChunk(transferId, UPLOAD_CHUNK);
+        const bytes = base64ToBytes(chunk.data);
+        if (bytes.length > 0) xfer.send(bytes);
+        eof = chunk.eof;
+      }
+      await xfer.end();
+      await ZmodemFinishUpload(transferId);
+      notifySuccess(i18n.t("zmodem.uploadComplete", { name: f.name }));
+    } catch (e) {
+      console.error("zmodem send file failed", e);
+      await ZmodemAbortUpload(transferId).catch(console.error);
+    } finally {
+      currentAbort = null;
+    }
+  }
+
+  return {
+    consume,
+    isActive: () => active,
+    abort,
+    dispose: () => {
+      abort();
+      cleanup();
+    },
+  };
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1484,6 +1484,10 @@
     "sessionOps": "{{count}} ops",
     "sessionPatterns": "Session approved patterns"
   },
+  "zmodem": {
+    "downloadComplete": "Received {{name}}",
+    "uploadComplete": "Sent {{name}}"
+  },
   "sftp": {
     "upload": "Upload File",
     "uploadDir": "Upload Folder",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1484,6 +1484,10 @@
     "sessionOps": "{{count}} 条操作",
     "sessionPatterns": "会话已允许模式"
   },
+  "zmodem": {
+    "downloadComplete": "{{name}} 接收完成",
+    "uploadComplete": "{{name}} 发送完成"
+  },
   "sftp": {
     "upload": "上传文件",
     "uploadDir": "上传文件夹",

--- a/frontend/src/stores/sftpStore.ts
+++ b/frontend/src/stores/sftpStore.ts
@@ -34,6 +34,12 @@ const DEFAULT_FILE_MANAGER_WIDTH = 280;
 const MIN_FILE_MANAGER_WIDTH = 200;
 const MAX_FILE_MANAGER_WIDTH = 600;
 
+// ZMODEM 这类"前端驱动协议、后端只做本地文件 IO"的传输，取消逻辑（中止 zmodem.js 会话
+// + 后端 Abort）和 SFTP 不同，没法走 SFTPCancelTransfer。这里按 transferId 注册各自的取消
+// 回调，cancelTransfer 查表分派、查不到再回落 SFTP 默认取消。extend-by-registration，
+// 避免在共享的 cancelTransfer 里按传输类型字符串分支。
+const cancelHandlers = new Map<string, () => void>();
+
 interface SFTPState {
   transfers: Record<string, SFTPTransfer>;
 
@@ -47,6 +53,13 @@ interface SFTPState {
   startUploadFile: (target: SFTPTransferTarget, localPath: string, remotePath: string) => Promise<string | null>;
   startDownload: (target: SFTPTransferTarget, remotePath: string) => Promise<string | null>;
   startDownloadDir: (target: SFTPTransferTarget, remotePath: string) => Promise<string | null>;
+  /** 登记一个外部驱动（如 ZMODEM）的传输：复用进度订阅 + 注册其专属取消回调。 */
+  subscribeExternalTransfer: (
+    transferId: string,
+    target: SFTPTransferTarget,
+    direction: "upload" | "download",
+    onCancel: () => void
+  ) => void;
   cancelTransfer: (transferId: string) => void;
   clearTransfer: (transferId: string) => void;
   clearCompleted: () => void;
@@ -56,6 +69,8 @@ interface SFTPState {
   getTabTransfers: (tabId: string) => SFTPTransfer[];
 
   toggleFileManager: (tabId: string) => void;
+  /** 幂等打开文件管理面板（ZMODEM 传输开始时用，确保进度 UI 可见）。 */
+  openFileManager: (tabId: string) => void;
   setFileManagerPath: (tabId: string, path: string) => void;
   setFileManagerWidth: (width: number) => void;
 }
@@ -87,7 +102,7 @@ function subscribeProgress(
     },
   }));
 
-  const eventName = "sftp:progress:" + transferId;
+  const eventName = "transfer:progress:" + transferId;
   EventsOn(
     eventName,
     (event: {
@@ -129,6 +144,7 @@ function subscribeProgress(
               [transferId]: { ...existing, status: "done" },
             },
           }));
+          cancelHandlers.delete(transferId);
           EventsOff(eventName);
           // 5 秒后自动清除已完成的传输
           setTimeout(() => {
@@ -141,6 +157,17 @@ function subscribeProgress(
             }
           }, 5000);
           break;
+        case "cancelled":
+          // ZMODEM 取消由后端显式发 "cancelled"（SFTP 则走下面 error 分支按消息推断）。
+          set((state) => ({
+            transfers: {
+              ...state.transfers,
+              [transferId]: { ...existing, status: "cancelled" },
+            },
+          }));
+          cancelHandlers.delete(transferId);
+          EventsOff(eventName);
+          break;
         case "error":
           set((state) => ({
             transfers: {
@@ -152,6 +179,7 @@ function subscribeProgress(
               },
             },
           }));
+          cancelHandlers.delete(transferId);
           EventsOff(eventName);
           break;
       }
@@ -200,11 +228,22 @@ export const useSFTPStore = create<SFTPState>((set, get) => ({
     return transferId;
   },
 
+  subscribeExternalTransfer: (transferId, target, direction, onCancel) => {
+    cancelHandlers.set(transferId, onCancel);
+    subscribeProgress(transferId, target, direction, set, get);
+  },
+
   cancelTransfer: (transferId) => {
+    const handler = cancelHandlers.get(transferId);
+    if (handler) {
+      handler();
+      return;
+    }
     SFTPCancelTransfer(transferId);
   },
 
   clearTransfer: (transferId) => {
+    cancelHandlers.delete(transferId);
     set((state) => {
       const { [transferId]: _, ...rest } = state.transfers;
       return { transfers: rest };
@@ -262,6 +301,15 @@ export const useSFTPStore = create<SFTPState>((set, get) => ({
         [tabId]: !state.fileManagerOpenTabs[tabId],
       },
     }));
+  },
+
+  openFileManager: (tabId) => {
+    set((state) => {
+      if (state.fileManagerOpenTabs[tabId]) return state;
+      return {
+        fileManagerOpenTabs: { ...state.fileManagerOpenTabs, [tabId]: true },
+      };
+    });
   },
 
   setFileManagerPath: (tabId, path) => {

--- a/frontend/src/types/zmodem.d.ts
+++ b/frontend/src/types/zmodem.d.ts
@@ -1,0 +1,71 @@
+// zmodem.js (FGasper) 没有自带类型，也没有 @types 包。这里只声明本项目实际用到的
+// 那一小片 API（Sentry / 收发 Session / Offer / Transfer），覆盖 strict 下的类型检查。
+// 入口用包根 index.js（导出 Sentry + Session），不用 dist 浏览器 bundle（它依赖 window）。
+declare module "zmodem.js" {
+  /** 文件元信息：offer.get_details() 返回 / send_offer() 入参。 */
+  export interface ZmodemFileDetails {
+    name: string;
+    size: number;
+    mtime?: number | Date | null;
+    mode?: number | null;
+    files_remaining?: number;
+    bytes_remaining?: number;
+  }
+
+  /** 接收会话里的一个待接收文件。 */
+  export interface ZmodemOffer {
+    get_details(): ZmodemFileDetails;
+    on(event: "input", handler: (payload: Uint8Array | number[]) => void): void;
+    /** 接受并开始接收，Promise 在该文件接收完成时 resolve。 */
+    accept(opts?: { on_input?: (payload: Uint8Array | number[]) => void }): Promise<void>;
+    skip(): Promise<void> | void;
+  }
+
+  /** 发送会话里 send_offer 被对端接受后返回的传输对象。 */
+  export interface ZmodemTransfer {
+    send(chunk: Uint8Array | number[]): void;
+    end(chunk?: Uint8Array | number[]): Promise<void>;
+  }
+
+  export interface ZmodemSession {
+    type: "receive" | "send";
+    on(event: "offer", handler: (offer: ZmodemOffer) => void): void;
+    on(event: "session_end", handler: () => void): void;
+    /** 接收会话：开始接收。 */
+    start(): void;
+    /** 发送会话：所有文件发完后关闭。 */
+    close(): Promise<void> | void;
+    /** 中止整个会话（发 ZABORT）。 */
+    abort(): void;
+    /** 发送会话：提交一个待发送文件，对端跳过时 resolve 为 undefined。 */
+    send_offer(params: ZmodemFileDetails): Promise<ZmodemTransfer | undefined>;
+  }
+
+  /** on_detect 回调拿到的检测对象：确认或拒绝一个 ZMODEM 会话。 */
+  export interface ZmodemDetection {
+    confirm(): ZmodemSession;
+    deny(): void;
+  }
+
+  export interface ZmodemSentryOptions {
+    to_terminal: (octets: Uint8Array | number[]) => void;
+    sender: (octets: Uint8Array | number[]) => void;
+    on_detect: (detection: ZmodemDetection) => void;
+    on_retract: () => void;
+  }
+
+  export interface ZmodemSentry {
+    consume(input: Uint8Array | number[]): void;
+  }
+
+  interface ZmodemSentryConstructor {
+    new (options: ZmodemSentryOptions): ZmodemSentry;
+  }
+
+  interface ZmodemModule {
+    Sentry: ZmodemSentryConstructor;
+  }
+
+  const Zmodem: ZmodemModule;
+  export default Zmodem;
+}

--- a/internal/app/ssh/sftp.go
+++ b/internal/app/ssh/sftp.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opskat/opskat/internal/pkg/transfer"
 	"github.com/opskat/opskat/internal/service/sftp_svc"
 
 	"github.com/cago-frame/cago/pkg/logger"
@@ -46,18 +47,18 @@ func (s *SSH) SFTPUpload(sessionID, remotePath string) (string, error) {
 
 	transferID := s.sftp.GenerateTransferID()
 	go func() {
-		err := s.sftp.Upload(s.ctx, transferID, sessionID, localPath, remotePath, func(p sftp_svc.TransferProgress) {
-			wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, p)
+		err := s.sftp.Upload(s.ctx, transferID, sessionID, localPath, remotePath, func(p transfer.Progress) {
+			wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, p)
 		})
 		if err != nil {
-			wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, sftp_svc.TransferProgress{
+			wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, transfer.Progress{
 				TransferID: transferID,
 				Status:     "error",
 				Error:      err.Error(),
 			})
 			return
 		}
-		wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, sftp_svc.TransferProgress{
+		wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, transfer.Progress{
 			TransferID: transferID,
 			Status:     "done",
 		})
@@ -85,18 +86,18 @@ func (s *SSH) SFTPUploadDir(sessionID, remotePath string) (string, error) {
 
 	transferID := s.sftp.GenerateTransferID()
 	go func() {
-		err := s.sftp.UploadDir(s.ctx, transferID, sessionID, localDir, remotePath, func(p sftp_svc.TransferProgress) {
-			wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, p)
+		err := s.sftp.UploadDir(s.ctx, transferID, sessionID, localDir, remotePath, func(p transfer.Progress) {
+			wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, p)
 		})
 		if err != nil {
-			wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, sftp_svc.TransferProgress{
+			wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, transfer.Progress{
 				TransferID: transferID,
 				Status:     "error",
 				Error:      err.Error(),
 			})
 			return
 		}
-		wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, sftp_svc.TransferProgress{
+		wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, transfer.Progress{
 			TransferID: transferID,
 			Status:     "done",
 		})
@@ -120,18 +121,18 @@ func (s *SSH) SFTPDownload(sessionID, remotePath string) (string, error) {
 
 	transferID := s.sftp.GenerateTransferID()
 	go func() {
-		err := s.sftp.Download(s.ctx, transferID, sessionID, remotePath, localPath, func(p sftp_svc.TransferProgress) {
-			wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, p)
+		err := s.sftp.Download(s.ctx, transferID, sessionID, remotePath, localPath, func(p transfer.Progress) {
+			wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, p)
 		})
 		if err != nil {
-			wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, sftp_svc.TransferProgress{
+			wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, transfer.Progress{
 				TransferID: transferID,
 				Status:     "error",
 				Error:      err.Error(),
 			})
 			return
 		}
-		wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, sftp_svc.TransferProgress{
+		wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, transfer.Progress{
 			TransferID: transferID,
 			Status:     "done",
 		})
@@ -155,18 +156,18 @@ func (s *SSH) SFTPDownloadDir(sessionID, remotePath string) (string, error) {
 
 	transferID := s.sftp.GenerateTransferID()
 	go func() {
-		err := s.sftp.DownloadDir(s.ctx, transferID, sessionID, remotePath, localDir, func(p sftp_svc.TransferProgress) {
-			wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, p)
+		err := s.sftp.DownloadDir(s.ctx, transferID, sessionID, remotePath, localDir, func(p transfer.Progress) {
+			wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, p)
 		})
 		if err != nil {
-			wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, sftp_svc.TransferProgress{
+			wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, transfer.Progress{
 				TransferID: transferID,
 				Status:     "error",
 				Error:      err.Error(),
 			})
 			return
 		}
-		wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, sftp_svc.TransferProgress{
+		wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, transfer.Progress{
 			TransferID: transferID,
 			Status:     "done",
 		})
@@ -182,15 +183,15 @@ func (s *SSH) SFTPUploadFile(sessionID, localPath, remotePath string) (string, e
 	}
 
 	transferID := s.sftp.GenerateTransferID()
-	emitProgress := func(p sftp_svc.TransferProgress) {
-		wailsRuntime.EventsEmit(s.ctx, "sftp:progress:"+transferID, p)
+	emitProgress := func(p transfer.Progress) {
+		wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+transferID, p)
 	}
 	emitDone := func(err error) {
 		if err != nil {
-			emitProgress(sftp_svc.TransferProgress{TransferID: transferID, Status: "error", Error: err.Error()})
+			emitProgress(transfer.Progress{TransferID: transferID, Status: "error", Error: err.Error()})
 			return
 		}
-		emitProgress(sftp_svc.TransferProgress{TransferID: transferID, Status: "done"})
+		emitProgress(transfer.Progress{TransferID: transferID, Status: "done"})
 	}
 
 	if info.IsDir() {

--- a/internal/app/ssh/ssh.go
+++ b/internal/app/ssh/ssh.go
@@ -6,11 +6,15 @@ import (
 	"sync"
 
 	"github.com/opskat/opskat/internal/model/entity/asset_entity"
+	"github.com/opskat/opskat/internal/pkg/transfer"
 	"github.com/opskat/opskat/internal/service/conntest"
 	"github.com/opskat/opskat/internal/service/sessionid"
 	"github.com/opskat/opskat/internal/service/sftp_svc"
 	"github.com/opskat/opskat/internal/service/ssh_svc"
+	"github.com/opskat/opskat/internal/service/zmodem_svc"
 	"github.com/opskat/opskat/internal/sshpool"
+
+	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 // LangProvider 由 system binder 实现，提供当前 UI 语言。
@@ -42,6 +46,7 @@ type SSH struct {
 
 	manager        *ssh_svc.Manager
 	sftp           *sftp_svc.Service
+	zmodem         *zmodem_svc.FileBridge
 	pool           *sshpool.Pool
 	forwardManager *ForwardManager
 
@@ -62,6 +67,11 @@ func New(appCtx context.Context, lang LangProvider, mgr *ssh_svc.Manager, sftp *
 		pool:      pool,
 		connIDGen: sessionid.NewGenerator("conn"),
 	}
+	// ZMODEM 文件桥的进度复用 SFTP 同一套 "transfer:progress:<id>" 事件管线。
+	// emit 在调用时才读 s.ctx（Startup 注入），传输总发生在 Startup 之后，故安全。
+	s.zmodem = zmodem_svc.New(func(p transfer.Progress) {
+		wailsRuntime.EventsEmit(s.ctx, "transfer:progress:"+p.TransferID, p)
+	})
 	s.forwardManager = NewForwardManager(&poolDialer{})
 	conntest.Register(asset_entity.AssetTypeSSH, s.testConnection)
 	return s

--- a/internal/app/ssh/zmodem.go
+++ b/internal/app/ssh/zmodem.go
@@ -1,0 +1,129 @@
+package ssh
+
+import (
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+
+	"github.com/opskat/opskat/internal/pkg/transfer"
+
+	"github.com/cago-frame/cago/pkg/logger"
+	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
+	"go.uber.org/zap"
+)
+
+// --- ZMODEM(lrzsz) 文件传输 ---
+//
+// 协议跑在前端 zmodem.js，这里只做两件事：弹原生对话框拿本地路径、把分块读写转发给
+// zmodem_svc.FileBridge。进度由 FileBridge 经注入的 emit 发到 "transfer:progress:<id>"，
+// 与 SFTP 复用同一前端订阅管线。所有跨边界的字节都按 base64 传，与 WriteSSH 一致。
+
+// ZmodemUploadFile 是一个待上传文件的句柄信息，回传给前端逐个 send_offer。
+type ZmodemUploadFile struct {
+	TransferID string `json:"transferId"`
+	Name       string `json:"name"`
+	Size       int64  `json:"size"`
+	Mtime      int64  `json:"mtime"` // Unix 秒
+}
+
+// ZmodemChunk 是一次上传读块的结果：base64 数据 + 是否已读到文件尾。
+type ZmodemChunk struct {
+	Data string `json:"data"` // base64
+	EOF  bool   `json:"eof"`
+}
+
+// ZmodemBeginDownload 弹原生 Save 对话框并创建本地文件，返回 transferID。
+// 用户取消对话框时返回空字符串（前端据此 offer.skip()）。
+func (s *SSH) ZmodemBeginDownload(sessionID, suggestedName string, size int64) (string, error) {
+	localPath, err := wailsRuntime.SaveFileDialog(s.ctx, wailsRuntime.SaveDialogOptions{
+		DefaultFilename: suggestedName,
+		Title:           "保存接收的文件",
+	})
+	if err != nil {
+		return "", fmt.Errorf("保存文件对话框失败: %w", err)
+	}
+	if localPath == "" {
+		return "", nil // 用户取消
+	}
+
+	transferID := transfer.GenerateID("zmodem")
+	if err := s.zmodem.BeginDownload(transferID, localPath, size); err != nil {
+		return "", err
+	}
+	logger.Default().Info("zmodem download begin",
+		zap.String("sessionID", sessionID), zap.String("transferID", transferID),
+		zap.String("path", localPath), zap.Int64("size", size))
+	return transferID, nil
+}
+
+// ZmodemAppendChunk 把一段已接收的 base64 字节追加写入下载文件。
+func (s *SSH) ZmodemAppendChunk(transferID, dataB64 string) error {
+	data, err := base64.StdEncoding.DecodeString(dataB64)
+	if err != nil {
+		return fmt.Errorf("解码下载分块失败: %w", err)
+	}
+	return s.zmodem.AppendChunk(transferID, data)
+}
+
+// ZmodemFinishDownload 关闭下载文件，置 done。
+func (s *SSH) ZmodemFinishDownload(transferID string) error {
+	logger.Default().Info("zmodem download finish", zap.String("transferID", transferID))
+	return s.zmodem.FinishDownload(transferID)
+}
+
+// ZmodemAbortDownload 取消下载：删除半截文件，置为已取消状态。
+func (s *SSH) ZmodemAbortDownload(transferID string) error {
+	logger.Default().Info("zmodem download abort", zap.String("transferID", transferID))
+	return s.zmodem.AbortDownload(transferID)
+}
+
+// ZmodemPickUploadFiles 弹原生多选对话框，逐个打开并登记上传句柄，返回文件列表。
+// 用户取消时返回空列表（前端据此 session.close()）。
+func (s *SSH) ZmodemPickUploadFiles(sessionID string) ([]ZmodemUploadFile, error) {
+	paths, err := wailsRuntime.OpenMultipleFilesDialog(s.ctx, wailsRuntime.OpenDialogOptions{
+		Title: "选择上传文件",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("打开文件对话框失败: %w", err)
+	}
+
+	files := make([]ZmodemUploadFile, 0, len(paths))
+	for _, p := range paths {
+		transferID := transfer.GenerateID("zmodem")
+		size, mtime, openErr := s.zmodem.OpenUpload(transferID, p)
+		if openErr != nil {
+			logger.Default().Warn("zmodem open upload file", zap.String("path", p), zap.Error(openErr))
+			continue
+		}
+		files = append(files, ZmodemUploadFile{
+			TransferID: transferID,
+			Name:       filepath.Base(p),
+			Size:       size,
+			Mtime:      mtime,
+		})
+	}
+	logger.Default().Info("zmodem upload pick",
+		zap.String("sessionID", sessionID), zap.Int("count", len(files)))
+	return files, nil
+}
+
+// ZmodemReadChunk 读取至多 n 字节的上传内容，base64 返回，并标记是否读到文件尾。
+func (s *SSH) ZmodemReadChunk(transferID string, n int) (ZmodemChunk, error) {
+	data, eof, err := s.zmodem.ReadChunk(transferID, n)
+	if err != nil {
+		return ZmodemChunk{}, err
+	}
+	return ZmodemChunk{Data: base64.StdEncoding.EncodeToString(data), EOF: eof}, nil
+}
+
+// ZmodemFinishUpload 关闭上传读句柄，置 done。
+func (s *SSH) ZmodemFinishUpload(transferID string) error {
+	logger.Default().Info("zmodem upload finish", zap.String("transferID", transferID))
+	return s.zmodem.FinishUpload(transferID)
+}
+
+// ZmodemAbortUpload 取消上传：关闭读句柄（不删本地源文件），置为已取消状态。
+func (s *SSH) ZmodemAbortUpload(transferID string) error {
+	logger.Default().Info("zmodem upload abort", zap.String("transferID", transferID))
+	return s.zmodem.AbortUpload(transferID)
+}

--- a/internal/pkg/transfer/transfer.go
+++ b/internal/pkg/transfer/transfer.go
@@ -1,0 +1,88 @@
+// Package transfer 提供文件传输的通用进度原语：进度事件结构、唯一传输 ID 生成、
+// 以及"节流 + 测速"的进度上报器。SFTP、ZMODEM(lrzsz) 等所有文件传输共用一套，
+// 避免各自重复实现节流/测速逻辑，也让前端订阅同一份进度事件形状。
+package transfer
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// 传输状态。值与前端 SFTPTransfer.status 枚举对齐，是前后端的唯一约定来源。
+const (
+	StatusProgress  = "progress"
+	StatusDone      = "done"
+	StatusError     = "error"
+	StatusCancelled = "cancelled" //nolint:misspell // 与前端 SFTPTransfer.status 枚举对齐（沿用英式拼写）
+)
+
+// Progress 是一次传输的进度快照，经 Wails 事件 "transfer:progress:<id>" 发往前端。
+// JSON tag 与前端 SFTPTransfer 一一对应，新增传输来源（如 ZMODEM）直接复用。
+type Progress struct {
+	TransferID     string `json:"transferId"`
+	Status         string `json:"status"` // "progress" | "done" | "error"
+	CurrentFile    string `json:"currentFile"`
+	FilesCompleted int    `json:"filesCompleted"`
+	FilesTotal     int    `json:"filesTotal"`
+	BytesDone      int64  `json:"bytesDone"`
+	BytesTotal     int64  `json:"bytesTotal"`
+	Speed          int64  `json:"speed"` // bytes/sec
+	Error          string `json:"error,omitempty"`
+}
+
+var idCounter atomic.Int64
+
+// GenerateID 生成全局唯一的传输 ID，prefix 标识来源（"sftp" / "zmodem"），
+// 便于日志溯源与前端按前缀区分。
+func GenerateID(prefix string) string {
+	return fmt.Sprintf("%s-%d-%d", prefix, time.Now().UnixNano(), idCounter.Add(1))
+}
+
+const defaultMinInterval = 100 * time.Millisecond
+
+// Reporter 把高频的字节进度收敛成"每 100ms 一条 + 整体平均速率"的进度事件。
+// 每个传输持有独立 Reporter；同一传输的 Report 调用必须串行（拷贝循环 / 单链 await
+// 天然满足），因此内部不加锁。"done"/"error" 等终态不受节流影响、立即发出。
+type Reporter struct {
+	emit        func(Progress)
+	now         func() time.Time
+	start       time.Time
+	lastEmit    time.Time // 零值表示尚未发过 progress，首条立即放行
+	minInterval time.Duration
+}
+
+// NewReporter 创建一个以真实时钟计时的进度上报器。
+func NewReporter(emit func(Progress)) *Reporter {
+	return newReporter(emit, time.Now)
+}
+
+// newReporter 允许注入时钟，便于在测试里确定性地验证节流与测速。
+func newReporter(emit func(Progress), now func() time.Time) *Reporter {
+	return &Reporter{
+		emit:        emit,
+		now:         now,
+		start:       now(),
+		minInterval: defaultMinInterval,
+	}
+}
+
+// Report 上报一次进度。"progress" 状态按 minInterval 节流并补齐平均速率；
+// 其余终态（done/error）立即发出。
+func (r *Reporter) Report(p Progress) {
+	if p.Status != "progress" {
+		r.emit(p)
+		return
+	}
+
+	now := r.now()
+	if !r.lastEmit.IsZero() && now.Sub(r.lastEmit) < r.minInterval {
+		return
+	}
+	r.lastEmit = now
+
+	if elapsed := now.Sub(r.start).Seconds(); elapsed > 0 {
+		p.Speed = int64(float64(p.BytesDone) / elapsed)
+	}
+	r.emit(p)
+}

--- a/internal/pkg/transfer/transfer_test.go
+++ b/internal/pkg/transfer/transfer_test.go
@@ -1,0 +1,62 @@
+package transfer
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateIDUniqueAndPrefixed(t *testing.T) {
+	a := GenerateID("sftp")
+	b := GenerateID("sftp")
+	if a == b {
+		t.Fatalf("expected unique ids, got %q == %q", a, b)
+	}
+	if !strings.HasPrefix(a, "sftp-") {
+		t.Fatalf("expected prefix sftp-, got %q", a)
+	}
+	if z := GenerateID("zmodem"); !strings.HasPrefix(z, "zmodem-") {
+		t.Fatalf("expected prefix zmodem-, got %q", z)
+	}
+}
+
+func TestReporterThrottleAndSpeed(t *testing.T) {
+	cur := time.Unix(0, 0)
+	clock := func() time.Time { return cur }
+	var got []Progress
+	r := newReporter(func(p Progress) { got = append(got, p) }, clock)
+
+	// t=0: 首条 progress 立即放行（此时 elapsed=0，速率仍为 0）。
+	r.Report(Progress{Status: "progress", BytesDone: 100})
+	// t=50ms: 距上次不足 100ms，被节流丢弃。
+	cur = cur.Add(50 * time.Millisecond)
+	r.Report(Progress{Status: "progress", BytesDone: 200})
+	// t=150ms: 放行，平均速率 = 300 bytes / 0.15s = 2000 bytes/s。
+	cur = cur.Add(100 * time.Millisecond)
+	r.Report(Progress{Status: "progress", BytesDone: 300})
+
+	if len(got) != 2 {
+		t.Fatalf("want 2 progress emits (throttled), got %d", len(got))
+	}
+	if got[0].Speed != 0 {
+		t.Fatalf("want first speed 0, got %d", got[0].Speed)
+	}
+	if got[1].Speed != 2000 {
+		t.Fatalf("want speed 2000, got %d", got[1].Speed)
+	}
+}
+
+func TestReporterEmitsTerminalImmediately(t *testing.T) {
+	cur := time.Unix(0, 0)
+	clock := func() time.Time { return cur }
+	var statuses []string
+	r := newReporter(func(p Progress) { statuses = append(statuses, p.Status) }, clock)
+
+	r.Report(Progress{Status: "progress", BytesDone: 1}) // 立即
+	r.Report(Progress{Status: "progress", BytesDone: 2}) // 同一时刻，被节流
+	r.Report(Progress{Status: "done"})                   // 终态，不受节流，立即
+
+	if len(statuses) != 2 || statuses[0] != "progress" || statuses[1] != "done" {
+		t.Fatalf("want [progress done], got %v", statuses)
+	}
+}

--- a/internal/service/sftp_svc/sftp.go
+++ b/internal/service/sftp_svc/sftp.go
@@ -13,10 +13,10 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/opskat/opskat/internal/pkg/dirsync"
+	"github.com/opskat/opskat/internal/pkg/transfer"
 	"github.com/opskat/opskat/internal/service/ssh_svc"
 
 	"github.com/cago-frame/cago/pkg/logger"
@@ -27,25 +27,11 @@ import (
 // MaxReadFileSize limits full-file reads used by desktop features such as external edit.
 const MaxReadFileSize int64 = 10 * 1024 * 1024
 
-// TransferProgress 传输进度事件
-type TransferProgress struct {
-	TransferID     string `json:"transferId"`
-	Status         string `json:"status"` // "progress" | "done" | "error"
-	CurrentFile    string `json:"currentFile"`
-	FilesCompleted int    `json:"filesCompleted"`
-	FilesTotal     int    `json:"filesTotal"`
-	BytesDone      int64  `json:"bytesDone"`
-	BytesTotal     int64  `json:"bytesTotal"`
-	Speed          int64  `json:"speed"` // bytes/sec
-	Error          string `json:"error,omitempty"`
-}
-
 // Service SFTP 文件传输服务
 type Service struct {
 	sshManager              *ssh_svc.Manager
 	clients                 sync.Map // sessionID -> *sftp.Client
 	cancels                 sync.Map // transferID -> context.CancelFunc
-	counter                 atomic.Int64
 	maxReadFileSizeProvider func() int64
 }
 
@@ -82,7 +68,7 @@ func (s *Service) maxReadFileSize() int64 {
 
 // GenerateTransferID 生成唯一传输 ID
 func (s *Service) GenerateTransferID() string {
-	return fmt.Sprintf("sftp-%d-%d", time.Now().UnixNano(), s.counter.Add(1))
+	return transfer.GenerateID("sftp")
 }
 
 // getSFTPClient 获取或创建 SFTP 客户端（懒加载）
@@ -338,7 +324,7 @@ func (s *Service) WriteFile(sessionID, remotePath string, data []byte) error {
 }
 
 // Upload 上传单个文件
-func (s *Service) Upload(ctx context.Context, transferID, sessionID, localPath, remotePath string, onProgress func(TransferProgress)) error {
+func (s *Service) Upload(ctx context.Context, transferID, sessionID, localPath, remotePath string, onProgress func(transfer.Progress)) error {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancels.Store(transferID, cancel)
 	defer func() {
@@ -380,7 +366,7 @@ func (s *Service) Upload(ctx context.Context, transferID, sessionID, localPath, 
 }
 
 // Download 下载单个文件
-func (s *Service) Download(ctx context.Context, transferID, sessionID, remotePath, localPath string, onProgress func(TransferProgress)) error {
+func (s *Service) Download(ctx context.Context, transferID, sessionID, remotePath, localPath string, onProgress func(transfer.Progress)) error {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancels.Store(transferID, cancel)
 	defer func() {
@@ -422,7 +408,7 @@ func (s *Service) Download(ctx context.Context, transferID, sessionID, remotePat
 }
 
 // UploadDir 上传目录
-func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir, remoteDir string, onProgress func(TransferProgress)) error {
+func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir, remoteDir string, onProgress func(transfer.Progress)) error {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancels.Store(transferID, cancel)
 	defer func() {
@@ -461,8 +447,7 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 	// 传输阶段
 	var filesCompleted int
 	var bytesDone int64
-	startTime := time.Now()
-	lastEmit := time.Now()
+	reporter := transfer.NewReporter(onProgress)
 
 	return filepath.WalkDir(localDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -516,24 +501,15 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 				}
 				bytesDone += int64(n)
 
-				if time.Since(lastEmit) >= 100*time.Millisecond {
-					elapsed := time.Since(startTime).Seconds()
-					speed := int64(0)
-					if elapsed > 0 {
-						speed = int64(float64(bytesDone) / elapsed)
-					}
-					onProgress(TransferProgress{
-						TransferID:     transferID,
-						Status:         "progress",
-						CurrentFile:    relPath,
-						FilesCompleted: filesCompleted,
-						FilesTotal:     filesTotal,
-						BytesDone:      bytesDone,
-						BytesTotal:     bytesTotal,
-						Speed:          speed,
-					})
-					lastEmit = time.Now()
-				}
+				reporter.Report(transfer.Progress{
+					TransferID:     transferID,
+					Status:         "progress",
+					CurrentFile:    relPath,
+					FilesCompleted: filesCompleted,
+					FilesTotal:     filesTotal,
+					BytesDone:      bytesDone,
+					BytesTotal:     bytesTotal,
+				})
 			}
 			if readErr == io.EOF {
 				break
@@ -549,7 +525,7 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 }
 
 // DownloadDir 下载目录
-func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remoteDir, localDir string, onProgress func(TransferProgress)) error {
+func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remoteDir, localDir string, onProgress func(transfer.Progress)) error {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancels.Store(transferID, cancel)
 	defer func() {
@@ -608,8 +584,7 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 	// 传输阶段
 	var filesCompleted int
 	var bytesDone int64
-	startTime := time.Now()
-	lastEmit := time.Now()
+	reporter := transfer.NewReporter(onProgress)
 
 	for _, entry := range entries {
 		if ctx.Err() != nil {
@@ -665,24 +640,15 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 				}
 				bytesDone += int64(n)
 
-				if time.Since(lastEmit) >= 100*time.Millisecond {
-					elapsed := time.Since(startTime).Seconds()
-					speed := int64(0)
-					if elapsed > 0 {
-						speed = int64(float64(bytesDone) / elapsed)
-					}
-					onProgress(TransferProgress{
-						TransferID:     transferID,
-						Status:         "progress",
-						CurrentFile:    relPath,
-						FilesCompleted: filesCompleted,
-						FilesTotal:     filesTotal,
-						BytesDone:      bytesDone,
-						BytesTotal:     bytesTotal,
-						Speed:          speed,
-					})
-					lastEmit = time.Now()
-				}
+				reporter.Report(transfer.Progress{
+					TransferID:     transferID,
+					Status:         "progress",
+					CurrentFile:    relPath,
+					FilesCompleted: filesCompleted,
+					FilesTotal:     filesTotal,
+					BytesDone:      bytesDone,
+					BytesTotal:     bytesTotal,
+				})
 			}
 			if readErr == io.EOF {
 				break
@@ -765,11 +731,10 @@ func (s *Service) removeDirRecursive(client *sftp.Client, path string) error {
 }
 
 // copyWithProgress 带进度的文件拷贝
-func (s *Service) copyWithProgress(ctx context.Context, transferID string, dst io.Writer, src io.Reader, totalBytes int64, filesTotal int, currentFile string, onProgress func(TransferProgress)) error {
+func (s *Service) copyWithProgress(ctx context.Context, transferID string, dst io.Writer, src io.Reader, totalBytes int64, filesTotal int, currentFile string, onProgress func(transfer.Progress)) error {
 	buf := make([]byte, 32*1024)
 	var bytesDone int64
-	startTime := time.Now()
-	lastEmit := time.Now()
+	reporter := transfer.NewReporter(onProgress)
 
 	for {
 		if ctx.Err() != nil {
@@ -783,24 +748,14 @@ func (s *Service) copyWithProgress(ctx context.Context, transferID string, dst i
 			}
 			bytesDone += int64(n)
 
-			if time.Since(lastEmit) >= 100*time.Millisecond {
-				elapsed := time.Since(startTime).Seconds()
-				speed := int64(0)
-				if elapsed > 0 {
-					speed = int64(float64(bytesDone) / elapsed)
-				}
-				onProgress(TransferProgress{
-					TransferID:     transferID,
-					Status:         "progress",
-					CurrentFile:    currentFile,
-					FilesCompleted: 0,
-					FilesTotal:     filesTotal,
-					BytesDone:      bytesDone,
-					BytesTotal:     totalBytes,
-					Speed:          speed,
-				})
-				lastEmit = time.Now()
-			}
+			reporter.Report(transfer.Progress{
+				TransferID:  transferID,
+				Status:      "progress",
+				CurrentFile: currentFile,
+				FilesTotal:  filesTotal,
+				BytesDone:   bytesDone,
+				BytesTotal:  totalBytes,
+			})
 		}
 		if readErr == io.EOF {
 			return nil

--- a/internal/service/zmodem_svc/zmodem.go
+++ b/internal/service/zmodem_svc/zmodem.go
@@ -1,0 +1,255 @@
+// Package zmodem_svc 提供 ZMODEM(lrzsz) 传输的本地文件 I/O 桥。
+//
+// ZMODEM 协议本身跑在前端（zmodem.js）：远端 sz/rz 的字节流由前端 Sentry 截获并驱动。
+// 后端只负责"协议落到本地磁盘"的那一段——下载时把前端推来的分块写盘，上传时按需把
+// 本地文件分块读给前端。进度则复用 internal/pkg/transfer 的 Reporter，与 SFTP 走同一
+// 套节流/测速 + "transfer:progress:<id>" 事件管线。
+//
+// 本包不依赖 Wails runtime（原生对话框留在 binder 层），因此可独立单测。
+package zmodem_svc
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/opskat/opskat/internal/pkg/transfer"
+
+	"github.com/cago-frame/cago/pkg/logger"
+	"go.uber.org/zap"
+)
+
+// dlHandle 是一次下载（远端 sz）的写盘句柄。
+type dlHandle struct {
+	f        *os.File
+	path     string
+	name     string
+	size     int64
+	written  int64
+	reporter *transfer.Reporter
+}
+
+// ulHandle 是一次上传（远端 rz）的读盘句柄。
+type ulHandle struct {
+	f         *os.File
+	name      string
+	size      int64
+	readTotal int64
+	reporter  *transfer.Reporter
+}
+
+// FileBridge 按 transferID 管理在传的本地文件句柄，并通过注入的 emit 上报进度。
+// 同一 transferID 的方法调用由前端的 await 链串行驱动，因此句柄内字段无需加锁；
+// mu 仅保护两张 map 自身，使并发的不同传输互不干扰。
+type FileBridge struct {
+	emit     func(transfer.Progress)
+	mu       sync.Mutex
+	download map[string]*dlHandle
+	upload   map[string]*ulHandle
+}
+
+// New 创建文件桥。emit 由 binder 接到 wailsRuntime.EventsEmit("transfer:progress:"+id)。
+func New(emit func(transfer.Progress)) *FileBridge {
+	return &FileBridge{
+		emit:     emit,
+		download: make(map[string]*dlHandle),
+		upload:   make(map[string]*ulHandle),
+	}
+}
+
+// --- 下载（远端 sz）---
+
+// BeginDownload 在 path 处创建/截断本地文件并登记下载句柄。path 来自原生 Save 对话框。
+func (b *FileBridge) BeginDownload(transferID, path string, size int64) error {
+	f, err := os.Create(path) //nolint:gosec // path 来自原生保存对话框
+	if err != nil {
+		return fmt.Errorf("创建本地文件失败: %w", err)
+	}
+	h := &dlHandle{
+		f:        f,
+		path:     path,
+		name:     filepath.Base(path),
+		size:     size,
+		reporter: transfer.NewReporter(b.emit),
+	}
+	b.mu.Lock()
+	b.download[transferID] = h
+	b.mu.Unlock()
+	return nil
+}
+
+// AppendChunk 把一段已接收的字节追加写入下载文件，并上报进度。
+func (b *FileBridge) AppendChunk(transferID string, data []byte) error {
+	h := b.dl(transferID)
+	if h == nil {
+		return fmt.Errorf("下载传输不存在: %s", transferID)
+	}
+	if _, err := h.f.Write(data); err != nil {
+		h.reporter.Report(transfer.Progress{
+			TransferID: transferID, Status: transfer.StatusError, CurrentFile: h.name, Error: err.Error(),
+		})
+		return fmt.Errorf("写入本地文件失败: %w", err)
+	}
+	h.written += int64(len(data))
+	h.reporter.Report(transfer.Progress{
+		TransferID: transferID, Status: transfer.StatusProgress, CurrentFile: h.name,
+		FilesTotal: 1, BytesDone: h.written, BytesTotal: h.size,
+	})
+	return nil
+}
+
+// FinishDownload 关闭下载文件并发出 done。幂等：句柄不存在时静默返回。
+func (b *FileBridge) FinishDownload(transferID string) error {
+	h := b.takeDL(transferID)
+	if h == nil {
+		return nil
+	}
+	if err := h.f.Close(); err != nil {
+		h.reporter.Report(transfer.Progress{
+			TransferID: transferID, Status: transfer.StatusError, CurrentFile: h.name, Error: err.Error(),
+		})
+		return fmt.Errorf("关闭本地文件失败: %w", err)
+	}
+	h.reporter.Report(transfer.Progress{
+		TransferID: transferID, Status: transfer.StatusDone, CurrentFile: h.name,
+		FilesTotal: 1, FilesCompleted: 1, BytesDone: h.written, BytesTotal: h.size,
+	})
+	return nil
+}
+
+// AbortDownload 关闭并删除半截的下载文件，置为已取消状态。幂等。
+func (b *FileBridge) AbortDownload(transferID string) error {
+	h := b.takeDL(transferID)
+	if h == nil {
+		return nil
+	}
+	if err := h.f.Close(); err != nil {
+		logger.Default().Warn("close aborted download", zap.String("path", h.path), zap.Error(err))
+	}
+	rmErr := os.Remove(h.path)
+	h.reporter.Report(transfer.Progress{
+		TransferID: transferID, Status: transfer.StatusCancelled, CurrentFile: h.name,
+	})
+	if rmErr != nil && !os.IsNotExist(rmErr) {
+		return fmt.Errorf("删除未完成文件失败: %w", rmErr)
+	}
+	return nil
+}
+
+// --- 上传（远端 rz）---
+
+// OpenUpload 打开 path 供读取并登记上传句柄，返回文件大小与修改时间(Unix 秒)。
+// path 来自原生多选对话框。
+func (b *FileBridge) OpenUpload(transferID, path string) (size, mtime int64, err error) {
+	f, err := os.Open(path) //nolint:gosec // path 来自原生打开对话框
+	if err != nil {
+		return 0, 0, fmt.Errorf("打开本地文件失败: %w", err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		if closeErr := f.Close(); closeErr != nil {
+			logger.Default().Warn("close upload after stat error", zap.String("path", path), zap.Error(closeErr))
+		}
+		return 0, 0, fmt.Errorf("获取文件信息失败: %w", err)
+	}
+	h := &ulHandle{
+		f:        f,
+		name:     filepath.Base(path),
+		size:     info.Size(),
+		reporter: transfer.NewReporter(b.emit),
+	}
+	b.mu.Lock()
+	b.upload[transferID] = h
+	b.mu.Unlock()
+	return info.Size(), info.ModTime().Unix(), nil
+}
+
+// ReadChunk 读取至多 n 字节供前端发往远端，并上报进度；返回 eof 表示文件已读完。
+func (b *FileBridge) ReadChunk(transferID string, n int) (data []byte, eof bool, err error) {
+	h := b.ul(transferID)
+	if h == nil {
+		return nil, false, fmt.Errorf("上传传输不存在: %s", transferID)
+	}
+	buf := make([]byte, n)
+	read, readErr := h.f.Read(buf)
+	if read > 0 {
+		h.readTotal += int64(read)
+		h.reporter.Report(transfer.Progress{
+			TransferID: transferID, Status: transfer.StatusProgress, CurrentFile: h.name,
+			FilesTotal: 1, BytesDone: h.readTotal, BytesTotal: h.size,
+		})
+	}
+	if readErr == io.EOF {
+		return buf[:read], true, nil
+	}
+	if readErr != nil {
+		h.reporter.Report(transfer.Progress{
+			TransferID: transferID, Status: transfer.StatusError, CurrentFile: h.name, Error: readErr.Error(),
+		})
+		return nil, false, fmt.Errorf("读取本地文件失败: %w", readErr)
+	}
+	return buf[:read], false, nil
+}
+
+// FinishUpload 关闭上传文件并发出 done。幂等。
+func (b *FileBridge) FinishUpload(transferID string) error {
+	h := b.takeUL(transferID)
+	if h == nil {
+		return nil
+	}
+	if err := h.f.Close(); err != nil {
+		return fmt.Errorf("关闭本地文件失败: %w", err)
+	}
+	h.reporter.Report(transfer.Progress{
+		TransferID: transferID, Status: transfer.StatusDone, CurrentFile: h.name,
+		FilesTotal: 1, FilesCompleted: 1, BytesDone: h.readTotal, BytesTotal: h.size,
+	})
+	return nil
+}
+
+// AbortUpload 关闭上传读句柄（不删除本地源文件），置为已取消状态。幂等。
+func (b *FileBridge) AbortUpload(transferID string) error {
+	h := b.takeUL(transferID)
+	if h == nil {
+		return nil
+	}
+	if err := h.f.Close(); err != nil {
+		logger.Default().Warn("close aborted upload", zap.String("file", h.name), zap.Error(err))
+	}
+	h.reporter.Report(transfer.Progress{
+		TransferID: transferID, Status: transfer.StatusCancelled, CurrentFile: h.name,
+	})
+	return nil
+}
+
+// --- 句柄存取小工具 ---
+
+func (b *FileBridge) dl(transferID string) *dlHandle {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.download[transferID]
+}
+
+func (b *FileBridge) takeDL(transferID string) *dlHandle {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	h := b.download[transferID]
+	delete(b.download, transferID)
+	return h
+}
+
+func (b *FileBridge) ul(transferID string) *ulHandle {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.upload[transferID]
+}
+
+func (b *FileBridge) takeUL(transferID string) *ulHandle {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	h := b.upload[transferID]
+	delete(b.upload, transferID)
+	return h
+}

--- a/internal/service/zmodem_svc/zmodem_test.go
+++ b/internal/service/zmodem_svc/zmodem_test.go
@@ -1,0 +1,204 @@
+package zmodem_svc
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/opskat/opskat/internal/pkg/transfer"
+)
+
+// collector 是线程安全的进度收集器，供并发测试使用。
+type collector struct {
+	mu sync.Mutex
+	ps []transfer.Progress
+}
+
+func (c *collector) emit(p transfer.Progress) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ps = append(c.ps, p)
+}
+
+func (c *collector) statuses(transferID string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []string
+	for _, p := range c.ps {
+		if p.TransferID == transferID {
+			out = append(out, p.Status)
+		}
+	}
+	return out
+}
+
+func TestBeginAppendFinish(t *testing.T) {
+	c := &collector{}
+	b := New(c.emit)
+	dst := filepath.Join(t.TempDir(), "out.bin")
+
+	if err := b.BeginDownload("t1", dst, 6); err != nil {
+		t.Fatalf("BeginDownload: %v", err)
+	}
+	if err := b.AppendChunk("t1", []byte("abc")); err != nil {
+		t.Fatalf("AppendChunk 1: %v", err)
+	}
+	if err := b.AppendChunk("t1", []byte("def")); err != nil {
+		t.Fatalf("AppendChunk 2: %v", err)
+	}
+	if err := b.FinishDownload("t1"); err != nil {
+		t.Fatalf("FinishDownload: %v", err)
+	}
+
+	got, err := os.ReadFile(dst) //nolint:gosec // 测试临时文件
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "abcdef" {
+		t.Fatalf("file content = %q, want abcdef", got)
+	}
+	if st := c.statuses("t1"); !slices.Contains(st, "progress") || st[len(st)-1] != "done" {
+		t.Fatalf("statuses = %v, want progress... done", st)
+	}
+}
+
+func TestAbortDownloadRemovesPartialFile(t *testing.T) {
+	c := &collector{}
+	b := New(c.emit)
+	dst := filepath.Join(t.TempDir(), "partial.bin")
+
+	if err := b.BeginDownload("t2", dst, 100); err != nil {
+		t.Fatalf("BeginDownload: %v", err)
+	}
+	if err := b.AppendChunk("t2", []byte("half")); err != nil {
+		t.Fatalf("AppendChunk: %v", err)
+	}
+	if err := b.AbortDownload("t2"); err != nil {
+		t.Fatalf("AbortDownload: %v", err)
+	}
+
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("partial file should be removed, stat err = %v", err)
+	}
+	if st := c.statuses("t2"); !slices.Contains(st, transfer.StatusCancelled) {
+		t.Fatalf("statuses = %v, want %s", st, transfer.StatusCancelled)
+	}
+}
+
+func TestOpenReadChunkEOF(t *testing.T) {
+	c := &collector{}
+	b := New(c.emit)
+	src := filepath.Join(t.TempDir(), "src.bin")
+	want := bytes.Repeat([]byte("xyz"), 1000) // 3000 bytes
+	if err := os.WriteFile(src, want, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	size, _, err := b.OpenUpload("u1", src)
+	if err != nil {
+		t.Fatalf("OpenUpload: %v", err)
+	}
+	if size != int64(len(want)) {
+		t.Fatalf("size = %d, want %d", size, len(want))
+	}
+
+	var got []byte
+	for {
+		data, eof, err := b.ReadChunk("u1", 512)
+		if err != nil {
+			t.Fatalf("ReadChunk: %v", err)
+		}
+		got = append(got, data...)
+		if eof {
+			break
+		}
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("read back %d bytes, want %d (equal=%v)", len(got), len(want), bytes.Equal(got, want))
+	}
+	if err := b.FinishUpload("u1"); err != nil {
+		t.Fatalf("FinishUpload: %v", err)
+	}
+	if st := c.statuses("u1"); st[len(st)-1] != "done" {
+		t.Fatalf("statuses = %v, want ...done", st)
+	}
+}
+
+func TestConcurrentTransfers(t *testing.T) {
+	c := &collector{}
+	b := New(c.emit)
+	dir := t.TempDir()
+
+	var wg sync.WaitGroup
+	for i := range 4 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := filepath.Base(filepath.Join(dir, string(rune('a'+i)))) // 唯一 transferID
+			dst := filepath.Join(dir, id+".bin")
+			payload := bytes.Repeat([]byte{byte('A' + i)}, 5000)
+			if err := b.BeginDownload(id, dst, int64(len(payload))); err != nil {
+				t.Errorf("BeginDownload %s: %v", id, err)
+				return
+			}
+			for off := 0; off < len(payload); off += 1000 {
+				if err := b.AppendChunk(id, payload[off:off+1000]); err != nil {
+					t.Errorf("AppendChunk %s: %v", id, err)
+					return
+				}
+			}
+			if err := b.FinishDownload(id); err != nil {
+				t.Errorf("FinishDownload %s: %v", id, err)
+				return
+			}
+			got, err := os.ReadFile(dst) //nolint:gosec // 测试临时文件
+			if err != nil {
+				t.Errorf("ReadFile %s: %v", id, err)
+				return
+			}
+			if !bytes.Equal(got, payload) {
+				t.Errorf("file %s content mismatch", id)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestIdempotentClose(t *testing.T) {
+	c := &collector{}
+	b := New(c.emit)
+	dst := filepath.Join(t.TempDir(), "idem.bin")
+
+	if err := b.BeginDownload("d", dst, 1); err != nil {
+		t.Fatalf("BeginDownload: %v", err)
+	}
+	if err := b.FinishDownload("d"); err != nil {
+		t.Fatalf("FinishDownload 1: %v", err)
+	}
+	if err := b.FinishDownload("d"); err != nil {
+		t.Fatalf("FinishDownload 2 (idempotent): %v", err)
+	}
+	if err := b.AbortDownload("d"); err != nil {
+		t.Fatalf("AbortDownload (idempotent): %v", err)
+	}
+
+	src := filepath.Join(t.TempDir(), "idem-src.bin")
+	if err := os.WriteFile(src, []byte("x"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, _, err := b.OpenUpload("u", src); err != nil {
+		t.Fatalf("OpenUpload: %v", err)
+	}
+	if err := b.FinishUpload("u"); err != nil {
+		t.Fatalf("FinishUpload 1: %v", err)
+	}
+	if err := b.FinishUpload("u"); err != nil {
+		t.Fatalf("FinishUpload 2 (idempotent): %v", err)
+	}
+	if err := b.AbortUpload("u"); err != nil {
+		t.Fatalf("AbortUpload (idempotent): %v", err)
+	}
+}


### PR DESCRIPTION
## 背景

SSH 终端此前不支持 ZMODEM：在远端跑 `sz`（下载）/ `rz`（上传）无法工作。`lrzsz` 是 ZMODEM 的事实标准实现，远端装了 `rz`/`sz` 就应直接可用。本 PR 在 **SSH 终端**里支持与 lrzsz 互通的文件传输。

## 方案

协议跑在**前端** `zmodem.js`（FGasper，ttyd 同款，与 lrzsz 互通验证充分）；后端只做一个很薄的**原生文件 I/O 桥**（原生对话框 + 分块读写本地磁盘）。客户端 ZMODEM 必须进程内实现（不能 shell 出本地 `rz`/`sz`，Windows 是一等目标且会抢 tty）。

**进度/传输生命周期与现有 SFTP 文件管理全栈复用**，抽出公共函数/接口，高内聚低耦合。

## 改动

**后端（新）**
- `internal/pkg/transfer/` — 公共包：`Progress` 类型、`GenerateID(prefix)`、`Reporter`（100ms 节流 + 测速）。SFTP 与 ZMODEM 共用。
- `internal/service/zmodem_svc/` — `FileBridge`：按 transferId 管理本地文件句柄，分块写(下载)/读(上传)、abort 删残file、进度走公共 `Reporter`。运行时无关、可单测。
- `internal/app/ssh/zmodem.go` — 8 个 Wails 绑定（原生对话框 + base64 分块 + abort + zap 日志）。

**后端（改）**
- `sftp_svc` 重构复用公共包（`copyWithProgress` 及目录传输内联节流/测速 → `transfer.Reporter`；`TransferProgress` → `transfer.Progress`；ID 生成统一）。
- 进度事件通道 `sftp:progress:` → 中性的 `transfer:progress:`（前后端 lockstep）。

**前端**
- `components/terminal/zmodem/zmodemSession.ts` — Sentry 控制器（截获 sz/rz、驱动收发、输入抑制、Ctrl-C/取消/断开中止）。
- `types/zmodem.d.ts` — `zmodem.js` ambient 类型。
- `terminalRegistry.ts` — **仅 SSH** 接入 Sentry。
- `sftpStore.ts` — 加 `subscribeExternalTransfer` / `openFileManager` / 注册式 `cancelTransfer` + `cancelled` 状态；`TransferSection`/`TransferRow`/`notify` **零改动复用**。

## 字节安全性

已读码确认 `internal/service/ssh_svc/dirsync.go` 的 `filterOutput` 对 ZMODEM 二进制帧**非破坏性**（仅剥 token 匹配的 OSC，且只在提示符渲染时出现，传输中远端独占 PTY 不会注入），**后端读循环无需改动**。

## 测试

- 后端：`go build ./...` ✅；`internal/pkg/transfer`、`internal/service/zmodem_svc`（分块完整性、abort 删残file、`-race` 并发、幂等）、`internal/app/ssh` 单测 ✅；`golangci-lint` 0 issues ✅。
- 前端：`tsc -b` ✅；新增 `zmodemSession.test.ts` 6/6（Sentry 路由、输入抑制、下载/上传 glue、取消路由）✅；eslint ✅。

> ⚠️ **真机 E2E 未跑**：lrzsz ↔ zmodem.js 的实时互通需要"装了 lrzsz 的远端 + GUI 操作"，无法自动化。单测覆盖了所有 glue 与后端文件桥，协议库本身经上游验证。合并前建议手动跑一遍：远端 `sz <file>` / `rz` 后对比 sha256，并验证取消时残file 被删。

## 注意

- 仅 SSH 终端启用（不含 serial/local）。
- `frontend/wailsjs/`（含新生成的 `Zmodem*` 绑定与 `ZmodemChunk`/`ZmodemUploadFile` 模型）是 gitignore 生成物，未进库；CI/dev 会 `wails generate module` 自动重生。