### PR TITLE
🐛 修复 DeepSeek 空工具结果历史回放报错

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/cago-frame/agents v0.0.0-20260610020000-640785b2d7a3
+	github.com/cago-frame/agents v0.0.0-20260617072949-d58533f30ab1
 	github.com/cago-frame/cago v0.0.0-20260609091633-ba2f550b2729
 	github.com/coder/websocket v1.8.14
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/bytedance/sonic/loader v0.2.1 h1:1GgorWTqf12TA8mma4DDSbaQigE2wOgQo7iC
 github.com/bytedance/sonic/loader v0.2.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/cago-frame/agents v0.0.0-20260610020000-640785b2d7a3 h1:N5wKkBE1wMo8KeJYx93seRP6BRW9XBydDZgQbGu7ouM=
 github.com/cago-frame/agents v0.0.0-20260610020000-640785b2d7a3/go.mod h1:s72XmeaSoa3ysdqSTc4qliGqLHH6iBBGW6b8bFi0QRk=
+github.com/cago-frame/agents v0.0.0-20260617072949-d58533f30ab1 h1:BN/vCxcxLnaU+Er1+yQgHm0f4GrubCE0K9rKkuXvhvY=
+github.com/cago-frame/agents v0.0.0-20260617072949-d58533f30ab1/go.mod h1:s72XmeaSoa3ysdqSTc4qliGqLHH6iBBGW6b8bFi0QRk=
 github.com/cago-frame/cago v0.0.0-20260609091633-ba2f550b2729 h1:HtiDxeq5rPdJaRQI7XzJbly1WPCeLKaEa9txs2SKnFM=
 github.com/cago-frame/cago v0.0.0-20260609091633-ba2f550b2729/go.mod h1:Z1Ej4kHLccX0njPnJA5K0eawJLC7VgwtcLegt38IjQA=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/internal/ai/runner/message_convert_test.go
+++ b/internal/ai/runner/message_convert_test.go
@@ -112,6 +112,20 @@ func TestToAgentMessages(t *testing.T) {
 			So(inner.Text, ShouldEqual, "ok-result")
 		})
 
+		Convey("tool 消息允许空结果文本", func() {
+			out := ToAgentMessages([]Message{
+				{Role: RoleTool, ToolCallID: "tu_empty", Content: ""},
+			})
+			So(out, ShouldHaveLength, 1)
+			So(out[0].Role, ShouldEqual, agent.RoleTool)
+			tr, ok := out[0].Content[0].(agent.ToolResultBlock)
+			So(ok, ShouldBeTrue)
+			So(tr.ToolUseID, ShouldEqual, "tu_empty")
+			inner, ok := tr.Content[0].(agent.TextBlock)
+			So(ok, ShouldBeTrue)
+			So(inner.Text, ShouldEqual, "")
+		})
+
 		Convey("system 消息被跳过（cago 不放进 Conversation）", func() {
 			out := ToAgentMessages([]Message{
 				{Role: RoleSystem, Content: "you are concise"},


### PR DESCRIPTION
## 概要
- 升级 `github.com/cago-frame/agents` 到已修复 OpenAI 兼容接口空工具消息序列化问题的 main 版本
- 增加 runner 回归测试，覆盖空工具结果的历史消息回放

## 背景
DeepSeek v4 flash 在历史消息中遇到 `role=tool` 但 JSON 缺少 `content` 字段时会返回 400：`missing field content`。该问题会在长链条工具调用后更容易触发，因为空工具结果经过 go-openai 序列化时会被 `omitempty` 省略 `content` 字段。

cago agents 的修复已推送到 `cago-frame/agents` main，提交为 `d58533f30ab1`；本 PR 升级到对应 pseudo-version。

## 验证
- `go test ./internal/ai/runner -count=1`
- `go test ./internal/ai/... -count=1`

closes #199 #150