### PR TITLE
🐛 修复 ZMODEM(rz/sz) 终端传输二进制文件损坏

### DIFF
--- a/frontend/src/__tests__/orderedQueue.test.ts
+++ b/frontend/src/__tests__/orderedQueue.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import { createOrderedQueue } from "../lib/orderedQueue";
+import { orderedBySession } from "../stores/terminalStore";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createOrderedQueue", () => {
+  it("runs the first task synchronously (no added latency for idle case)", () => {
+    const q = createOrderedQueue();
+    const task = vi.fn().mockResolvedValue(undefined);
+    q.push(task);
+    expect(task).toHaveBeenCalledTimes(1); // 同步发起，未等微任务
+    expect(q.idle).toBe(false);
+  });
+
+  it("does not start task N+1 until task N settles (serialization)", async () => {
+    const q = createOrderedQueue();
+    const d1 = deferred();
+    const t1 = vi.fn().mockReturnValue(d1.promise);
+    const t2 = vi.fn().mockResolvedValue(undefined);
+    const t3 = vi.fn().mockResolvedValue(undefined);
+
+    q.push(t1);
+    q.push(t2);
+    q.push(t3);
+    await flush();
+    expect(t1).toHaveBeenCalledTimes(1);
+    expect(t2).not.toHaveBeenCalled();
+    expect(t3).not.toHaveBeenCalled();
+
+    d1.resolve();
+    await flush();
+    expect(t2).toHaveBeenCalledTimes(1);
+    expect(t3).toHaveBeenCalledTimes(1); // t2 立即 resolve → t3 紧随
+  });
+
+  it("keeps ordering and stays drainable even if a task rejects", async () => {
+    const q = createOrderedQueue();
+    const order: number[] = [];
+    q.push(() => Promise.reject(new Error("boom"))).catch(() => order.push(0));
+    q.push(() => {
+      order.push(1);
+      return Promise.resolve();
+    });
+    await q.drain();
+    expect(order).toEqual([0, 1]);
+    expect(q.idle).toBe(true);
+  });
+
+  it("drain resolves immediately when idle and becomes idle after the last task", async () => {
+    const q = createOrderedQueue();
+    await expect(q.drain()).resolves.toBeUndefined();
+    const d = deferred();
+    q.push(() => d.promise);
+    let drained = false;
+    void q.drain().then(() => (drained = true));
+    await flush();
+    expect(drained).toBe(false);
+    d.resolve();
+    await flush();
+    expect(drained).toBe(true);
+    expect(q.idle).toBe(true);
+  });
+});
+
+describe("orderedBySession", () => {
+  it("serializes writes within a session (next not issued until prev resolves)", async () => {
+    const resolvers: Array<() => void> = [];
+    const raw = vi.fn().mockImplementation(() => new Promise<void>((res) => resolvers.push(res)));
+    const write = orderedBySession(raw);
+
+    write("s1", "a");
+    write("s1", "b");
+    write("s1", "c");
+    await flush();
+    expect(raw).toHaveBeenCalledTimes(1);
+    expect(raw).toHaveBeenNthCalledWith(1, "s1", "a");
+
+    resolvers[0]();
+    await flush();
+    expect(raw).toHaveBeenCalledTimes(2);
+    expect(raw).toHaveBeenNthCalledWith(2, "s1", "b");
+  });
+
+  it("does not serialize across different sessions (independent order)", async () => {
+    const pending: Record<string, Array<() => void>> = {};
+    const raw = vi.fn().mockImplementation(
+      (id: string) =>
+        new Promise<void>((res) => {
+          (pending[id] ??= []).push(res);
+        })
+    );
+    const write = orderedBySession(raw);
+
+    write("s1", "a"); // 在途、未 resolve
+    write("s2", "x"); // 另一会话不应被 s1 阻塞
+    await flush();
+
+    expect(raw).toHaveBeenCalledWith("s1", "a");
+    expect(raw).toHaveBeenCalledWith("s2", "x");
+    expect(raw).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/__tests__/zmodemSession.test.ts
+++ b/frontend/src/__tests__/zmodemSession.test.ts
@@ -129,6 +129,7 @@ describe("zmodemSession controller", () => {
     expect(useSFTPStore.getState().transfers["z-1"].direction).toBe("download");
 
     offer.pushInput([10, 20, 30]);
+    await flush();
     expect(ZmodemAppendChunk).toHaveBeenCalledWith("z-1", bytesToBase64(new Uint8Array([10, 20, 30])));
 
     offer.finishAccept();
@@ -231,6 +232,46 @@ describe("zmodemSession controller", () => {
 
     await vi.waitFor(() => expect(ZmodemPickUploadFiles).toHaveBeenCalledWith("s1"));
     expect(ZmodemOpenUploadFiles).not.toHaveBeenCalled();
+  });
+
+  it("sender forwards each protocol byte batch to write as base64 (ordering enforced by the transport)", () => {
+    // 出站字节的保序在 transport 层(orderedBySession)统一处理，见 orderedQueue.test.ts；
+    // 这里只验 sender 把 zmodem.js 产出的字节正确编码并转交注入的 write。
+    const write = vi.fn().mockResolvedValue(undefined);
+    createZmodemController({ sessionId: "s1", write, toTerminal: vi.fn() });
+
+    hoisted.sentryOpts.sender([1]);
+    hoisted.sentryOpts.sender([2, 3]);
+
+    expect(write).toHaveBeenNthCalledWith(1, "s1", bytesToBase64(new Uint8Array([1])));
+    expect(write).toHaveBeenNthCalledWith(2, "s1", bytesToBase64(new Uint8Array([2, 3])));
+  });
+
+  it("download serializes AppendChunk so the local file keeps received order", async () => {
+    vi.mocked(ZmodemBeginDownload).mockResolvedValue("z-ord");
+    let resolveAppend!: () => void;
+    vi.mocked(ZmodemAppendChunk)
+      .mockImplementationOnce(() => new Promise<void>((res) => (resolveAppend = res)))
+      .mockResolvedValue(undefined as never);
+    makeController();
+    const session = makeReceiveSession();
+    hoisted.sentryOpts.on_detect({ confirm: () => session, deny: vi.fn() });
+    const offer = makeOffer({ name: "a.bin", size: 6 });
+    session.fire("offer", offer);
+    await flush();
+
+    offer.pushInput([10, 20]);
+    offer.pushInput([30, 40]);
+    await flush();
+
+    // 第二块在第一块 AppendChunk resolve 前不得发起。
+    expect(ZmodemAppendChunk).toHaveBeenCalledTimes(1);
+    expect(ZmodemAppendChunk).toHaveBeenNthCalledWith(1, "z-ord", bytesToBase64(new Uint8Array([10, 20])));
+
+    resolveAppend();
+    await flush();
+    expect(ZmodemAppendChunk).toHaveBeenCalledTimes(2);
+    expect(ZmodemAppendChunk).toHaveBeenNthCalledWith(2, "z-ord", bytesToBase64(new Uint8Array([30, 40])));
   });
 
   it("upload cancel interrupts the remote rz process", async () => {

--- a/frontend/src/components/terminal/zmodem/zmodemSession.ts
+++ b/frontend/src/components/terminal/zmodem/zmodemSession.ts
@@ -11,6 +11,7 @@ import {
   ZmodemAbortUpload,
 } from "../../../../wailsjs/go/ssh/SSH";
 import { bytesToBase64 } from "@/lib/terminalEncode";
+import { createOrderedQueue } from "@/lib/orderedQueue";
 import { useSFTPStore, type SFTPTransferTarget } from "@/stores/sftpStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { notifySuccess } from "@/lib/notify";
@@ -61,10 +62,14 @@ export function createZmodemController(opts: ZmodemControllerOptions): ZmodemCon
   let queuedUploadPaths: string[] = [];
   let queuedUploadExpiresAt = 0;
 
+  // 下载分块按序写入本地文件。出站 PTY 字节流的保序由注入的 write
+  // (transport 层 orderedBySession)负责，这里只管下载这条独立的本地写流。
+  const appendQueue = createOrderedQueue();
+
   const sentry: ZmodemSentry = new Zmodem.Sentry({
     to_terminal: (octets) => toTerminal(toUint8(octets)),
     sender: (octets) => {
-      write(sessionId, bytesToBase64(toUint8(octets))).catch(console.error);
+      write(sessionId, bytesToBase64(toUint8(octets))).catch((e) => console.error("zmodem write error", e));
     },
     on_retract: () => {
       // 握手被收回（探测到的 ZMODEM 其实不是）：无在途状态可清，留待下次。
@@ -176,11 +181,17 @@ export function createZmodemController(opts: ZmodemControllerOptions): ZmodemCon
     };
 
     offer.on("input", (payload) => {
-      ZmodemAppendChunk(transferId, bytesToBase64(toUint8(payload))).catch(console.error);
+      appendQueue.push(() =>
+        ZmodemAppendChunk(transferId, bytesToBase64(toUint8(payload))).catch((e) =>
+          console.error("zmodem append error", e)
+        )
+      );
     });
 
     try {
       await offer.accept();
+      // accept() resolve 时分块多半仍在队列在途；先排空再收尾，避免文件被提前关闭而截断。
+      await appendQueue.drain();
       await ZmodemFinishDownload(transferId);
       notifySuccess(i18n.t("zmodem.downloadComplete", { name }));
     } catch (e) {

--- a/frontend/src/lib/orderedQueue.ts
+++ b/frontend/src/lib/orderedQueue.ts
@@ -1,0 +1,38 @@
+// 顺序队列：把异步任务串成一条 promise 链，保证 任务N+1 在 任务N settle 后才发起。
+//
+// 为什么需要：跨 Wails 边界的后端调用是 fire-and-forget，而 Wails 给每条 IPC 消息各起一个
+// goroutine 并发执行(internal/frontend/desktop/darwin/frontend.go: `go ...ProcessMessage`)，
+// 互斥锁只保证排他、不保证 FIFO。于是连续的写会乱序抵达后端——破坏任何有序字节流：
+// ZMODEM 子包错序→CRC 失败→二进制损坏；大段粘贴乱序→文本错乱。串行化后严格按提交顺序抵达。
+//
+// 空闲时首个任务同步发起(不引入额外微任务延迟，逐键输入零开销)，仅在有在途任务时才排队。
+export interface OrderedQueue {
+  /** 入队一个任务，返回该任务自身的 promise(可能 reject，调用方按需处理)。 */
+  push<T>(task: () => Promise<T>): Promise<T>;
+  /** 等到当前已入队任务全部 settle。 */
+  drain(): Promise<void>;
+  /** 队列是否空闲(无在途任务)。 */
+  readonly idle: boolean;
+}
+
+export function createOrderedQueue(): OrderedQueue {
+  let tail: Promise<unknown> | null = null;
+  return {
+    push<T>(task: () => Promise<T>): Promise<T> {
+      const result: Promise<T> = tail ? tail.then(() => task()) : task();
+      // 链路用「吞掉异常」的版本续接：单个任务失败不破坏后续顺序；调用方仍从 result 拿到原始结果。
+      const guarded = result.catch(() => undefined);
+      tail = guarded;
+      void guarded.then(() => {
+        if (tail === guarded) tail = null; // 排空即复位，下一个任务又能同步发起。
+      });
+      return result;
+    },
+    drain() {
+      return (tail ?? Promise.resolve()).then(() => undefined);
+    },
+    get idle() {
+      return tail === null;
+    },
+  };
+}

--- a/frontend/src/stores/terminalStore.ts
+++ b/frontend/src/stores/terminalStore.ts
@@ -27,6 +27,7 @@ import {
 import { ssh as ssh_models, asset_entity } from "../../wailsjs/go/models";
 import { EventsOn, EventsOff } from "../../wailsjs/runtime/runtime";
 import { bytesToBase64 } from "../lib/terminalEncode";
+import { createOrderedQueue, type OrderedQueue } from "../lib/orderedQueue";
 import { useTabStore, registerTabCloseHook, registerTabRestoreHook, type TerminalTabMeta } from "./tabStore";
 import { useAssetStore } from "./assetStore";
 
@@ -51,13 +52,38 @@ interface TransportSpec {
   hasDirectorySync: boolean;
 }
 
+// 把「写入某会话」的后端调用按 sessionId 串行化：所有出站写(终端输入/粘贴、ZMODEM 出站
+// 字节、rz 触发)都经 spec.write，统一在此保序，互不串扰。否则 Wails 的并发 IPC 派发会让
+// 突发写乱序抵达后端，损坏 ZMODEM 传输与大段粘贴(详见 lib/orderedQueue.ts)。
+export function orderedBySession(
+  raw: (sessionId: string, dataB64: string) => Promise<void>
+): (sessionId: string, dataB64: string) => Promise<void> {
+  const queues = new Map<string, OrderedQueue>();
+  return (sessionId, dataB64) => {
+    let q = queues.get(sessionId);
+    if (!q) {
+      q = createOrderedQueue();
+      queues.set(sessionId, q);
+    }
+    const result = q.push(() => raw(sessionId, dataB64));
+    // 会话写空闲即回收 map 条目，避免随开过的会话无限增长。
+    void result
+      .catch(() => undefined)
+      .then(() => {
+        const cur = queues.get(sessionId);
+        if (cur && cur.idle) queues.delete(sessionId);
+      });
+    return result;
+  };
+}
+
 // 单一 transport 能力表：连接/读写/尺寸/断开/事件前缀/分屏/目录同步全部按 transport 查表，
 // 取代散落各处的 isSerial 二分支。新增 transport 只需在此登记一行。
 export const TRANSPORTS: Record<TerminalTransport, TransportSpec> = {
   ssh: {
     connectAsync: (assetId, { cols, rows, password }) =>
       ConnectSSHAsync(new ssh_models.SSHConnectRequest({ assetId, password, key: "", cols, rows })),
-    write: WriteSSH,
+    write: orderedBySession(WriteSSH),
     resize: ResizeSSH,
     disconnect: DisconnectSSH,
     eventPrefix: "ssh",
@@ -67,7 +93,7 @@ export const TRANSPORTS: Record<TerminalTransport, TransportSpec> = {
   },
   serial: {
     connectAsync: (assetId) => ConnectSerialAsync({ assetId }),
-    write: WriteSerial,
+    write: orderedBySession(WriteSerial),
     resize: ResizeSerialTerminal,
     disconnect: DisconnectSerial,
     eventPrefix: "serial",
@@ -76,7 +102,7 @@ export const TRANSPORTS: Record<TerminalTransport, TransportSpec> = {
   },
   local: {
     connectAsync: (assetId, { cols, rows }) => ConnectLocalAsync({ assetId, cols, rows }),
-    write: WriteLocal,
+    write: orderedBySession(WriteLocal),
     resize: ResizeLocalTerminal,
     disconnect: DisconnectLocal,
     eventPrefix: "local",


### PR DESCRIPTION
## 问题

通过终端 `rz` 上传(或 `sz` 下载)二进制文件后，远端/本地文件的 md5 与源文件不一致，且**每次结果还不一样**。SFTP 上传同一文件则字节一致。

## 根因

ZMODEM 协议跑在前端 `zmodem.js`，出站字节经 `WriteSSH` 逐笔送往 PTY，但调用是 **fire-and-forget**；而 Wails(darwin) 给每条 IPC 消息**各起一个 goroutine** 并发执行（`internal/frontend/desktop/darwin/frontend.go` 的 `go ...ProcessMessage`），会话锁只保证排他、**不保证 FIFO**。

于是高速 firehose 下连续的写会**乱序抵达后端** → ZMODEM 子包错序 → rz 端 CRC 失败 → rz 发 `ZRPOS` 要求回退，但 zmodem.js 假定可靠传输、**忽略 ZRPOS 不重传** → rz 写出损坏数据。这解释了"二进制损坏 + 每次不同(竞态)"。SFTP 不受影响——它是后端单条 `io.Copy` 顺序写、无逐块 IPC。

> 同库的 Tabby 有相同症状(#11064/#5243)，其修复亦为 "write queue"。

## 修复

把保序放到**正确的层**——transport 边界，而非 zmodem 内部：

- 新增可复用原语 `frontend/src/lib/orderedQueue.ts`（`createOrderedQueue`，空闲首发同步、突发才排队，逐键输入零额外延迟）。
- `terminalStore.ts` 的 `orderedBySession` 包裹 `ssh`/`serial`/`local` 三个 `write`：终端输入/粘贴、ZMODEM 出站字节、`rz` 触发**统一按 sessionId 保序**，一并修掉同类的**大段粘贴乱序**隐患。
- `zmodemSession.ts` 移除自带写队列(已冗余)，仅保留下载→本地文件这条独立写流的 `appendQueue`，并在收尾前 `drain()` 确保分块落盘。

清晰的职责切分：PTY/串口出站由 transport 统一保序；下载文件落盘由其归属方(zmodem)保序。

## 验证

- 单测：新增 `orderedQueue.test.ts`（串行化 / 排空 / 异常隔离 / 会话间互不阻塞）+ 既有 zmodem 用例。全量 **1486 passed**，eslint + tsc clean。
- 端到端：以**真实 lrzsz `rz`**(跑在 pty 里)驱动实际 zmodem.js 发送路径 —— 串行化字节级 md5 一致 ✅；模拟 Wails 并发派发的乱序写则损坏/卡死 ❌（可见 rz 发出 `ZRPOS`、被 zmodem.js 忽略，正是该机制）。