### PR TITLE
✨ 分屏窗格独立工具条与固定/隐藏切换

### DIFF
--- a/frontend/src/__tests__/SessionToolbar.test.tsx
+++ b/frontend/src/__tests__/SessionToolbar.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SessionToolbar } from "@/components/terminal/SessionToolbar";
+import { useTerminalStore, type SplitNode } from "@/stores/terminalStore";
+import { useTabStore } from "@/stores/tabStore";
+import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
+
+const TAB = "tab1";
+
+function setup(paneIds: string[], activePaneId = paneIds[0]) {
+  const closePane = vi.fn();
+  const splitPane = vi.fn();
+  const reconnect = vi.fn();
+  const setActivePaneId = vi.fn();
+
+  const panes = Object.fromEntries(
+    paneIds.map((id) => [id, { sessionId: id, transport: "ssh" as const, connected: true, connectedAt: 0 }])
+  );
+  const splitTree: SplitNode =
+    paneIds.length > 1
+      ? {
+          type: "split",
+          direction: "vertical",
+          ratio: 0.5,
+          first: { type: "terminal", sessionId: paneIds[0] },
+          second: { type: "terminal", sessionId: paneIds[1] },
+        }
+      : { type: "terminal", sessionId: paneIds[0] };
+
+  useTerminalStore.setState({
+    tabData: { [TAB]: { splitTree, activePaneId, panes, directoryFollowMode: "off" } },
+    closePane,
+    splitPane,
+    reconnect,
+    setActivePaneId,
+  });
+  useTabStore.setState({
+    tabs: [
+      {
+        id: TAB,
+        type: "terminal",
+        label: "web-01",
+        meta: {
+          type: "terminal",
+          assetId: 1,
+          assetName: "web-01",
+          assetIcon: "",
+          host: "web-01",
+          port: 22,
+          username: "root",
+        },
+      },
+    ],
+    activeTabId: TAB,
+  });
+
+  return { closePane, splitPane, reconnect, setActivePaneId };
+}
+
+beforeEach(() => {
+  useTerminalThemeStore.setState({ toolbarPinned: true });
+});
+
+describe("SessionToolbar (per-pane)", () => {
+  it("shows the close button only when the tab is split, and closes that specific pane", () => {
+    const { closePane } = setup(["s1", "s2"]);
+    render(<SessionToolbar tabId={TAB} sessionId="s2" />);
+
+    const closeBtn = screen.getByTitle("ssh.contextMenu.closePane");
+    fireEvent.click(closeBtn);
+    expect(closePane).toHaveBeenCalledWith(TAB, "s2");
+  });
+
+  it("hides the close button when there is only a single pane", () => {
+    setup(["only"]);
+    render(<SessionToolbar tabId={TAB} sessionId="only" />);
+    expect(screen.queryByTitle("ssh.contextMenu.closePane")).toBeNull();
+  });
+
+  it("pin toggle flips the global toolbarPinned preference", () => {
+    setup(["s1"]);
+    render(<SessionToolbar tabId={TAB} sessionId="s1" />);
+
+    // Currently pinned → the button offers to auto-hide.
+    fireEvent.click(screen.getByTitle("ssh.session.autoHideToolbar"));
+    expect(useTerminalThemeStore.getState().toolbarPinned).toBe(false);
+  });
+
+  it("splitting focuses the owning pane first, then splits", () => {
+    const { splitPane, setActivePaneId } = setup(["s1", "s2"], "s1");
+    render(<SessionToolbar tabId={TAB} sessionId="s2" />);
+
+    fireEvent.click(screen.getByTitle("ssh.session.splitV"));
+    expect(setActivePaneId).toHaveBeenCalledWith(TAB, "s2");
+    expect(splitPane).toHaveBeenCalledWith(TAB, "vertical");
+  });
+});

--- a/frontend/src/components/layout/MainPanel.tsx
+++ b/frontend/src/components/layout/MainPanel.tsx
@@ -16,9 +16,6 @@ import { useLayoutStore } from "@/stores/layoutStore";
 const AssetDetail = lazy(() => import("@/components/asset/AssetDetail").then((m) => ({ default: m.AssetDetail })));
 const GroupDetail = lazy(() => import("@/components/asset/GroupDetail").then((m) => ({ default: m.GroupDetail })));
 const SplitPane = lazy(() => import("@/components/terminal/SplitPane").then((m) => ({ default: m.SplitPane })));
