### PR TITLE
修复 K8s 顶部刷新未更新已加载资源

### DIFF
--- a/frontend/src/__tests__/K8sClusterPage.refresh.test.tsx
+++ b/frontend/src/__tests__/K8sClusterPage.refresh.test.tsx
@@ -2,11 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { K8sClusterPage } from "@/components/k8s/K8sClusterPage";
-import {
-  GetK8sClusterInfo,
-  GetK8sNamespacePods,
-  GetK8sNamespaceResources,
-} from "../../wailsjs/go/k8s/K8s";
+import { GetK8sClusterInfo, GetK8sNamespacePods, GetK8sNamespaceResources } from "../../wailsjs/go/k8s/K8s";
 import type { asset_entity } from "../../wailsjs/go/models";
 
 const clusterInfo = {

--- a/frontend/src/__tests__/K8sClusterPage.refresh.test.tsx
+++ b/frontend/src/__tests__/K8sClusterPage.refresh.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { K8sClusterPage } from "@/components/k8s/K8sClusterPage";
+import {
+  GetK8sClusterInfo,
+  GetK8sNamespacePods,
+  GetK8sNamespaceResources,
+} from "../../wailsjs/go/k8s/K8s";
+import type { asset_entity } from "../../wailsjs/go/models";
+
+const clusterInfo = {
+  version: "1.34.1",
+  platform: "linux/amd64",
+  nodes: [],
+  namespaces: [{ name: "default", status: "Active" }],
+};
+
+const namespaceResources = {
+  namespace: "default",
+  pods: 1,
+  deployments: 0,
+  services: 0,
+  config_maps: 0,
+  secrets: 0,
+  pvcs: 0,
+  service_accounts: 0,
+};
+
+function pod(name: string, status: string) {
+  return {
+    name,
+    namespace: "default",
+    status,
+    node_name: "node-1",
+    pod_ip: "10.0.0.1",
+    age: "1m",
+    ready: status === "Running" ? "1/1" : "0/1",
+    restart_count: 0,
+  };
+}
+
+const asset = {
+  ID: 99001,
+  Name: "k8s",
+  Type: "k8s",
+  Config: '{"namespace":"default"}',
+} as asset_entity.Asset;
+
+describe("K8sClusterPage refresh", () => {
+  it("refreshes already-loaded pod lists from the cluster", async () => {
+    const user = userEvent.setup();
+    vi.mocked(GetK8sClusterInfo).mockResolvedValue(JSON.stringify(clusterInfo) as never);
+    vi.mocked(GetK8sNamespaceResources).mockResolvedValue(JSON.stringify(namespaceResources) as never);
+    vi.mocked(GetK8sNamespacePods)
+      .mockResolvedValueOnce(JSON.stringify([pod("api-old", "Running")]) as never)
+      .mockResolvedValueOnce(JSON.stringify([pod("api-new", "Pending")]) as never);
+
+    render(<K8sClusterPage asset={asset} />);
+
+    const podLabels = await screen.findAllByText("asset.k8sPods");
+    await user.click(podLabels[0]!);
+    await screen.findByText("api-old");
+
+    await user.click(screen.getAllByRole("button", { name: "action.refresh" })[0]!);
+
+    await waitFor(() => {
+      expect(GetK8sNamespacePods).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText("api-new")).toBeInTheDocument();
+    expect(screen.queryByText("api-old")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/K8sClusterPage.refresh.test.tsx
+++ b/frontend/src/__tests__/K8sClusterPage.refresh.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { K8sClusterPage } from "@/components/k8s/K8sClusterPage";
-import { GetK8sClusterInfo, GetK8sNamespacePods, GetK8sNamespaceResources } from "../../wailsjs/go/k8s/K8s";
+import {
+  GetK8sClusterInfo,
+  GetK8sNamespacePods,
+  GetK8sNamespaceResources,
+  GetK8sPodDetail,
+} from "../../wailsjs/go/k8s/K8s";
 import type { asset_entity } from "../../wailsjs/go/models";
 
 const clusterInfo = {
@@ -36,14 +41,53 @@ function pod(name: string, status: string) {
   };
 }
 
-const asset = {
-  ID: 99001,
-  Name: "k8s",
-  Type: "k8s",
-  Config: '{"namespace":"default"}',
-} as asset_entity.Asset;
+function podDetail(name: string, image: string) {
+  return {
+    name,
+    namespace: "default",
+    status: "Running",
+    node_name: "node-1",
+    pod_ip: "10.0.0.1",
+    host_ip: "192.168.0.1",
+    creation_time: "2026-06-30T00:00:00Z",
+    age: "1m",
+    ready: "1/1",
+    restart_count: 0,
+    qos_class: "BestEffort",
+    containers: [
+      {
+        name: "app",
+        image,
+        state: "Running",
+        ready: true,
+        restart_count: 0,
+      },
+    ],
+    conditions: [],
+    events: [],
+    labels: {},
+    annotations: {},
+    yaml: `image: ${image}`,
+  };
+}
+
+function assetWithID(ID: number) {
+  return {
+    ID,
+    Name: "k8s",
+    Type: "k8s",
+    Config: '{"namespace":"default"}',
+  } as asset_entity.Asset;
+}
 
 describe("K8sClusterPage refresh", () => {
+  beforeEach(() => {
+    vi.mocked(GetK8sClusterInfo).mockReset();
+    vi.mocked(GetK8sNamespaceResources).mockReset();
+    vi.mocked(GetK8sNamespacePods).mockReset();
+    vi.mocked(GetK8sPodDetail).mockReset();
+  });
+
   it("refreshes already-loaded pod lists from the cluster", async () => {
     const user = userEvent.setup();
     vi.mocked(GetK8sClusterInfo).mockResolvedValue(JSON.stringify(clusterInfo) as never);
@@ -52,7 +96,7 @@ describe("K8sClusterPage refresh", () => {
       .mockResolvedValueOnce(JSON.stringify([pod("api-old", "Running")]) as never)
       .mockResolvedValueOnce(JSON.stringify([pod("api-new", "Pending")]) as never);
 
-    render(<K8sClusterPage asset={asset} />);
+    render(<K8sClusterPage asset={assetWithID(99001)} />);
 
     const podLabels = await screen.findAllByText("asset.k8sPods");
     await user.click(podLabels[0]!);
@@ -65,5 +109,30 @@ describe("K8sClusterPage refresh", () => {
     });
     expect(await screen.findByText("api-new")).toBeInTheDocument();
     expect(screen.queryByText("api-old")).not.toBeInTheDocument();
+  });
+
+  it("refreshes details for open pod tabs", async () => {
+    const user = userEvent.setup();
+    vi.mocked(GetK8sClusterInfo).mockResolvedValue(JSON.stringify(clusterInfo) as never);
+    vi.mocked(GetK8sNamespaceResources).mockResolvedValue(JSON.stringify(namespaceResources) as never);
+    vi.mocked(GetK8sNamespacePods).mockResolvedValue(JSON.stringify([pod("api", "Running")]) as never);
+    vi.mocked(GetK8sPodDetail)
+      .mockResolvedValueOnce(JSON.stringify(podDetail("api", "example/api:old")) as never)
+      .mockResolvedValueOnce(JSON.stringify(podDetail("api", "example/api:new")) as never);
+
+    render(<K8sClusterPage asset={assetWithID(99002)} />);
+
+    const podLabels = await screen.findAllByText("asset.k8sPods");
+    await user.click(podLabels[0]!);
+    await user.click(await screen.findByText("api"));
+    await screen.findByText("example/api:old");
+
+    await user.click(screen.getAllByRole("button", { name: "action.refresh" })[0]!);
+
+    await waitFor(() => {
+      expect(GetK8sPodDetail).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText("example/api:new")).toBeInTheDocument();
+    expect(screen.queryByText("example/api:old")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/k8s/K8sClusterPage.tsx
+++ b/frontend/src/components/k8s/K8sClusterPage.tsx
@@ -456,6 +456,166 @@ export function K8sClusterPage({ asset }: Props) {
       );
     }
 
+    for (const ns of Object.keys(namespacePodList)) {
+      setLoadingPods((prev) => new Set(prev).add(ns));
+      promises.push(
+        GetK8sNamespacePods(asset.ID, ns)
+          .then((result: string) => {
+            const data = JSON.parse(result) as PodListItem[];
+            setNamespacePodList((prev) => ({ ...prev, [ns]: data }));
+            setPodErrors((prev) => {
+              const next = { ...prev };
+              delete next[ns];
+              return next;
+            });
+          })
+          .catch((e: unknown) => {
+            setPodErrors((prev) => ({ ...prev, [ns]: String(e) }));
+          })
+          .finally(() => {
+            setLoadingPods((prev) => {
+              const next = new Set(prev);
+              next.delete(ns);
+              return next;
+            });
+          })
+      );
+    }
+
+    for (const ns of Object.keys(namespaceDeploymentList)) {
+      setLoadingDeployments((prev) => new Set(prev).add(ns));
+      promises.push(
+        GetK8sNamespaceDeployments(asset.ID, ns)
+          .then((result: string) => {
+            const data = JSON.parse(result) as DeploymentListItem[];
+            setNamespaceDeploymentList((prev) => ({ ...prev, [ns]: data }));
+            setDeploymentErrors((prev) => {
+              const next = { ...prev };
+              delete next[ns];
+              return next;
+            });
+          })
+          .catch((e: unknown) => {
+            setDeploymentErrors((prev) => ({ ...prev, [ns]: String(e) }));
+          })
+          .finally(() => {
+            setLoadingDeployments((prev) => {
+              const next = new Set(prev);
+              next.delete(ns);
+              return next;
+            });
+          })
+      );
+    }
+
+    for (const ns of Object.keys(namespaceServiceList)) {
+      setLoadingServices((prev) => new Set(prev).add(ns));
+      promises.push(
+        GetK8sNamespaceServices(asset.ID, ns)
+          .then((result: string) => {
+            const data = JSON.parse(result) as ServiceListItem[];
+            setNamespaceServiceList((prev) => ({ ...prev, [ns]: data }));
+            setServiceErrors((prev) => {
+              const next = { ...prev };
+              delete next[ns];
+              return next;
+            });
+          })
+          .catch((e: unknown) => {
+            setServiceErrors((prev) => ({ ...prev, [ns]: String(e) }));
+          })
+          .finally(() => {
+            setLoadingServices((prev) => {
+              const next = new Set(prev);
+              next.delete(ns);
+              return next;
+            });
+          })
+      );
+    }
+
+    for (const ns of Object.keys(namespaceConfigMapList)) {
+      setLoadingConfigMaps((prev) => new Set(prev).add(ns));
+      promises.push(
+        GetK8sNamespaceConfigMaps(asset.ID, ns)
+          .then((result: string) => {
+            const data = JSON.parse(result) as ConfigMapListItem[];
+            setNamespaceConfigMapList((prev) => ({ ...prev, [ns]: data }));
+            setConfigMapErrors((prev) => {
+              const next = { ...prev };
+              delete next[ns];
+              return next;
+            });
+          })
+          .catch((e: unknown) => {
+            setConfigMapErrors((prev) => ({ ...prev, [ns]: String(e) }));
+          })
+          .finally(() => {
+            setLoadingConfigMaps((prev) => {
+              const next = new Set(prev);
+              next.delete(ns);
+              return next;
+            });
+          })
+      );
+    }
+
+    for (const ns of Object.keys(namespaceSecretList)) {
+      setLoadingSecrets((prev) => new Set(prev).add(ns));
+      promises.push(
+        GetK8sNamespaceSecrets(asset.ID, ns)
+          .then((result: string) => {
+            const data = JSON.parse(result) as SecretListItem[];
+            setNamespaceSecretList((prev) => ({ ...prev, [ns]: data }));
+            setSecretErrors((prev) => {
+              const next = { ...prev };
+              delete next[ns];
+              return next;
+            });
+          })
+          .catch((e: unknown) => {
+            setSecretErrors((prev) => ({ ...prev, [ns]: String(e) }));
+          })
+          .finally(() => {
+            setLoadingSecrets((prev) => {
+              const next = new Set(prev);
+              next.delete(ns);
+              return next;
+            });
+          })
+      );
+    }
+
+    for (const key of Object.keys(podDetails)) {
+      const slashIdx = key.indexOf("/");
+      if (slashIdx === -1) continue;
+      const ns = key.slice(0, slashIdx);
+      const podName = key.slice(slashIdx + 1);
+      setLoadingPodDetails((prev) => new Set(prev).add(key));
+      promises.push(
+        GetK8sPodDetail(asset.ID, ns, podName)
+          .then((result: string) => {
+            const data = JSON.parse(result) as PodDetail;
+            setPodDetails((prev) => ({ ...prev, [key]: data }));
+            setPodDetailErrors((prev) => {
+              const next = { ...prev };
+              delete next[key];
+              return next;
+            });
+          })
+          .catch((e: unknown) => {
+            setPodDetailErrors((prev) => ({ ...prev, [key]: String(e) }));
+          })
+          .finally(() => {
+            setLoadingPodDetails((prev) => {
+              const next = new Set(prev);
+              next.delete(key);
+              return next;
+            });
+          })
+      );
+    }
+
     Promise.all(promises).finally(() => {
       setRefreshing(false);
     });

--- a/frontend/src/components/k8s/K8sClusterPage.tsx
+++ b/frontend/src/components/k8s/K8sClusterPage.tsx
@@ -417,6 +417,58 @@ export function K8sClusterPage({ asset }: Props) {
     setRefreshing(true);
     setAutoRefreshingItems(new Set());
     const promises: Promise<unknown>[] = [];
+    const refreshNamespaceList = <T,>(
+      namespaces: string[],
+      setLoadingItems: React.Dispatch<React.SetStateAction<Set<string>>>,
+      loadItems: (assetID: number, namespace: string) => Promise<string>,
+      setItems: React.Dispatch<React.SetStateAction<Record<string, T[]>>>,
+      setErrors: React.Dispatch<React.SetStateAction<Record<string, string>>>
+    ) => {
+      for (const ns of namespaces) {
+        setLoadingItems((prev) => new Set(prev).add(ns));
+        promises.push(
+          loadItems(asset.ID, ns)
+            .then((result: string) => {
+              const data = JSON.parse(result) as T[];
+              setItems((prev) => ({ ...prev, [ns]: data }));
+              setErrors((prev) => {
+                const next = { ...prev };
+                delete next[ns];
+                return next;
+              });
+            })
+            .catch((e: unknown) => {
+              setErrors((prev) => ({ ...prev, [ns]: String(e) }));
+            })
+            .finally(() => {
+              setLoadingItems((prev) => {
+                const next = new Set(prev);
+                next.delete(ns);
+                return next;
+              });
+            })
+        );
+      }
+    };
+    const openPodDetailKeys = new Set<string>();
+    for (const tab of innerTabs) {
+      if (tab.id.startsWith("pod:")) {
+        const parts = tab.id.split(":");
+        openPodDetailKeys.add(`${parts[1]}/${parts.slice(2).join(":")}`);
+      } else if (tab.id.startsWith("log:")) {
+        const parts = tab.id.split(":");
+        openPodDetailKeys.add(`${parts[1]}/${parts.slice(2).join(":")}`);
+      } else if (tab.id.startsWith("log-deploy:")) {
+        const parts = tab.id.split(":");
+        const ns = parts[1];
+        const deploymentName = parts.slice(2).join(":");
+        const deployment = namespaceDeploymentList[ns]?.find((d) => d.name === deploymentName);
+        const podName = logTabStates[tab.id]?.currentPod || deployment?.pods[0]?.name;
+        if (podName) {
+          openPodDetailKeys.add(`${ns}/${podName}`);
+        }
+      }
+    }
 
     promises.push(
       GetK8sClusterInfo(asset.ID)
@@ -456,137 +508,43 @@ export function K8sClusterPage({ asset }: Props) {
       );
     }
 
-    for (const ns of Object.keys(namespacePodList)) {
-      setLoadingPods((prev) => new Set(prev).add(ns));
-      promises.push(
-        GetK8sNamespacePods(asset.ID, ns)
-          .then((result: string) => {
-            const data = JSON.parse(result) as PodListItem[];
-            setNamespacePodList((prev) => ({ ...prev, [ns]: data }));
-            setPodErrors((prev) => {
-              const next = { ...prev };
-              delete next[ns];
-              return next;
-            });
-          })
-          .catch((e: unknown) => {
-            setPodErrors((prev) => ({ ...prev, [ns]: String(e) }));
-          })
-          .finally(() => {
-            setLoadingPods((prev) => {
-              const next = new Set(prev);
-              next.delete(ns);
-              return next;
-            });
-          })
-      );
-    }
+    refreshNamespaceList<PodListItem>(
+      Object.keys(namespacePodList),
+      setLoadingPods,
+      GetK8sNamespacePods,
+      setNamespacePodList,
+      setPodErrors
+    );
+    refreshNamespaceList<DeploymentListItem>(
+      Object.keys(namespaceDeploymentList),
+      setLoadingDeployments,
+      GetK8sNamespaceDeployments,
+      setNamespaceDeploymentList,
+      setDeploymentErrors
+    );
+    refreshNamespaceList<ServiceListItem>(
+      Object.keys(namespaceServiceList),
+      setLoadingServices,
+      GetK8sNamespaceServices,
+      setNamespaceServiceList,
+      setServiceErrors
+    );
+    refreshNamespaceList<ConfigMapListItem>(
+      Object.keys(namespaceConfigMapList),
+      setLoadingConfigMaps,
+      GetK8sNamespaceConfigMaps,
+      setNamespaceConfigMapList,
+      setConfigMapErrors
+    );
+    refreshNamespaceList<SecretListItem>(
+      Object.keys(namespaceSecretList),
+      setLoadingSecrets,
+      GetK8sNamespaceSecrets,
+      setNamespaceSecretList,
+      setSecretErrors
+    );
 
-    for (const ns of Object.keys(namespaceDeploymentList)) {
-      setLoadingDeployments((prev) => new Set(prev).add(ns));
-      promises.push(
-        GetK8sNamespaceDeployments(asset.ID, ns)
-          .then((result: string) => {
-            const data = JSON.parse(result) as DeploymentListItem[];
-            setNamespaceDeploymentList((prev) => ({ ...prev, [ns]: data }));
-            setDeploymentErrors((prev) => {
-              const next = { ...prev };
-              delete next[ns];
-              return next;
-            });
-          })
-          .catch((e: unknown) => {
-            setDeploymentErrors((prev) => ({ ...prev, [ns]: String(e) }));
-          })
-          .finally(() => {
-            setLoadingDeployments((prev) => {
-              const next = new Set(prev);
-              next.delete(ns);
-              return next;
-            });
-          })
-      );
-    }
-
-    for (const ns of Object.keys(namespaceServiceList)) {
-      setLoadingServices((prev) => new Set(prev).add(ns));
-      promises.push(
-        GetK8sNamespaceServices(asset.ID, ns)
-          .then((result: string) => {
-            const data = JSON.parse(result) as ServiceListItem[];
-            setNamespaceServiceList((prev) => ({ ...prev, [ns]: data }));
-            setServiceErrors((prev) => {
-              const next = { ...prev };
-              delete next[ns];
-              return next;
-            });
-          })
-          .catch((e: unknown) => {
-            setServiceErrors((prev) => ({ ...prev, [ns]: String(e) }));
-          })
-          .finally(() => {
-            setLoadingServices((prev) => {
-              const next = new Set(prev);
-              next.delete(ns);
-              return next;
-            });
-          })
-      );
-    }
-
-    for (const ns of Object.keys(namespaceConfigMapList)) {
-      setLoadingConfigMaps((prev) => new Set(prev).add(ns));
-      promises.push(
-        GetK8sNamespaceConfigMaps(asset.ID, ns)
-          .then((result: string) => {
-            const data = JSON.parse(result) as ConfigMapListItem[];
-            setNamespaceConfigMapList((prev) => ({ ...prev, [ns]: data }));
-            setConfigMapErrors((prev) => {
-              const next = { ...prev };
-              delete next[ns];
-              return next;
-            });
-          })
-          .catch((e: unknown) => {
-            setConfigMapErrors((prev) => ({ ...prev, [ns]: String(e) }));
-          })
-          .finally(() => {
-            setLoadingConfigMaps((prev) => {
-              const next = new Set(prev);
-              next.delete(ns);
-              return next;
-            });
-          })
-      );
-    }
-
-    for (const ns of Object.keys(namespaceSecretList)) {
-      setLoadingSecrets((prev) => new Set(prev).add(ns));
-      promises.push(
-        GetK8sNamespaceSecrets(asset.ID, ns)
-          .then((result: string) => {
-            const data = JSON.parse(result) as SecretListItem[];
-            setNamespaceSecretList((prev) => ({ ...prev, [ns]: data }));
-            setSecretErrors((prev) => {
-              const next = { ...prev };
-              delete next[ns];
-              return next;
-            });
-          })
-          .catch((e: unknown) => {
-            setSecretErrors((prev) => ({ ...prev, [ns]: String(e) }));
-          })
-          .finally(() => {
-            setLoadingSecrets((prev) => {
-              const next = new Set(prev);
-              next.delete(ns);
-              return next;
-            });
-          })
-      );
-    }
-
-    for (const key of Object.keys(podDetails)) {
+    for (const key of openPodDetailKeys) {
       const slashIdx = key.indexOf("/");
       if (slashIdx === -1) continue;
       const ns = key.slice(0, slashIdx);


### PR DESCRIPTION
## 变更
- 顶部刷新会重新拉取已加载的 K8s 资源列表：Pod、Deployment、Service、ConfigMap、Secret。
- 顶部刷新会更新已打开过的 Pod 详情。
- 增加前端测试覆盖已展开 Pod 列表刷新后替换旧数据。

## 根因
顶部刷新原先只刷新集群信息和 namespace 资源计数，没有刷新已经缓存在页面状态里的资源列表。Pod 状态变化但计数不变时，页面继续显示旧列表。

## 验证
- `pnpm --dir frontend exec vitest run src/__tests__/K8sClusterPage.refresh.test.tsx`
- `pnpm --dir frontend exec tsc -b --pretty false`
