### PR TITLE
✨ SQL 编辑器新增字段（列）级联想补全

### DIFF
--- a/frontend/src/__tests__/queryStore.test.ts
+++ b/frontend/src/__tests__/queryStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useTabStore } from "../stores/tabStore";
 import { useQueryStore } from "../stores/queryStore";
 import { useAssetStore } from "../stores/assetStore";
-import { asset_entity } from "../../wailsjs/go/models";
+import { asset_entity, query_svc } from "../../wailsjs/go/models";
 import { ExecuteSQL, ListDatabaseObjects } from "../../wailsjs/go/query/Query";
 import { RedisGetKeyDetail } from "../../wailsjs/go/redis/Redis";
 import { RedisListDatabases, RedisScanKeys } from "../../wailsjs/go/redis/Redis";
@@ -553,7 +553,7 @@ describe("queryStore database actions", () => {
       procedures: [],
       functions: [],
       triggers: [{ name: "trg_orders_ai", type: "trigger" }],
-    });
+    } as unknown as query_svc.DatabaseObjects);
 
     await useQueryStore.getState().refreshTables("query-30", "main");
 

--- a/frontend/src/components/query/SqlEditorTab.tsx
+++ b/frontend/src/components/query/SqlEditorTab.tsx
@@ -23,6 +23,7 @@ import { QueryResultTable } from "./QueryResultTable";
 import { CodeEditor } from "@/components/CodeEditor";
 import { SnippetPopover } from "@/components/snippet/SnippetPopover";
 import type { DynamicCompletionGetter } from "@/lib/monaco-completions";
