### PR TITLE
✨ 记住 WebDAV 备份参数

### DIFF
--- a/frontend/src/components/settings/BackupSection.tsx
+++ b/frontend/src/components/settings/BackupSection.tsx
@@ -45,7 +45,7 @@ import {
   ImportFromWebDAV,
 } from "../../../wailsjs/go/system/System";
 import { backup_svc } from "../../../wailsjs/go/models";
-import { ExportDialog } from "@/components/settings/ExportDialog";
+import { ExportDialog, type WebDAVExportDefaults } from "@/components/settings/ExportDialog";
 import { BackupImportDialog } from "@/components/settings/BackupImportDialog";
 import {
   Download,
@@ -70,6 +70,16 @@ import { useShortcutStore } from "@/stores/shortcutStore";
 import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 
 const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e));
+
+const emptyWebDAVExportDefaults: WebDAVExportDefaults = {
+  configured: false,
+  password: "",
+  includeCredentials: false,
+  includeForwards: true,
+  includePolicyGroups: true,
+  includeShortcuts: false,
+  includeThemes: false,
+};
 
 function PasswordInput({
   showGenerate,
@@ -156,6 +166,7 @@ export function BackupSection() {
   const [webdavPulling, setWebDAVPulling] = useState(false);
   const [webdavPullPasswordOpen, setWebDAVPullPasswordOpen] = useState(false);
   const [webdavPullPassword, setWebDAVPullPassword] = useState("");
+  const [webDAVExportDefaults, setWebDAVExportDefaults] = useState<WebDAVExportDefaults>(emptyWebDAVExportDefaults);
 
   // Load GitHub token on mount
   useEffect(() => {
@@ -212,6 +223,15 @@ export function BackupSection() {
         setWebDAVPassword(cfg.password || "");
         setWebDAVToken(cfg.token || "");
         setWebDAVConfigured(!!cfg.configured);
+        setWebDAVExportDefaults({
+          configured: !!cfg.exportDefaultsConfigured,
+          password: cfg.exportPassword || "",
+          includeCredentials: !!cfg.exportIncludeCredentials,
+          includeForwards: cfg.exportDefaultsConfigured ? !!cfg.exportIncludeForwards : true,
+          includePolicyGroups: cfg.exportDefaultsConfigured ? !!cfg.exportIncludePolicyGroups : true,
+          includeShortcuts: !!cfg.exportIncludeShortcuts,
+          includeThemes: !!cfg.exportIncludeThemes,
+        });
       } catch {
         /* not configured */
       }
@@ -442,6 +462,7 @@ export function BackupSection() {
       setWebDAVToken("");
       setWebDAVBackups([]);
       setSelectedWebDAVBackup("");
+      setWebDAVExportDefaults(emptyWebDAVExportDefaults);
       notifySuccess(t("backup.webdavCleared"));
     } catch (e: unknown) {
       toast.error(errMsg(e));
@@ -468,6 +489,15 @@ export function BackupSection() {
       if (result?.name) {
         setSelectedWebDAVBackup(result.name);
       }
+      setWebDAVExportDefaults({
+        configured: true,
+        password,
+        includeCredentials: opts.include_credentials,
+        includeForwards: opts.include_forwards,
+        includePolicyGroups: opts.include_policy_groups,
+        includeShortcuts: opts.include_shortcuts,
+        includeThemes: opts.include_themes,
+      });
     } finally {
       setWebDAVPushing(false);
     }
@@ -716,6 +746,7 @@ export function BackupSection() {
         mode={exportDialogMode}
         onGistExport={handleGistExport}
         onWebDAVExport={handleWebDAVExport}
+        webDAVDefaults={webDAVExportDefaults}
       />
 
       {/* Backup import dialog */}

--- a/frontend/src/components/settings/ExportDialog.tsx
+++ b/frontend/src/components/settings/ExportDialog.tsx
@@ -61,7 +61,14 @@ function generatePassword(length = 20): string {
   return Array.from(arr, (b) => chars[b % chars.length]).join("");
 }
 
-export function ExportDialog({ open, onOpenChange, mode, onGistExport, onWebDAVExport, webDAVDefaults }: ExportDialogProps) {
+export function ExportDialog({
+  open,
+  onOpenChange,
+  mode,
+  onGistExport,
+  onWebDAVExport,
+  webDAVDefaults,
+}: ExportDialogProps) {
   const { t } = useTranslation();
   const { assets } = useAssetStore();
   const { shortcuts } = useShortcutStore();

--- a/frontend/src/components/settings/ExportDialog.tsx
+++ b/frontend/src/components/settings/ExportDialog.tsx
@@ -39,9 +39,20 @@ interface ExportDialogProps {
   mode: "file" | "gist" | "webdav";
   onGistExport?: (password: string, opts: backup_svc.ExportOptions) => Promise<void>;
   onWebDAVExport?: (password: string, opts: backup_svc.ExportOptions) => Promise<void>;
+  webDAVDefaults?: WebDAVExportDefaults;
 }
 
 type AssetSelectionMode = "all" | "specific";
+
+export interface WebDAVExportDefaults {
+  configured: boolean;
+  password: string;
+  includeCredentials: boolean;
+  includeForwards: boolean;
+  includePolicyGroups: boolean;
+  includeShortcuts: boolean;
+  includeThemes: boolean;
+}
 
 function generatePassword(length = 20): string {
   const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*";
@@ -50,7 +61,7 @@ function generatePassword(length = 20): string {
   return Array.from(arr, (b) => chars[b % chars.length]).join("");
 }
 
-export function ExportDialog({ open, onOpenChange, mode, onGistExport, onWebDAVExport }: ExportDialogProps) {
+export function ExportDialog({ open, onOpenChange, mode, onGistExport, onWebDAVExport, webDAVDefaults }: ExportDialogProps) {
   const { t } = useTranslation();
   const { assets } = useAssetStore();
   const { shortcuts } = useShortcutStore();
@@ -75,14 +86,23 @@ export function ExportDialog({ open, onOpenChange, mode, onGistExport, onWebDAVE
     if (!open) return;
     setSelectionMode("all");
     setSelectedIds([]);
-    setIncludeCredentials(false);
-    setIncludeForwards(true);
-    setIncludePolicyGroups(true);
-    setIncludeShortcuts(false);
-    setIncludeThemes(false);
-    setPassword("");
+    if (mode === "webdav" && webDAVDefaults?.configured) {
+      setIncludeCredentials(webDAVDefaults.includeCredentials);
+      setIncludeForwards(webDAVDefaults.includeForwards);
+      setIncludePolicyGroups(webDAVDefaults.includePolicyGroups);
+      setIncludeShortcuts(webDAVDefaults.includeShortcuts);
+      setIncludeThemes(webDAVDefaults.includeThemes);
+      setPassword(webDAVDefaults.password);
+    } else {
+      setIncludeCredentials(false);
+      setIncludeForwards(true);
+      setIncludePolicyGroups(true);
+      setIncludeShortcuts(false);
+      setIncludeThemes(false);
+      setPassword("");
+    }
     setShowPassword(false);
-  }, [open]);
+  }, [mode, open, webDAVDefaults]);
 
   const selectAll = () => setSelectedIds(assets.map((a) => a.ID));
   const selectNone = () => setSelectedIds([]);
@@ -99,6 +119,8 @@ export function ExportDialog({ open, onOpenChange, mode, onGistExport, onWebDAVE
     opts.include_credentials = includeCredentials;
     opts.include_forwards = includeForwards;
     opts.include_policy_groups = includePolicyGroups;
+    opts.include_shortcuts = includeShortcuts;
+    opts.include_themes = includeThemes;
 
     if (includeShortcuts) {
       // Export only custom (non-default) bindings

--- a/internal/app/system/settings.go
+++ b/internal/app/system/settings.go
@@ -462,12 +462,19 @@ func (s *System) GetGitHubUser(token string) (*backup_svc.GitHubUser, error) {
 // WebDAVStoredConfig 是前端可读取的 WebDAV 配置；password / token 解密后明文回填，
 // 便于设置页编辑时直接显示已有值（数据未离开本地进程，加密存储已在落盘层做）。
 type WebDAVStoredConfig struct {
-	URL        string `json:"url"`
-	AuthType   string `json:"authType"`
-	Username   string `json:"username,omitempty"`
-	Password   string `json:"password,omitempty"`
-	Token      string `json:"token,omitempty"`
-	Configured bool   `json:"configured"`
+	URL                       string `json:"url"`
+	AuthType                  string `json:"authType"`
+	Username                  string `json:"username,omitempty"`
+	Password                  string `json:"password,omitempty"`
+	Token                     string `json:"token,omitempty"`
+	Configured                bool   `json:"configured"`
+	ExportDefaultsConfigured  bool   `json:"exportDefaultsConfigured"`
+	ExportPassword            string `json:"exportPassword,omitempty"`
+	ExportIncludeCredentials  bool   `json:"exportIncludeCredentials"`
+	ExportIncludeForwards     bool   `json:"exportIncludeForwards"`
+	ExportIncludePolicyGroups bool   `json:"exportIncludePolicyGroups"`
+	ExportIncludeShortcuts    bool   `json:"exportIncludeShortcuts"`
+	ExportIncludeThemes       bool   `json:"exportIncludeThemes"`
 }
 
 // WebDAVSaveInput 是 SaveWebDAVConfig / TestWebDAVConfig 的入参，把鉴权方式与凭据收成一个 struct。
@@ -618,10 +625,16 @@ func (s *System) GetWebDAVConfig() (*WebDAVStoredConfig, error) {
 	}
 
 	out := &WebDAVStoredConfig{
-		URL:        cfg.WebDAVURL,
-		AuthType:   authType,
-		Username:   cfg.WebDAVUsername,
-		Configured: strings.TrimSpace(cfg.WebDAVURL) != "",
+		URL:                       cfg.WebDAVURL,
+		AuthType:                  authType,
+		Username:                  cfg.WebDAVUsername,
+		Configured:                strings.TrimSpace(cfg.WebDAVURL) != "",
+		ExportDefaultsConfigured:  cfg.WebDAVExportDefaultsConfigured,
+		ExportIncludeCredentials:  cfg.WebDAVExportIncludeCredentials,
+		ExportIncludeForwards:     cfg.WebDAVExportIncludeForwards,
+		ExportIncludePolicyGroups: cfg.WebDAVExportIncludePolicyGroups,
+		ExportIncludeShortcuts:    cfg.WebDAVExportIncludeShortcuts,
+		ExportIncludeThemes:       cfg.WebDAVExportIncludeThemes,
 	}
 	if cfg.WebDAVPassword != "" {
 		decrypted, err := credential_svc.Default().Decrypt(cfg.WebDAVPassword)
@@ -637,6 +650,13 @@ func (s *System) GetWebDAVConfig() (*WebDAVStoredConfig, error) {
 		}
 		out.Token = decrypted
 	}
+	if cfg.WebDAVExportPassword != "" {
+		decrypted, err := credential_svc.Default().Decrypt(cfg.WebDAVExportPassword)
+		if err != nil {
+			return nil, fmt.Errorf("解密 WebDAV 备份密码失败: %w", err)
+		}
+		out.ExportPassword = decrypted
+	}
 	return out, nil
 }
 
@@ -651,6 +671,7 @@ func (s *System) ClearWebDAVConfig() error {
 	cfg.WebDAVUsername = ""
 	cfg.WebDAVPassword = ""
 	cfg.WebDAVToken = ""
+	clearWebDAVExportDefaults(cfg)
 	return bootstrap.SaveConfig(cfg)
 }
 
@@ -702,7 +723,45 @@ func (s *System) ExportToWebDAV(password string, opts backup_svc.ExportOptions) 
 		return nil, err
 	}
 
-	return backup_svc.CreateOrUpdateWebDAVBackup(cfg, encrypted)
+	info, err := backup_svc.CreateOrUpdateWebDAVBackup(cfg, encrypted)
+	if err != nil {
+		return nil, err
+	}
+	// 备份已上传成功；记住导出默认项只是次要诉求。即便写 config.json 失败也不能
+	// 把"上传成功"误报为失败，否则前端既弹出错误、又不会刷新到刚上传的备份。
+	if err := s.saveWebDAVExportDefaults(password, opts); err != nil {
+		logger.Default().Warn("save WebDAV export defaults failed", zap.Error(err))
+	}
+	return info, nil
+}
+
+func (s *System) saveWebDAVExportDefaults(password string, opts backup_svc.ExportOptions) error {
+	cfg := bootstrap.GetConfig()
+	if cfg == nil {
+		return fmt.Errorf("config not loaded")
+	}
+	encrypted, err := credential_svc.Default().Encrypt(password)
+	if err != nil {
+		return fmt.Errorf("加密 WebDAV 备份密码失败: %w", err)
+	}
+	cfg.WebDAVExportDefaultsConfigured = true
+	cfg.WebDAVExportPassword = encrypted
+	cfg.WebDAVExportIncludeCredentials = opts.IncludeCredentials
+	cfg.WebDAVExportIncludeForwards = opts.IncludeForwards
+	cfg.WebDAVExportIncludePolicyGroups = opts.IncludePolicyGroups
+	cfg.WebDAVExportIncludeShortcuts = opts.IncludeShortcuts
+	cfg.WebDAVExportIncludeThemes = opts.IncludeThemes
+	return bootstrap.SaveConfig(cfg)
+}
+
+func clearWebDAVExportDefaults(cfg *bootstrap.AppConfig) {
+	cfg.WebDAVExportDefaultsConfigured = false
+	cfg.WebDAVExportPassword = ""
+	cfg.WebDAVExportIncludeCredentials = false
+	cfg.WebDAVExportIncludeForwards = false
+	cfg.WebDAVExportIncludePolicyGroups = false
+	cfg.WebDAVExportIncludeShortcuts = false
+	cfg.WebDAVExportIncludeThemes = false
 }
 
 // ImportFromWebDAV 从 WebDAV 导入备份。

--- a/internal/app/system/settings_test.go
+++ b/internal/app/system/settings_test.go
@@ -5,8 +5,29 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
+
+	"github.com/opskat/opskat/internal/bootstrap"
+	"github.com/opskat/opskat/internal/service/backup_svc"
+	"github.com/opskat/opskat/internal/service/credential_svc"
 )
+
+var initBootstrapForSystemTestOnce sync.Once
+
+func initBootstrapForSystemTest(t *testing.T) {
+	t.Helper()
+	initBootstrapForSystemTestOnce.Do(func() {
+		dataDir, err := os.MkdirTemp("", "opskat-system-test-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp: %v", err)
+		}
+		if _, err := bootstrap.LoadConfig(dataDir); err != nil {
+			t.Fatalf("bootstrap.LoadConfig: %v", err)
+		}
+		credential_svc.SetDefault(credential_svc.New("system-test", []byte("1234567890abcdef")))
+	})
+}
 
 func TestPathTraversesSymlink(t *testing.T) {
 	t.Parallel()
@@ -97,6 +118,88 @@ func TestUninstallSkillHandlesUnknownAndMissingTargets(t *testing.T) {
 	}
 	if err := s.UninstallSkill("codex"); err != nil {
 		t.Fatalf("missing target should be treated as success: %v", err)
+	}
+}
+
+func TestWebDAVExportDefaultsRoundTripEncryptedPassword(t *testing.T) {
+	initBootstrapForSystemTest(t)
+	cfg := &bootstrap.AppConfig{
+		WebDAVURL:      "https://example.com/dav/",
+		WebDAVAuthType: string(backup_svc.WebDAVAuthNone),
+	}
+	if err := bootstrap.SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	s := New(t.Context(), SkillContent{})
+	// include 标志按原值持久化，与是否真的有 payload 可序列化无关。让标志与 payload 在
+	// 两个方向上都不一致，以此锁定该独立性：快捷键标志为开但无 payload；主题标志为关但带 payload。
+	opts := backup_svc.ExportOptions{
+		IncludeCredentials:  true,
+		IncludeForwards:     false,
+		IncludePolicyGroups: true,
+		IncludeShortcuts:    true,
+		IncludeThemes:       false,
+		CustomThemes:        `[{"name":"solarized"}]`,
+	}
+
+	if err := s.saveWebDAVExportDefaults("backup-password", opts); err != nil {
+		t.Fatalf("saveWebDAVExportDefaults: %v", err)
+	}
+	if cfg.WebDAVExportPassword == "backup-password" {
+		t.Fatalf("backup password should be encrypted at rest")
+	}
+
+	stored, err := s.GetWebDAVConfig()
+	if err != nil {
+		t.Fatalf("GetWebDAVConfig: %v", err)
+	}
+	if !stored.ExportDefaultsConfigured {
+		t.Fatalf("export defaults should be marked configured")
+	}
+	if stored.ExportPassword != "backup-password" {
+		t.Fatalf("export password = %q", stored.ExportPassword)
+	}
+	if !stored.ExportIncludeCredentials {
+		t.Fatalf("include credentials should round-trip true")
+	}
+	if stored.ExportIncludeForwards {
+		t.Fatalf("include forwards should round-trip false")
+	}
+	if !stored.ExportIncludePolicyGroups {
+		t.Fatalf("include policy groups should round-trip true")
+	}
+	if !stored.ExportIncludeShortcuts {
+		t.Fatalf("include shortcuts flag should round-trip true even with an empty shortcuts payload")
+	}
+	if stored.ExportIncludeThemes {
+		t.Fatalf("include themes flag should round-trip false even when a custom themes payload is present")
+	}
+}
+
+func TestClearWebDAVConfigClearsExportDefaults(t *testing.T) {
+	initBootstrapForSystemTest(t)
+	cfg := &bootstrap.AppConfig{
+		WebDAVURL:                       "https://example.com/dav/",
+		WebDAVAuthType:                  string(backup_svc.WebDAVAuthNone),
+		WebDAVExportDefaultsConfigured:  true,
+		WebDAVExportPassword:            "encrypted",
+		WebDAVExportIncludeCredentials:  true,
+		WebDAVExportIncludeForwards:     true,
+		WebDAVExportIncludePolicyGroups: true,
+		WebDAVExportIncludeShortcuts:    true,
+		WebDAVExportIncludeThemes:       true,
+	}
+	if err := bootstrap.SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	s := New(t.Context(), SkillContent{})
+	if err := s.ClearWebDAVConfig(); err != nil {
+		t.Fatalf("ClearWebDAVConfig: %v", err)
+	}
+	if cfg.WebDAVExportDefaultsConfigured || cfg.WebDAVExportPassword != "" || cfg.WebDAVExportIncludeCredentials || cfg.WebDAVExportIncludeForwards || cfg.WebDAVExportIncludePolicyGroups || cfg.WebDAVExportIncludeShortcuts || cfg.WebDAVExportIncludeThemes {
+		t.Fatalf("WebDAV export defaults should be cleared: %#v", cfg)
 	}
 }
 

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -9,24 +9,31 @@ import (
 
 // AppConfig 应用持久化配置（config.json）
 type AppConfig struct {
-	UpdateChannel   string `json:"update_channel,omitempty"`    // stable, beta, nightly
-	DownloadMirror  string `json:"download_mirror,omitempty"`   // 下载镜像 URL 前缀，空表示直连 GitHub
-	KDFSalt         string `json:"kdf_salt,omitempty"`          // base64 编码的 Argon2id salt
-	AIProviderType  string `json:"ai_provider_type,omitempty"`  // openai, local_cli
-	AIAPIBase       string `json:"ai_api_base,omitempty"`       // API base URL 或 CLI 路径
-	AIAPIKey        string `json:"ai_api_key,omitempty"`        // 加密后的 API Key
-	AIModel         string `json:"ai_model,omitempty"`          // 模型名或 CLI 类型
-	GitHubToken     string `json:"github_token,omitempty"`      // 加密后的 GitHub token
-	GitHubUser      string `json:"github_user,omitempty"`       // GitHub 用户名（非敏感）
-	WebDAVURL       string `json:"webdav_url,omitempty"`        // WebDAV 备份目录
-	WebDAVAuthType  string `json:"webdav_auth_type,omitempty"`  // "none" | "basic" | "bearer"
-	WebDAVUsername  string `json:"webdav_username,omitempty"`   // WebDAV 用户名（非敏感，仅 basic）
-	WebDAVPassword  string `json:"webdav_password,omitempty"`   // 加密后的 WebDAV 密码（仅 basic）
-	WebDAVToken     string `json:"webdav_token,omitempty"`      // 加密后的 Bearer token（仅 bearer）
-	LastUpdateCheck int64  `json:"last_update_check,omitempty"` // 上次自动检查更新的 Unix 时间戳
-	DebugMode       bool   `json:"debug_mode,omitempty"`        // 开启后日志级别降为 debug
-	WindowWidth     int    `json:"window_width,omitempty"`      // 上次正常窗口宽度
-	WindowHeight    int    `json:"window_height,omitempty"`     // 上次正常窗口高度
+	UpdateChannel                   string `json:"update_channel,omitempty"`                    // stable, beta, nightly
+	DownloadMirror                  string `json:"download_mirror,omitempty"`                   // 下载镜像 URL 前缀，空表示直连 GitHub
+	KDFSalt                         string `json:"kdf_salt,omitempty"`                          // base64 编码的 Argon2id salt
+	AIProviderType                  string `json:"ai_provider_type,omitempty"`                  // openai, local_cli
+	AIAPIBase                       string `json:"ai_api_base,omitempty"`                       // API base URL 或 CLI 路径
+	AIAPIKey                        string `json:"ai_api_key,omitempty"`                        // 加密后的 API Key
+	AIModel                         string `json:"ai_model,omitempty"`                          // 模型名或 CLI 类型
+	GitHubToken                     string `json:"github_token,omitempty"`                      // 加密后的 GitHub token
+	GitHubUser                      string `json:"github_user,omitempty"`                       // GitHub 用户名（非敏感）
+	WebDAVURL                       string `json:"webdav_url,omitempty"`                        // WebDAV 备份目录
+	WebDAVAuthType                  string `json:"webdav_auth_type,omitempty"`                  // "none" | "basic" | "bearer"
+	WebDAVUsername                  string `json:"webdav_username,omitempty"`                   // WebDAV 用户名（非敏感，仅 basic）
+	WebDAVPassword                  string `json:"webdav_password,omitempty"`                   // 加密后的 WebDAV 密码（仅 basic）
+	WebDAVToken                     string `json:"webdav_token,omitempty"`                      // 加密后的 Bearer token（仅 bearer）
+	WebDAVExportDefaultsConfigured  bool   `json:"webdav_export_defaults_configured,omitempty"` // 是否已保存 WebDAV 导出默认项
+	WebDAVExportPassword            string `json:"webdav_export_password,omitempty"`            // 加密后的 WebDAV 备份密码
+	WebDAVExportIncludeCredentials  bool   `json:"webdav_export_include_credentials,omitempty"`
+	WebDAVExportIncludeForwards     bool   `json:"webdav_export_include_forwards,omitempty"`
+	WebDAVExportIncludePolicyGroups bool   `json:"webdav_export_include_policy_groups,omitempty"`
+	WebDAVExportIncludeShortcuts    bool   `json:"webdav_export_include_shortcuts,omitempty"`
+	WebDAVExportIncludeThemes       bool   `json:"webdav_export_include_themes,omitempty"`
+	LastUpdateCheck                 int64  `json:"last_update_check,omitempty"` // 上次自动检查更新的 Unix 时间戳
+	DebugMode                       bool   `json:"debug_mode,omitempty"`        // 开启后日志级别降为 debug
+	WindowWidth                     int    `json:"window_width,omitempty"`      // 上次正常窗口宽度
+	WindowHeight                    int    `json:"window_height,omitempty"`     // 上次正常窗口高度
 
 	// 外部编辑配置。仅持久化用户自定义编辑器；内置候选由运行时探测生成。
 	ExternalEditDefaultEditorID      string                 `json:"external_edit_default_editor_id,omitempty"`

--- a/internal/service/backup_svc/backup.go
+++ b/internal/service/backup_svc/backup.go
@@ -80,6 +80,8 @@ type ExportOptions struct {
 	IncludeCredentials  bool    `json:"include_credentials"`   // 包含凭据（强制加密）
 	IncludeForwards     bool    `json:"include_forwards"`      // 包含端口转发
 	IncludePolicyGroups bool    `json:"include_policy_groups"` // 包含策略组
+	IncludeShortcuts    bool    `json:"include_shortcuts"`     // 包含快捷键
+	IncludeThemes       bool    `json:"include_themes"`        // 包含终端主题
 	Shortcuts           string  `json:"shortcuts,omitempty"`   // JSON 字符串
 	CustomThemes        string  `json:"custom_themes,omitempty"`
 }


### PR DESCRIPTION
<!-- 标题请使用 gitmoji / Use gitmoji in title: ✨ Feature / 🐛 Bugfix / ♻️ Refactor / 🎨 UI / ⚡️ Perf / 🔒 Security / 🔧 Chore / ✅ Tests / 📄 Docs -->

## 变更说明 / Summary

<!-- 简述改动内容与动机 / What changed and why -->

  在 WebDAV 备份成功后，自动保存本次导出参数，下一次打开 WebDAV 导出弹窗时默认回填。
  保存范围：导出勾选项 + 备份密码；不保存资产选择，资产范围仍默认“全部资产”。
  备份密码使用现有 credential_svc 加密后写入本地 config.json，不放到前端 localStorage。

## 关联 Issue / Related Issue

Closes #

## 截图 / Screenshots

<!-- UI 改动必填 / Required for UI changes -->

## 自检 / Checklist

- [x]  Code reviewed by human / 代码通过人工检查
- [x]  Code reviewed by CC / 代码通过CC检查
- [x]  Changes tested / 已完成测试