-const SessionToolbar = lazy(() =>
-  import("@/components/terminal/SessionToolbar").then((m) => ({ default: m.SessionToolbar }))
-);
 const TerminalToolbar = lazy(() =>
   import("@/components/terminal/TerminalToolbar").then((m) => ({ default: m.TerminalToolbar }))
 );
@@ -233,7 +230,6 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPa
               }}
             >
               <LazySurface>
-                <SessionToolbar tabId={tab.id} />
                 <div className="flex-1 min-h-0 overflow-hidden flex">
                   <div className="flex-1 min-w-0 overflow-hidden">
                     {data && (

--- a/frontend/src/components/terminal/SessionToolbar.tsx
+++ b/frontend/src/components/terminal/SessionToolbar.tsx
@@ -1,12 +1,15 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Columns2, Rows2, RotateCcw } from "lucide-react";
-import { Button } from "@opskat/ui";
+import { Columns2, Rows2, RotateCcw, Pin, PinOff, X } from "lucide-react";
+import { Button, cn } from "@opskat/ui";
 import { useTerminalStore, TRANSPORTS } from "@/stores/terminalStore";
 import { useTabStore, type TerminalTabMeta } from "@/stores/tabStore";
+import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 
 interface SessionToolbarProps {
   tabId: string;
+  /** The pane this toolbar belongs to. Each split pane renders its own toolbar. */
+  sessionId: string;
 }
 
 function formatUptime(connectedAt: number): string {
@@ -46,33 +49,35 @@ function useUptime(connectedAt: number | undefined, connected: boolean, active: 
   return elapsed;
 }
 
-export function SessionToolbar({ tabId }: SessionToolbarProps) {
+export function SessionToolbar({ tabId, sessionId }: SessionToolbarProps) {
   const { t } = useTranslation();
   const tabData = useTerminalStore((s) => s.tabData[tabId]);
   const splitPane = useTerminalStore((s) => s.splitPane);
   const reconnect = useTerminalStore((s) => s.reconnect);
-  const isActive = useTabStore((s) => s.activeTabId === tabId);
+  const closePane = useTerminalStore((s) => s.closePane);
+  const setActivePaneId = useTerminalStore((s) => s.setActivePaneId);
+  const isTabActive = useTabStore((s) => s.activeTabId === tabId);
+  const pinned = useTerminalThemeStore((s) => s.toolbarPinned);
+  const setToolbarPinned = useTerminalThemeStore((s) => s.setToolbarPinned);
 
   // hooks 必须在所有条件分支之前调用
-  const activePane = tabData ? tabData.panes[tabData.activePaneId] : undefined;
-  const activeConnected = activePane?.connected ?? false;
-  const uptime = useUptime(activePane?.connectedAt, activeConnected, isActive);
+  const pane = tabData?.panes[sessionId];
+  const paneConnected = pane?.connected ?? false;
+  const uptime = useUptime(pane?.connectedAt, paneConnected, isTabActive);
 
   const tabMeta = useTabStore((s) => {
     const t = s.tabs.find((t) => t.id === tabId);
     return t?.meta as TerminalTabMeta | undefined;
   });
 
-  if (!tabData) return null;
+  if (!tabData || !pane) return null;
 
-  // 连接中的 tab 没有有效的 pane，不显示工具栏
-  if (Object.keys(tabData.panes).length === 0) return null;
-
-  const paneValues = Object.values(tabData.panes);
-  const anyConnected = paneValues.some((p) => p.connected);
+  const paneCount = Object.keys(tabData.panes).length;
+  const isSplit = paneCount > 1;
+  const isActivePane = tabData.activePaneId === sessionId;
   // 仅当前 pane 的 transport 支持分屏才点亮分屏按钮(与右键菜单一致),
   // 否则像 serial 这种不可分屏的会出现"可点却无反应"的死按钮。
-  const canSplit = TRANSPORTS[activePane?.transport ?? "ssh"].canSplit;
+  const canSplit = TRANSPORTS[pane.transport ?? "ssh"].canSplit;
 
   const hostInfo =
     tabMeta?.username && tabMeta?.host
@@ -81,12 +86,21 @@ export function SessionToolbar({ tabId }: SessionToolbarProps) {
         ? `${tabMeta.host}${tabMeta.port !== 22 ? `:${tabMeta.port}` : ""}`
         : "";
 
+  // 拆分 / 重连作用于本窗格：先把它设为活动窗格，再执行 store 的活动窗格级操作。
+  const focusPane = () => setActivePaneId(tabId, sessionId);
+
   return (
-    <div className="flex items-center gap-1.5 px-2 py-1 border-b bg-background shrink-0 text-xs">
+    <div
+      className={cn(
+        "flex items-center gap-1.5 px-2 py-1 border-b shrink-0 text-xs",
+        // 分屏时非活动窗格的工具条淡化，帮助区分当前活动窗格；单窗格不淡化。
+        isSplit && !isActivePane ? "bg-muted/40" : "bg-background"
+      )}
+    >
       {/* 连接状态指示器 */}
       <span
-        className={`h-2 w-2 rounded-full shrink-0 ${anyConnected ? "bg-success" : "bg-destructive"}`}
-        title={anyConnected ? t("ssh.session.connected") : t("ssh.session.disconnected")}
+        className={`h-2 w-2 rounded-full shrink-0 ${paneConnected ? "bg-success" : "bg-destructive"}`}
+        title={paneConnected ? t("ssh.session.connected") : t("ssh.session.disconnected")}
       />
 
       {/* 主机信息 */}
@@ -102,13 +116,27 @@ export function SessionToolbar({ tabId }: SessionToolbarProps) {
 
       <div className="flex-1" />
 
+      {/* 固定 / 隐藏切换（全局，持久化）：固定时点击切到自动隐藏，反之亦然。 */}
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        title={pinned ? t("ssh.session.autoHideToolbar") : t("ssh.session.pinToolbar")}
+        aria-label={pinned ? t("ssh.session.autoHideToolbar") : t("ssh.session.pinToolbar")}
+        onClick={() => setToolbarPinned(!pinned)}
+      >
+        {pinned ? <Pin className="h-3.5 w-3.5" /> : <PinOff className="h-3.5 w-3.5" />}
+      </Button>
+
       {/* 分割窗格按钮 */}
       <Button
         variant="ghost"
         size="icon-xs"
         title={t("ssh.session.splitH")}
-        disabled={!anyConnected || !canSplit}
-        onClick={() => splitPane(tabId, "horizontal")}
+        disabled={!paneConnected || !canSplit}
+        onClick={() => {
+          focusPane();
+          splitPane(tabId, "horizontal");
+        }}
       >
         <Rows2 className="h-3.5 w-3.5" />
       </Button>
@@ -116,16 +144,40 @@ export function SessionToolbar({ tabId }: SessionToolbarProps) {
         variant="ghost"
         size="icon-xs"
         title={t("ssh.session.splitV")}
-        disabled={!anyConnected || !canSplit}
-        onClick={() => splitPane(tabId, "vertical")}
+        disabled={!paneConnected || !canSplit}
+        onClick={() => {
+          focusPane();
+          splitPane(tabId, "vertical");
+        }}
       >
         <Columns2 className="h-3.5 w-3.5" />
       </Button>
 
       {/* 重新连接 */}
-      <Button variant="ghost" size="icon-xs" title={t("ssh.session.reconnect")} onClick={() => reconnect(tabId)}>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        title={t("ssh.session.reconnect")}
+        onClick={() => {
+          focusPane();
+          reconnect(tabId);
+        }}
+      >
         <RotateCcw className="h-3.5 w-3.5" />
       </Button>
+
+      {/* 关闭窗格：仅在分屏时出现——单窗格用关闭标签页即可，这里补上「选中即复制/右键粘贴」下丢失的关闭入口。 */}
+      {isSplit && (
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          title={t("ssh.contextMenu.closePane")}
+          aria-label={t("ssh.contextMenu.closePane")}
+          onClick={() => closePane(tabId, sessionId)}
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/terminal/SplitPane.tsx
+++ b/frontend/src/components/terminal/SplitPane.tsx
@@ -2,7 +2,9 @@ import { useRef, useCallback, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { Terminal } from "./Terminal";
 import { ConnectionProgress } from "./ConnectionProgress";
+import { SessionToolbar } from "./SessionToolbar";
 import { useTerminalStore, type SplitNode } from "@/stores/terminalStore";
+import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 
 interface SplitPaneProps {
   node: SplitNode;
@@ -15,21 +17,14 @@ interface SplitPaneProps {
 
 export function SplitPane({ node, tabId, isTabActive, activePaneId, showFocusRing, path }: SplitPaneProps) {
   if (node.type === "terminal") {
-    const isFocused = activePaneId === node.sessionId;
     return (
-      <div
-        className="h-full w-full relative"
-        onMouseDown={() => {
-          if (!isFocused) {
-            useTerminalStore.getState().setActivePaneId(tabId, node.sessionId);
-          }
-        }}
-      >
-        {showFocusRing && isFocused && (
-          <div className="absolute inset-0 ring-1 ring-primary/40 rounded-sm pointer-events-none z-10" />
-        )}
-        <Terminal sessionId={node.sessionId} active={isTabActive} tabId={tabId} />
-      </div>
+      <TerminalPaneView
+        tabId={tabId}
+        sessionId={node.sessionId}
+        isTabActive={isTabActive}
+        isFocused={activePaneId === node.sessionId}
+        showFocusRing={showFocusRing}
+      />
     );
   }
 
@@ -54,6 +49,60 @@ export function SplitPane({ node, tabId, isTabActive, activePaneId, showFocusRin
       showFocusRing={showFocusRing}
       path={path}
     />
+  );
+}
+
+interface TerminalPaneViewProps {
+  tabId: string;
+  sessionId: string;
+  isTabActive: boolean;
+  isFocused: boolean;
+  showFocusRing: boolean;
+}
+
+// 单个终端窗格：顶部挂本窗格的工具条。固定态常驻；隐藏态默认收起、
+// 鼠标移到窗格顶部时向下滑出并浮在终端内容之上（不挤压内容）。
+function TerminalPaneView({ tabId, sessionId, isTabActive, isFocused, showFocusRing }: TerminalPaneViewProps) {
+  const toolbarPinned = useTerminalThemeStore((s) => s.toolbarPinned);
+
+  const terminal = (
+    <div className="flex-1 min-h-0">
+      <Terminal sessionId={sessionId} active={isTabActive} tabId={tabId} />
+    </div>
+  );
+
+  return (
+    <div
+      className="h-full w-full relative flex flex-col"
+      onMouseDown={() => {
+        if (!isFocused) {
+          useTerminalStore.getState().setActivePaneId(tabId, sessionId);
+        }
+      }}
+    >
+      {showFocusRing && isFocused && (
+        <div className="absolute inset-0 ring-1 ring-primary/40 rounded-sm pointer-events-none z-30" />
+      )}
+      {toolbarPinned ? (
+        <>
+          <SessionToolbar tabId={tabId} sessionId={sessionId} />
+          {terminal}
+        </>
+      ) : (
+        <>
+          {terminal}
+          {/* 隐藏态：透明悬停触发条 + 向下滑出的浮层工具条（被外层 overflow-hidden 裁掉上移部分）。 */}
+          <div className="absolute inset-x-0 top-0 z-20">
+            <div className="peer h-2 w-full" />
+            {/* 未悬停时的极简提示手柄，悬停后淡出 */}
+            <div className="pointer-events-none absolute left-1/2 top-1 h-1 w-8 -translate-x-1/2 rounded-full bg-foreground/15 transition-opacity duration-150 peer-hover:opacity-0" />
+            <div className="-translate-y-full shadow-md transition-transform duration-200 ease-out peer-hover:translate-y-0 hover:translate-y-0">
+              <SessionToolbar tabId={tabId} sessionId={sessionId} />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -734,6 +734,8 @@
       "disconnect": "Disconnect",
       "splitH": "Split Horizontal",
       "splitV": "Split Vertical",
+      "pinToolbar": "Pin toolbar",
+      "autoHideToolbar": "Auto-hide toolbar",
       "connected": "Connected",
       "disconnected": "Disconnected",
       "closedHint": "[Connection closed — press Enter to reconnect]"

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -734,6 +734,8 @@
       "disconnect": "断开连接",
       "splitH": "水平分割",
       "splitV": "垂直分割",
+      "pinToolbar": "固定工具栏",
+      "autoHideToolbar": "自动隐藏工具栏",
       "connected": "已连接",
       "disconnected": "已断开",
       "closedHint": "[连接已断开 — 按回车重连]"

--- a/frontend/src/stores/terminalThemeStore.ts
+++ b/frontend/src/stores/terminalThemeStore.ts
@@ -36,6 +36,8 @@ interface TerminalThemeState {
   webglEnabled: boolean;
   highlightLinks: boolean;
   copyBehavior: TerminalCopyBehavior;
+  // 分屏窗格顶部工具条：true = 固定常驻；false = 隐藏，鼠标移到窗格顶部时向下滑出。
+  toolbarPinned: boolean;
   // 最近一次 WebGL 自动关闭的原因。setWebglEnabled(true) 会把它清掉，所以只在
   // GPU 加速被系统自动关掉后到下一次用户主动开启之间存在。
   webglError: WebglFailure | null;
@@ -48,6 +50,7 @@ interface TerminalThemeState {
   setWebglEnabled: (enabled: boolean) => void;
   setHighlightLinks: (enabled: boolean) => void;
   setCopyBehavior: (behavior: TerminalCopyBehavior) => void;
+  setToolbarPinned: (pinned: boolean) => void;
   reportWebglFailure: (failure: WebglFailure) => void;
   addCustomTheme: (theme: TerminalTheme) => void;
   updateCustomTheme: (theme: TerminalTheme) => void;
@@ -82,6 +85,7 @@ export const useTerminalThemeStore = create<TerminalThemeState>()(
       webglEnabled: true,
       highlightLinks: false,
       copyBehavior: "popover-menu",
+      toolbarPinned: true,
       webglError: null,
 
       setSelectedThemeId: (id) => set({ selectedThemeId: id }),
@@ -90,6 +94,7 @@ export const useTerminalThemeStore = create<TerminalThemeState>()(
       setWebglEnabled: (enabled) => set(enabled ? { webglEnabled: true, webglError: null } : { webglEnabled: false }),
       setHighlightLinks: (enabled) => set({ highlightLinks: enabled }),
       setCopyBehavior: (behavior) => set({ copyBehavior: behavior }),
+      setToolbarPinned: (pinned) => set({ toolbarPinned: pinned }),
       reportWebglFailure: (failure) => set({ webglError: failure }),
 
       setFontSize: (size) => set({ fontSize: Math.max(8, Math.min(32, size)) }),


### PR DESCRIPTION
## 变更说明 / Summary

重做 #191 中「给分割窗口单独添加关闭按钮」的部分（原 PR 的右上角 X 会压住 xterm 滚动条，已弃用），落点对齐现有 `SessionToolbar`：

- **顶部工具条改为按窗格**：现有 `SessionToolbar` 从「每标签一条」改造成「每个分屏窗格各一条」，显示本窗格的 `● 状态 · user@host:port · 时长`，活动窗格高亮、非活动淡化（单窗格时即整窗口顶栏，视觉不变）。
- **关闭窗格按钮 ✕**：仅在分屏时出现（中性色，不描红），补上「选中即复制 / 右键粘贴」模式下右键菜单被占用、无法关闭单个分屏窗格的入口。
- **固定 / 隐藏切换（图钉）**：全局持久化偏好 `terminalThemeStore.toolbarPinned`（默认固定）。
  - 固定：工具条常驻。
  - 隐藏：默认收起、最大化终端可视区；鼠标移到窗格顶部时向下滑出浮层，浮在内容之上、不挤压终端。

UI/UX 定稿于设计稿 `opskat.pen`「分屏窗格工具条 · 固定/隐藏（定稿）」。

## 未包含 / Out of scope

#191 的另一半「禁用快捷键按钮」未包含 —— 按此前讨论，全局禁用不合适，应仅禁用终端内快捷键，后续单独处理。

## 自检 / Checklist

- [x] `tsc -b` 通过、eslint 通过
- [x] 全量前端测试通过（1547 passed / 154 files），含新增 `SessionToolbar.test.tsx`
- [ ] 隐藏态悬停下滑动画为纯 CSS，需真机 `wails dev` 眼过