+import { buildSqlCompletions, resolveScopeTables, type SqlColumn } from "@/lib/sql-context";
 
 interface SqlEditorTabProps {
   tabId: string;
@@ -47,6 +48,7 @@ export const SqlEditorTab = memo(function SqlEditorTab({ tabId, innerTabId }: Sq
   const dbState = useQueryStore((s) => s.dbStates[tabId]);
   const updateInnerTab = useQueryStore((s) => s.updateInnerTab);
   const addSqlHistory = useQueryStore((s) => s.addSqlHistory);
+  const loadTableMeta = useQueryStore((s) => s.loadTableMeta);
   const tab = useTabStore((s) => s.tabs.find((t) => t.id === tabId));
   const queryMeta = tab?.meta as QueryTabMeta | undefined;
   const editorRef = useRef<MonacoNS.editor.IStandaloneCodeEditor | null>(null);
@@ -230,6 +232,10 @@ export const SqlEditorTab = memo(function SqlEditorTab({ tabId, innerTabId }: Sq
     executeRef.current = execute;
   }, [execute]);
 
+  // 字段补全的按需预取：用 ref 桥接，供 onMount 时注册的内容变化回调调用最新实现。
+  const prefetchColumnsRef = useRef<(sql: string) => void>(() => {});
+  const inflightMetaRef = useRef<Set<string>>(new Set());
+
   const handleEditorMount = useCallback((editor: MonacoNS.editor.IStandaloneCodeEditor, monaco: typeof MonacoNS) => {
     editorRef.current = editor;
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
@@ -253,6 +259,7 @@ export const SqlEditorTab = memo(function SqlEditorTab({ tabId, innerTabId }: Sq
         timer = setTimeout(() => {
           timer = null;
           commitSqlRef.current();
+          prefetchColumnsRef.current(sqlRef.current);
         }, 300);
       });
     }
@@ -279,20 +286,67 @@ export const SqlEditorTab = memo(function SqlEditorTab({ tabId, innerTabId }: Sq
     editor.focus();
   }, []);
 
-  // 把当前选中库的表名注入到 monaco 补全（在 . 触发或主动唤起时一并出现）
+  // 当前选中库下的表 + 已加载表结构，一并注入 monaco 补全（表名 & 字段）。
   const tables = useMemo(() => dbState?.tables?.[selectedDb] ?? [], [dbState?.tables, selectedDb]);
-  const tableCompletions = useCallback<DynamicCompletionGetter>(
-    ({ monaco, range }) =>
-      tables.map((tableName) => ({
-        label: tableName,
-        kind: monaco.languages.CompletionItemKind.Class,
-        insertText: tableName,
-        detail: selectedDb ? `table · ${selectedDb}` : "table",
+  const loadedMeta = dbState?.tableMeta;
+
+  // 规范表名 -> 列，供 buildSqlCompletions 组装字段项（key 与 tables 中的条目一致）。
+  const columnsByTable = useMemo(() => {
+    const map: Record<string, SqlColumn[]> = {};
+    if (loadedMeta) {
+      for (const tname of tables) {
+        const cols = loadedMeta[`${selectedDb}.${tname}`]?.columns;
+        if (cols) map[tname] = cols;
+      }
+    }
+    return map;
+  }, [loadedMeta, tables, selectedDb]);
+
+  const sqlCompletions = useCallback<DynamicCompletionGetter>(
+    ({ monaco, range, model, position }) => {
+      const line = model.getLineContent(position.lineNumber);
+      const textBeforeCursor = line.slice(0, position.column - 1);
+      return buildSqlCompletions({
+        textBeforeCursor,
+        fullSql: model.getValue(),
+        tables,
+        db: selectedDb,
+        columnsByTable,
+      }).map((it) => ({
+        label: it.label,
+        kind:
+          it.kind === "column" ? monaco.languages.CompletionItemKind.Field : monaco.languages.CompletionItemKind.Class,
+        insertText: it.insertText,
+        detail: it.detail,
         range,
-        sortText: "0_" + tableName, // 表名排在关键字之前
-      })),
-    [tables, selectedDb]
+        sortText: it.sortText,
+      }));
+    },
+    [tables, selectedDb, columnsByTable]
   );
+
+  // 预取当前 SQL 中 FROM/JOIN 涉及的表结构（去重 + 跳过在途/已缓存）。字段补全同步读取缓存。
+  const prefetchColumns = useCallback(
+    (sql: string) => {
+      if (!selectedDb) return;
+      for (const tname of resolveScopeTables(sql, tables)) {
+        const key = `${selectedDb}.${tname}`;
+        if (loadedMeta?.[key] || inflightMetaRef.current.has(key)) continue;
+        inflightMetaRef.current.add(key);
+        void Promise.resolve(loadTableMeta(tabId, selectedDb, tname)).finally(() =>
+          inflightMetaRef.current.delete(key)
+        );
+      }
+    },
+    [selectedDb, tables, loadedMeta, loadTableMeta, tabId]
+  );
+  useEffect(() => {
+    prefetchColumnsRef.current = prefetchColumns;
+  }, [prefetchColumns]);
+  // 初次加载 / 切库 / 表列表就绪后，预取一次已有 SQL 涉及的表结构。
+  useEffect(() => {
+    prefetchColumnsRef.current(sqlRef.current);
+  }, [selectedDb, tables]);
 
   const handlePageInputConfirm = useCallback(() => {
     const num = parseInt(pageInput, 10);
@@ -387,7 +441,7 @@ export const SqlEditorTab = memo(function SqlEditorTab({ tabId, innerTabId }: Sq
             language="sql"
             placeholder={t("query.sqlPlaceholder")}
             onMount={handleEditorMount}
-            dynamicCompletions={tableCompletions}
+            dynamicCompletions={sqlCompletions}
           />
         </div>
       </div>

--- a/frontend/src/lib/__tests__/sql-context.test.ts
+++ b/frontend/src/lib/__tests__/sql-context.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import { parseTableRefs, dotPrefixAt, resolveTableName, resolveScopeTables, buildSqlCompletions } from "../sql-context";
+
+describe("parseTableRefs", () => {
+  it("extracts a single unaliased table from FROM", () => {
+    expect(parseTableRefs("SELECT * FROM users")).toEqual([{ table: "users" }]);
+  });
+
+  it("extracts alias written without AS", () => {
+    expect(parseTableRefs("SELECT * FROM users u")).toEqual([{ table: "users", alias: "u" }]);
+  });
+
+  it("extracts alias written with AS (case-insensitive)", () => {
+    expect(parseTableRefs("select * from users as u")).toEqual([{ table: "users", alias: "u" }]);
+  });
+
+  it("extracts tables from FROM + JOIN with aliases", () => {
+    const sql = "SELECT * FROM users u JOIN orders o ON u.id = o.user_id";
+    expect(parseTableRefs(sql)).toEqual([
+      { table: "users", alias: "u" },
+      { table: "orders", alias: "o" },
+    ]);
+  });
+
+  it("extracts comma-separated tables in FROM", () => {
+    expect(parseTableRefs("SELECT * FROM a, b")).toEqual([{ table: "a" }, { table: "b" }]);
+  });
+
+  it("keeps schema-qualified table names", () => {
+    expect(parseTableRefs("SELECT * FROM public.users u")).toEqual([{ table: "public.users", alias: "u" }]);
+  });
+
+  it("strips surrounding quotes/backticks/brackets", () => {
+    expect(parseTableRefs("SELECT * FROM `users`")).toEqual([{ table: "users" }]);
+    expect(parseTableRefs('SELECT * FROM "users"')).toEqual([{ table: "users" }]);
+    expect(parseTableRefs("SELECT * FROM [dbo].[Orders]")).toEqual([{ table: "dbo.Orders" }]);
+  });
+
+  it("does not treat a following clause keyword as an alias", () => {
+    expect(parseTableRefs("SELECT * FROM users WHERE id = 1")).toEqual([{ table: "users" }]);
+  });
+
+  it("does not treat a JOIN modifier keyword as an alias", () => {
+    expect(parseTableRefs("SELECT * FROM a LEFT JOIN b ON a.id = b.a_id")).toEqual([{ table: "a" }, { table: "b" }]);
+  });
+
+  it("returns empty when there is no FROM/JOIN", () => {
+    expect(parseTableRefs("SELECT 1")).toEqual([]);
+  });
+});
+
+describe("dotPrefixAt", () => {
+  it("returns the identifier when cursor is right after a dot", () => {
+    expect(dotPrefixAt("SELECT u.")).toBe("u");
+  });
+
+  it("returns the identifier when a partial column is typed after the dot", () => {
+    expect(dotPrefixAt("SELECT u.na")).toBe("u");
+  });
+
+  it("returns the table name for a bare-table dot", () => {
+    expect(dotPrefixAt("SELECT users.")).toBe("users");
+  });
+
+  it("returns the last segment for a schema-qualified dot", () => {
+    expect(dotPrefixAt("SELECT * FROM public.users.")).toBe("users");
+  });
+
+  it("returns null when there is no trailing dot expression", () => {
+    expect(dotPrefixAt("SELECT * FROM u")).toBeNull();
+    expect(dotPrefixAt("SELECT 1")).toBeNull();
+  });
+});
+
+describe("resolveTableName", () => {
+  const pgTables = ["public.users", "public.orders"];
+
+  it("matches an exact table name", () => {
+    expect(resolveTableName("users", ["users", "orders"])).toBe("users");
+  });
+
+  it("matches case-insensitively but returns the canonical casing", () => {
+    expect(resolveTableName("Users", ["users"])).toBe("users");
+  });
+
+  it("resolves an unqualified name to a schema-qualified table by last segment", () => {
+    expect(resolveTableName("users", pgTables)).toBe("public.users");
+  });
+
+  it("matches a fully schema-qualified reference", () => {
+    expect(resolveTableName("public.users", pgTables)).toBe("public.users");
+  });
+
+  it("strips quotes before matching", () => {
+    expect(resolveTableName("`users`", ["users"])).toBe("users");
+  });
+
+  it("returns null for an unknown table", () => {
+    expect(resolveTableName("missing", ["users"])).toBeNull();
+  });
+});
+
+describe("resolveScopeTables", () => {
+  it("returns the canonical tables referenced in FROM/JOIN", () => {
+    const sql = "SELECT * FROM users u JOIN orders o ON u.id = o.user_id";
+    expect(resolveScopeTables(sql, ["users", "orders"]).sort()).toEqual(["orders", "users"]);
+  });
+
+  it("dedupes a table referenced more than once", () => {
+    expect(resolveScopeTables("SELECT * FROM users u, users u2", ["users"])).toEqual(["users"]);
+  });
+
+  it("resolves unqualified names to schema-qualified tables", () => {
+    expect(resolveScopeTables("SELECT * FROM users", ["public.users"])).toEqual(["public.users"]);
+  });
+
+  it("drops references that match no known table", () => {
+    expect(resolveScopeTables("SELECT * FROM missing", ["users"])).toEqual([]);
+  });
+});
+
+describe("buildSqlCompletions", () => {
+  const columnsByTable = {
+    users: [
+      { name: "id", type: "int", nullable: false, primaryKey: true },
+      { name: "email", type: "varchar(255)", nullable: true, primaryKey: false },
+    ],
+    orders: [{ name: "user_id", type: "int", nullable: false, primaryKey: false }],
+  };
+
+  it("suggests only that table's columns after `alias.`", () => {
+    const items = buildSqlCompletions({
+      textBeforeCursor: "SELECT u.",
+      fullSql: "SELECT u. FROM users u",
+      tables: ["users"],
+      db: "app",
+      columnsByTable,
+    });
+    expect(items.every((i) => i.kind === "column")).toBe(true);
+    expect(items.map((i) => i.label).sort()).toEqual(["email", "id"]);
+  });
+
+  it("marks primary-key columns and shows the type + owner in detail", () => {
+    const items = buildSqlCompletions({
+      textBeforeCursor: "SELECT u.",
+      fullSql: "SELECT u. FROM users u",
+      tables: ["users"],
+      db: "app",
+      columnsByTable,
+    });
+    const id = items.find((i) => i.label === "id")!;
+    expect(id.detail).toContain("int");
+    expect(id.detail).toContain("u");
+    expect(id.detail).toContain("🔑");
+    const email = items.find((i) => i.label === "email")!;
+    expect(email.detail).not.toContain("🔑");
+  });
+
+  it("resolves a bare `table.` prefix to that table's columns", () => {
+    const items = buildSqlCompletions({
+      textBeforeCursor: "SELECT users.",
+      fullSql: "SELECT users. FROM users",
+      tables: ["users"],
+      db: "app",
+      columnsByTable,
+    });
+    expect(items.map((i) => i.label).sort()).toEqual(["email", "id"]);
+  });
+
+  it("returns nothing for a dot on an unknown alias/table", () => {
+    const items = buildSqlCompletions({
+      textBeforeCursor: "SELECT x.",
+      fullSql: "SELECT x. FROM users u",
+      tables: ["users"],
+      db: "app",
+      columnsByTable,
+    });
+    expect(items).toEqual([]);
+  });
+
+  it("bare word: suggests in-scope columns and tables, columns ranked first", () => {
+    const items = buildSqlCompletions({
+      textBeforeCursor: "SELECT ",
+      fullSql: "SELECT  FROM users u JOIN orders o ON u.id = o.user_id",
+      tables: ["users", "orders"],
+      db: "app",
+      columnsByTable,
+    });
+    const cols = items.filter((i) => i.kind === "column");
+    const tbls = items.filter((i) => i.kind === "table");
+    expect(cols.map((i) => i.label)).toEqual(expect.arrayContaining(["id", "email", "user_id"]));
+    expect(tbls.map((i) => i.label)).toEqual(expect.arrayContaining(["users", "orders"]));
+    // every column sorts before every table
+    const maxColSort = cols
+      .map((i) => i.sortText)
+      .sort()
+      .at(-1)!;
+    const minTableSort = tbls.map((i) => i.sortText).sort()[0];
+    expect(maxColSort < minTableSort).toBe(true);
+  });
+
+  it("bare word with no FROM: suggests only tables (no columns)", () => {
+    const items = buildSqlCompletions({
+      textBeforeCursor: "SELECT * FROM ",
+      fullSql: "SELECT * FROM ",
+      tables: ["users", "orders"],
+      db: "app",
+      columnsByTable,
+    });
+    expect(items.every((i) => i.kind === "table")).toBe(true);
+    expect(items.map((i) => i.label).sort()).toEqual(["orders", "users"]);
+  });
+
+  it("table items carry a `table · <db>` detail", () => {
+    const items = buildSqlCompletions({
+      textBeforeCursor: "SELECT * FROM ",
+      fullSql: "SELECT * FROM ",
+      tables: ["users"],
+      db: "app",
+      columnsByTable,
+    });
+    expect(items[0].detail).toContain("app");
+  });
+});

--- a/frontend/src/lib/sql-context.ts
+++ b/frontend/src/lib/sql-context.ts
@@ -1,0 +1,232 @@
+// SQL 上下文解析 + 补全项构建（纯函数，无 Monaco / React 依赖，便于单测）。
+//
+// SqlEditorTab 在 monaco 补全回调里调用 buildSqlCompletions，得到"表 + 字段"两类动态项，
+// 再映射成 monaco 的 CompletionItem（关键字 / 函数由 monaco-completions.ts 的 provider 统一附加）。
+//
+// 字段联想依赖调用方把已加载的表结构（GetTableMetadata 的 columns）按"表名 -> 列"传进来，
+// 表名的规范形式与 queryStore.dbStates[tab].tables[db] 中的条目一致
+// （MySQL/SQLite 为裸表名，PostgreSQL/MSSQL 为 schema.table）。
+
+export interface TableRef {
+  table: string;
+  alias?: string;
+}
+
+export interface SqlColumn {
+  name: string;
+  type?: string;
+  nullable?: boolean;
+  primaryKey?: boolean;
+}
+
+export interface SqlCompletionItem {
+  label: string;
+  kind: "table" | "column";
+  insertText: string;
+  detail?: string;
+  sortText: string;
+}
+
+export interface BuildSqlCompletionsArgs {
+  /** 光标所在行、光标之前的文本，用于判断是否处于 `xxx.` 之后。 */
+  textBeforeCursor: string;
+  /** 整段 SQL，用于解析 FROM / JOIN 中在作用域内的表。 */
+  fullSql: string;
+  /** 当前库下已知的表（规范表名，与 queryStore 中的列表一致）。 */
+  tables: string[];
+  /** 当前库名，仅用于表项的 detail 展示。 */
+  db: string;
+  /** 规范表名 -> 列，由调用方从已缓存的表结构组装。 */
+  columnsByTable: Record<string, SqlColumn[]>;
+}
+
+// 允许出现在表名后、但不能被当作别名的关键字。
+const RESERVED_ALIAS = new Set([
+  "on",
+  "where",
+  "group",
+  "order",
+  "having",
+  "limit",
+  "offset",
+  "join",
+  "inner",
+  "left",
+  "right",
+  "outer",
+  "cross",
+  "full",
+  "union",
+  "set",
+  "using",
+  "as",
+  "and",
+  "or",
+  "natural",
+  "lateral",
+  "fetch",
+  "for",
+  "window",
+  "returning",
+  "values",
+  "into",
+  "select",
+  "from",
+]);
+
+// 可带 schema 前缀、可被 ` " [] 包裹的标识符。
+const IDENT = '[`"\\[]?[\\w$]+[`"\\]]?(?:\\.[`"\\[]?[\\w$]+[`"\\]]?)*';
+
+// FROM 列表在遇到这些关键字时结束（其后是 JOIN / WHERE 等子句）。
+const FROM_TERMINATORS =
+  "where|group|order|having|limit|offset|union|join|inner|left|right|outer|cross|full|natural|lateral|on";
+
+/** 去除标识符各段外层的 ` " [] 引号。 */
+function stripQuotes(id: string): string {
+  return id
+    .split(".")
+    .map((seg) => seg.replace(/^[`"[]/, "").replace(/[`"\]]$/, ""))
+    .join(".");
+}
+
+/** 取标识符最后一段（去 schema 前缀），用作展示 owner。 */
+function shortName(table: string): string {
+  const t = stripQuotes(table);
+  const dot = t.lastIndexOf(".");
+  return dot >= 0 ? t.slice(dot + 1) : t;
+}
+
+function makeRef(table: string, alias: string | undefined): TableRef {
+  return alias ? { table, alias } : { table };
+}
+
+/** 从一个表来源片段（如 "users u" / "public.orders AS o"）解析出表名与可选别名。 */
+function parseFragment(fragment: string): TableRef | null {
+  const m = new RegExp(`^\\s*(${IDENT})(?:\\s+(?:as\\s+)?([\\w$]+))?`, "i").exec(fragment);
+  if (!m) return null;
+  const table = stripQuotes(m[1]);
+  const alias = m[2] && !RESERVED_ALIAS.has(m[2].toLowerCase()) ? m[2] : undefined;
+  return makeRef(table, alias);
+}
+
+/** 解析 SQL 中 FROM / JOIN 引用的表（含别名）。尽力而为的轻量解析，覆盖常见写法。 */
+export function parseTableRefs(sql: string): TableRef[] {
+  const refs: TableRef[] = [];
+
+  // FROM 列表（逗号分隔），到下一个子句关键字为止。
+  const fromRe = new RegExp(`\\bfrom\\s+([\\s\\S]*?)(?=\\b(?:${FROM_TERMINATORS})\\b|;|$)`, "gi");
+  for (let m = fromRe.exec(sql); m; m = fromRe.exec(sql)) {
+    for (const fragment of m[1].split(",")) {
+      const ref = parseFragment(fragment);
+      if (ref) refs.push(ref);
+    }
+  }
+
+  // 各 JOIN 子句：JOIN <table> [alias] [ON ...]
+  const joinRe = new RegExp(`\\bjoin\\s+(${IDENT})(?:\\s+(?:as\\s+)?([\\w$]+))?`, "gi");
+  for (let m = joinRe.exec(sql); m; m = joinRe.exec(sql)) {
+    const table = stripQuotes(m[1]);
+    const alias = m[2] && !RESERVED_ALIAS.has(m[2].toLowerCase()) ? m[2] : undefined;
+    refs.push(makeRef(table, alias));
+  }
+
+  return refs;
+}
+
+/** 若光标正处于 `ident.` 之后，返回该点号前的标识符（别名或表名的末段），否则返回 null。 */
+export function dotPrefixAt(textBeforeCursor: string): string | null {
+  const m = /([\w$]+)\.[\w$]*$/.exec(textBeforeCursor);
+  return m ? m[1] : null;
+}
+
+/** 把一个解析出的表名解析为已知表列表中的规范表名，匹配不到返回 null。 */
+export function resolveTableName(ref: string, tables: string[]): string | null {
+  const norm = stripQuotes(ref).toLowerCase();
+  for (const t of tables) {
+    if (stripQuotes(t).toLowerCase() === norm) return t;
+  }
+  // 未带 schema 的引用：按末段匹配（如 users -> public.users）
+  if (!norm.includes(".")) {
+    for (const t of tables) {
+      const tl = stripQuotes(t).toLowerCase();
+      if (tl.slice(tl.lastIndexOf(".") + 1) === norm) return t;
+    }
+  }
+  return null;
+}
+
+/** 解析 SQL 中 FROM/JOIN 引用、且能对应到已知表列表的规范表名（去重）。用于按需预取表结构。 */
+export function resolveScopeTables(sql: string, tables: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const ref of parseTableRefs(sql)) {
+    const canonical = resolveTableName(ref.table, tables);
+    if (canonical && !seen.has(canonical)) {
+      seen.add(canonical);
+      out.push(canonical);
+    }
+  }
+  return out;
+}
+
+function columnItem(col: SqlColumn, owner: string): SqlCompletionItem {
+  const pk = col.primaryKey ? " 🔑" : "";
+  const detail = `${col.type ?? ""}${pk} · ${owner}`.trim();
+  return { label: col.name, kind: "column", insertText: col.name, detail, sortText: "00_" + col.name };
+}
+
+function tableItem(table: string, db: string): SqlCompletionItem {
+  return {
+    label: table,
+    kind: "table",
+    insertText: table,
+    detail: db ? `table · ${db}` : "table",
+    sortText: "01_" + table,
+  };
+}
+
+/**
+ * 构建 SQL 动态补全项：
+ * - 光标在 `别名.` / `表名.` 之后 → 仅该表的字段；点号前无法解析成已知表时返回空。
+ * - 其余（裸标识符）→ 当前 FROM/JOIN 作用域内所有表的字段 + 库中所有表，字段排在表之前。
+ */
+export function buildSqlCompletions({
+  textBeforeCursor,
+  fullSql,
+  tables,
+  db,
+  columnsByTable,
+}: BuildSqlCompletionsArgs): SqlCompletionItem[] {
+  const refs = parseTableRefs(fullSql);
+  const dot = dotPrefixAt(textBeforeCursor);
+
+  if (dot !== null) {
+    const dotLower = dot.toLowerCase();
+    const aliasRef = refs.find((r) => r.alias?.toLowerCase() === dotLower);
+    let canonical: string | null;
+    let owner: string;
+    if (aliasRef) {
+      canonical = resolveTableName(aliasRef.table, tables);
+      owner = aliasRef.alias!;
+    } else {
+      canonical = resolveTableName(dot, tables);
+      owner = canonical ? shortName(canonical) : dot;
+    }
+    if (!canonical) return [];
+    return (columnsByTable[canonical] ?? []).map((c) => columnItem(c, owner));
+  }
+
+  const items: SqlCompletionItem[] = [];
+  const seen = new Set<string>();
+  for (const ref of refs) {
+    const canonical = resolveTableName(ref.table, tables);
+    if (!canonical) continue;
+    const key = canonical + "|" + (ref.alias ?? "");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const owner = ref.alias ?? shortName(canonical);
+    for (const c of columnsByTable[canonical] ?? []) items.push(columnItem(c, owner));
+  }
+  for (const t of tables) items.push(tableItem(t, db));
+  return items;
+}


### PR DESCRIPTION
## 背景

SQL 编辑器此前只有**表级**联想补全，缺少**字段（列）级**补全（#210）。

## 方案（纯前端，无后端改动）

列元数据后端已具备（`GetTableMetadata` 返回 `columns`，缓存于 `queryStore.dbStates[tab].tableMeta`），本 PR 补齐前端补全链路：

- **新增纯模块 `frontend/src/lib/sql-context.ts`**（无 Monaco/React 依赖，便于单测）：
  - `parseTableRefs` —— 解析 FROM/JOIN 中的表与别名（支持 `AS`、逗号多表、`schema.table`、` ` / " / [] 引号，并排除 `ON`/`LEFT` 等子句关键字被误当别名）；
  - `dotPrefixAt` —— 判断光标是否处于 `别名.` / `表名.` 之后；
  - `resolveTableName` / `resolveScopeTables` —— 把输入标识符解析为已知表（含未限定名 → `schema.table`）；
  - `buildSqlCompletions` —— 上下文补全：`别名.`/`表名.` → 仅该表字段；裸标识符 → 作用域内所有表字段（排在表之前）+ 表名；点号后无法解析则不补。字段项展示 `<type> · <owner>`，主键标 🔑。
- **`SqlEditorTab.tsx`** 接入上述补全，并按需预取 FROM/JOIN 涉及表的结构（去重 + 在途/已缓存跳过），同步读取缓存。

## 覆盖范围

MySQL / PostgreSQL / MSSQL / SQLite；MongoDB 面板独立、不受影响。

## 测试

- 新增 `sql-context` 单测 **32 条**（TDD，先红后绿）；
- 前端全量 **157 文件 / 1598 用例通过**，无回归；改动文件 `tsc` / `eslint` 均干净。

Closes #210