### PR TITLE
✨ SSH 终端支持重连恢复上次工作目录 (#195)

### DIFF
--- a/docs/superpowers/specs/2026-07-02-restore-cwd-on-reconnect-design.md
+++ b/docs/superpowers/specs/2026-07-02-restore-cwd-on-reconnect-design.md
@@ -74,9 +74,10 @@ SSH 终端常因服务端 `sshd ClientAlive*` / shell `TMOUT` 空闲登出而掉
 
 ### 恢复：重连时 cd 回上次目录
 
-- **前端 `reconnect()`**（`frontend/src/stores/terminalStore.ts`）：在 `unregisterSessionSyncListener(sessionId)` 清空前，先读旧 cwd：
+- **掉线即快照 cwd 到 pane**（关键修正）：服务端掉线时 `ssh:closed` → `markClosed(sessionId)` → `unregisterSessionSyncListener` 会**立即清空 `sessionSync[sessionId]`**，而用户按 Enter 重连发生在其后——若重连时才读 `sessionSync`，cwd 已丢。故在 `markClosed`（以及对称的 `disconnect`）里，于 `unregisterSessionSyncListener` **之前**把 `sessionSync[sessionId]?.cwd` 快照到 `TerminalPane.lastCwd`（pane 长存，不随监听注销消失）。
+- **前端 `reconnect()`**（`frontend/src/stores/terminalStore.ts`）：优先读 pane 快照，仍连接的活会话回退读 sessionSync：
   ```ts
-  const lastCwd = get().sessionSync[sessionId]?.cwd ?? "";
+  const lastCwd = pane?.lastCwd ?? get().sessionSync[sessionId]?.cwd ?? "";
   ...
   spec.connectAsync(meta.assetId, { cols: 80, rows: 24, password: "", initialWorkdir: lastCwd })
   ```
@@ -100,7 +101,7 @@ shell 启动 → 立即写 `builtin cd -- '<lastCwd>'`（回显抑制，恢复�
 
 - **前端 vitest**
   - `SSHConfigSection.config.test.ts`：`restoreCwdOnReconnect` 的 build（true 写 / false 不写）与 parse 往返。
-  - `terminalStore.test.ts`：`reconnect` 从 `sessionSync` 读 cwd 并把 `initialWorkdir` 传给 `connectAsync`；普通 `connect` 不传；空 cwd 传空串。
+  - `terminalStore.test.ts`：`reconnect` 把 `initialWorkdir` 传给 `connectAsync`；普通 `connect` 不传；cwd 未知传空串；**掉线（`markClosed` 清空 sessionSync）后重连仍能从 pane 快照恢复**。
 - **Go**
   - `asset_entity/asset_test.go` 的 `TestAsset_SSHConfig` 往返块补 `RestoreCwdOnReconnect: true`。
   - `ssh_svc/ssh_test.go`：`TestSession_RestoreWorkingDirectory` —— 空 dir 不写；非空 dir 写 `builtin cd -- '<dir>'\r`（复用 `recordingWriteCloser`）。

--- a/docs/superpowers/specs/2026-07-02-restore-cwd-on-reconnect-design.md
+++ b/docs/superpowers/specs/2026-07-02-restore-cwd-on-reconnect-design.md
@@ -1,0 +1,111 @@
+# 重连时恢复上次工作目录 (Restore last working directory on reconnect)
+
+- **Issue:** #195 —「保持后台连接 + 重新连接到上次的路径」。keepalive/TCP 调优部分已由 #204 完成，本设计只做**重连恢复路径**部分。
+- **Date:** 2026-07-02
+- **Status:** Approved (inline design), pending implementation.
+
+## 背景 / Problem
+
+SSH 终端常因服务端 `sshd ClientAlive*` / shell `TMOUT` 空闲登出而掉线（客户端 keepalive 无法阻止，见 `ssh.go readOutput` 的 `io.EOF` 注释）。掉线后用户在同一 tab 手动重连（面板提示「按 Enter 重连」），新会话落在 home 目录，用户还得手动 `cd` 回原来的工作目录。
+
+目标：新增一个**每资产**的高级开关，开启后掉线重连时自动回到上次所在目录。
+
+## 关键约束（来自代码勘察）
+
+1. 远端 cwd 只有在**目录同步（directory sync）**激活时才可知——它向 shell 注入隐形 prompt hook（`\x1b]1337;opskat:` OSC 序列 + `/proc/PID/cwd` 探针），仅支持 bash/zsh/ksh/mksh，回显被 `suppressInternalEcho` 抹掉。默认**不启用**，目前只有文件管理器「跟随终端」时按需 `EnableSSHSync`。
+2. 会话一旦断开，cwd **不可事后恢复**（`/proc/PID/cwd` 需要活着的 shell 进程）。因此路径必须在会话**存活期间持续追踪**，没有「断开时抓一把」的选项。
+3. 前端已在**连接和重连时**注册 `ssh:sync:{sessionId}` 监听（`terminalStore.ts:618`、`:747`），并把状态存进 `sessionSync[sessionId]`（含 `cwd`）。所以只要后端启用同步，前端 cwd 自动可得，无需新增捕获代码。
+4. `Session.ChangeDirectoryDirect(path)` 已存在：写 `builtin cd -- '<path>'\r` 且**回显被抑制**（走 `writeInternal`），无需 prompt hook 即可切目录。已有测试 `ssh_test.go:553`。
+
+## 决策（已与维护者确认）
+
+- **捕获机制：** 开关开启时，该资产的 SSH 终端**连接即自动启用目录同步**，复用现有成熟机制。不支持的 shell 静默不恢复。
+- **重连方式：** 保持现有**手动重连**（按 Enter），只在这条重连路径上恢复 cwd。**不**加自动重连（超出本 issue 范围）。
+- **开关默认：** 关（自动注入 hook 属行为变更，默认关更稳）。
+- **恢复可见性：** 复用 `ChangeDirectoryDirect` 的**回显抑制** `cd`——用户直接落在正确目录，不显示 `cd` 命令。
+
+## 设计
+
+### 数据层：每资产高级开关（沿用 `KeepAliveIntervalSeconds` 模式）
+
+- **后端 `SSHConfig`**（`internal/model/entity/asset_entity/asset.go`）：新增
+  ```go
+  // RestoreCwdOnReconnect 开启后，该资产 SSH 终端断线手动重连时自动 cd 回上次目录，
+  // 并在连接时自动启用目录同步以持续追踪 cwd（仅 bash/zsh/ksh/mksh）。
+  RestoreCwdOnReconnect bool `json:"restore_cwd_on_reconnect,omitempty"`
+  ```
+  随 `GetSSHConfig`/`SetSSHConfig` 的 JSON blob 自动往返。**无需**改 `assettype/ssh.go`（keepalive 同样未走 `ApplyCreateArgs`；前端表单直接序列化整个 `SSHConfig` JSON）。
+
+- **前端类型**（`frontend/src/components/asset/SSHConfigSection.config.ts`）：
+  - `SSHConfig` JSON 接口加 `restore_cwd_on_reconnect?: boolean`。
+  - `SSHFormState` 加 `restoreCwdOnReconnect: boolean`；`SSH_DEFAULTS` 置 `false`。
+  - `buildSSHConfig`：`if (state.restoreCwdOnReconnect) cfg.restore_cwd_on_reconnect = true;`（omitempty 语义，false 不写）。
+  - `parseSSHConfig`：`restoreCwdOnReconnect: cfg.restore_cwd_on_reconnect || false`。
+
+- **表单 UI**（`frontend/src/components/asset/SSHConfigSection.tsx` 的 `advanced` 组）：在 keepalive 字段后新增一个 `custom` 字段，用 `Field` + `Switch`（复用现有组件），label/hint 走 i18n。
+
+- **i18n**（`zh-CN` / `en` 的 `common.json`）：`asset.sshRestoreCwdOnReconnect`（label）、`asset.sshRestoreCwdOnReconnectHint`（说明：仅支持 bash/zsh/ksh/mksh，会自动启用目录同步）。
+
+### 捕获：开启时自动启用目录同步
+
+- `ConnectConfig`（`internal/service/ssh_svc/ssh.go`）新增 `RestoreCwdOnReconnect bool`、`InitialWorkdir string`。
+- `internal/app/ssh/ssh_ops.go` 的 `ConnectSSH` **和** `ConnectSSHAsync` 构建 `connectCfg` 时：
+  - `RestoreCwdOnReconnect: sshCfg.RestoreCwdOnReconnect`
+  - `InitialWorkdir: req.InitialWorkdir`
+- `SSHConnectRequest`（`ssh_ops.go`）新增 `InitialWorkdir string \`json:"initialWorkdir"\``。
+- **编排放在 `Manager.Connect`（`createSession` 之后）**，保持 `createSession` 单一职责：
+  ```go
+  sessionID, err := m.createSession(...)
+  if err != nil { ... }
+  if cfg.RestoreCwdOnReconnect {
+      if sess, ok := m.GetSession(sessionID); ok {
+          // 恢复：重连时 cd 回上次目录（首次连接 InitialWorkdir 为空 → no-op）
+          if err := sess.RestoreWorkingDirectory(cfg.InitialWorkdir); err != nil {
+              logger.Default().Warn("restore cwd on reconnect failed",
+                  zap.String("sessionID", sessionID), zap.Error(err))
+          }
+          // 捕获：延迟后自动启用目录同步，持续追踪 cwd 供下次重连
+          go m.autoEnableDirectorySync(sess)
+      }
+  }
+  ```
+- 新增 `Session.RestoreWorkingDirectory(dir string) error`：`dir == ""` 直接返回 nil；否则 `return s.ChangeDirectoryDirect(dir)`。（可用 `recordingWriteCloser` 单测。）
+- 新增 `Manager.autoEnableDirectorySync(sess)`：`time.Sleep(autoSyncSettleDelay)` 后 `sess.EnableSync()`，best-effort（不支持 shell / 超时 → `logger.Default().Warn` 记录，不影响会话）。`autoSyncSettleDelay`（默认 ~1s）设为包级变量便于测试缩短。settle 延迟避免注入 hook 与 sshd 的 motd/首个 prompt 交错。日志按 DEVELOP.md「三态」记 start/fail。
+
+### 恢复：重连时 cd 回上次目录
+
+- **前端 `reconnect()`**（`frontend/src/stores/terminalStore.ts`）：在 `unregisterSessionSyncListener(sessionId)` 清空前，先读旧 cwd：
+  ```ts
+  const lastCwd = get().sessionSync[sessionId]?.cwd ?? "";
+  ...
+  spec.connectAsync(meta.assetId, { cols: 80, rows: 24, password: "", initialWorkdir: lastCwd })
+  ```
+- `connectAsync` opts 类型加可选 `initialWorkdir?: string`；SSH transport 把它塞进 `ssh_models.SSHConnectRequest`；serial/local 忽略。
+- 普通 `connect()`（`terminalStore.ts:531`）**不**传 `initialWorkdir` → 后端 `InitialWorkdir` 为空 → 只捕获不恢复（对应「仅重连恢复」决策）。
+- **后端权威闸门：** 只有 `cfg.RestoreCwdOnReconnect`（读自 `sshCfg`）为真时才 `cd`。即便前端传了 cwd（例如文件管理器独立开了同步但本开关关着），后端也不恢复 → 尊重开关。前端因此无需读取该配置。
+
+### 时序（重连，开关开）
+
+shell 启动 → 立即写 `builtin cd -- '<lastCwd>'`（回显抑制，恢复）→ `autoSyncSettleDelay` 后 `EnableSync` 注入 hook（恢复追踪）→ 新 prompt 显示已在恢复后的目录。
+
+## 边界 / 限制
+
+- 非 bash/zsh/ksh/mksh：同步无法追踪 → cwd 未知 → 落在 home（同现状），静默。
+- cwd 未知（同步未及填充 / 用户身处全屏 TUI）：`lastCwd` 空 → 跳过恢复。
+- 目录已被删除：`builtin cd` 失败，shell 自报错并留在 home，不特殊处理。
+- 分屏 `NewSessionFrom` 不走 `Connect`，本期**不**为分屏 pane 自动启用同步/恢复（超出 issue 范围，记为已知缺口）。
+- 仅 SSH 生效（serial/local `hasDirectorySync: false`）。
+
+## 测试（TDD）
+
+- **前端 vitest**
+  - `SSHConfigSection.config.test.ts`：`restoreCwdOnReconnect` 的 build（true 写 / false 不写）与 parse 往返。
+  - `terminalStore.test.ts`：`reconnect` 从 `sessionSync` 读 cwd 并把 `initialWorkdir` 传给 `connectAsync`；普通 `connect` 不传；空 cwd 传空串。
+- **Go**
+  - `asset_entity/asset_test.go` 的 `TestAsset_SSHConfig` 往返块补 `RestoreCwdOnReconnect: true`。
+  - `ssh_svc/ssh_test.go`：`TestSession_RestoreWorkingDirectory` —— 空 dir 不写；非空 dir 写 `builtin cd -- '<dir>'\r`（复用 `recordingWriteCloser`）。
+- **手动/观察验证**（`Manager.Connect` 无 fake SSH server，无法单测端到端）：按 AGENTS.md「靠观察验证」，跑真机/opsctl，掉线重连后核对落回原目录，并查 `logs/opskat.log` 的 auto-sync start/fail 日志。
+
+## 需重新生成的产物
+
+- `SSHConnectRequest` 改了 → `frontend/wailsjs/go/**`（含 `models.ts`）需 `wails generate module` 重新生成（gitignore 产物，不提交）。

--- a/frontend/src/__tests__/terminalStore.test.ts
+++ b/frontend/src/__tests__/terminalStore.test.ts
@@ -292,6 +292,86 @@ describe("terminalStore.connect", () => {
   });
 });
 
+describe("terminalStore.reconnect", () => {
+  beforeEach(() => {
+    __resetTerminalSyncListenersForTest();
+    vi.clearAllMocks();
+    vi.mocked(EventsOn).mockReturnValue(vi.fn());
+    useTabStore.setState({ tabs: [], activeTabId: null });
+    useTerminalStore.setState({ tabData: {}, sessionSync: {}, connections: {}, connectingAssetIds: new Set() });
+  });
+
+  function seedReconnectTab() {
+    useTabStore.setState({
+      tabs: [
+        {
+          id: "tab-1",
+          type: "terminal",
+          label: "Server 1",
+          meta: {
+            type: "terminal",
+            assetId: 1,
+            assetName: "Server 1",
+            assetIcon: "",
+            host: "10.0.0.1",
+            port: 22,
+            username: "root",
+          },
+        },
+      ],
+      activeTabId: "tab-1",
+    });
+    useTerminalStore.setState({
+      tabData: {
+        "tab-1": {
+          splitTree: { type: "terminal", sessionId: "s1" },
+          activePaneId: "s1",
+          panes: { s1: { sessionId: "s1", transport: "ssh", connected: true, connectedAt: 1 } },
+          directoryFollowMode: "off",
+        },
+      },
+    });
+  }
+
+  it("恢复上次 cwd:把 sessionSync 的 cwd 作为 initialWorkdir 传给 connectAsync", async () => {
+    seedReconnectTab();
+    useTerminalStore.getState().setSessionSyncState("s1", makeSyncState({ sessionId: "s1", cwd: "/srv/app" }));
+    vi.mocked(ConnectSSHAsync).mockResolvedValue("conn-new");
+
+    useTerminalStore.getState().reconnect("tab-1");
+    await Promise.resolve();
+
+    expect(ConnectSSHAsync).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(ConnectSSHAsync).mock.calls[0][0].initialWorkdir).toBe("/srv/app");
+  });
+
+  it("cwd 未知时 initialWorkdir 传空串", async () => {
+    seedReconnectTab();
+    vi.mocked(ConnectSSHAsync).mockResolvedValue("conn-new");
+
+    useTerminalStore.getState().reconnect("tab-1");
+    await Promise.resolve();
+
+    expect(vi.mocked(ConnectSSHAsync).mock.calls[0][0].initialWorkdir).toBe("");
+  });
+
+  it("掉线后重连仍能恢复:markClosed 把 cwd 快照到 pane,即使 sessionSync 已被清除", async () => {
+    seedReconnectTab();
+    useTerminalStore.getState().setSessionSyncState("s1", makeSyncState({ sessionId: "s1", cwd: "/srv/app" }));
+    vi.mocked(ConnectSSHAsync).mockResolvedValue("conn-new");
+
+    // 服务端掉线:markClosed 应把 cwd 快照到 pane;真实环境里紧接着监听注销会清空
+    // sessionSync(本单测未注册监听,故显式清空模拟),cwd 只能靠 pane 快照留存。
+    useTerminalStore.getState().markClosed("s1");
+    useTerminalStore.setState({ sessionSync: {} });
+
+    useTerminalStore.getState().reconnect("tab-1");
+    await Promise.resolve();
+
+    expect(vi.mocked(ConnectSSHAsync).mock.calls[0][0].initialWorkdir).toBe("/srv/app");
+  });
+});
+
 describe("terminalStore.splitPane", () => {
   const flush = () => new Promise((r) => setTimeout(r, 0));
 

--- a/frontend/src/components/asset/SSHConfigSection.config.ts
+++ b/frontend/src/components/asset/SSHConfigSection.config.ts
@@ -19,6 +19,7 @@ interface SSHConfig {
   jump_host_id?: number;
   proxy?: ProxyConfigJSON | null;
   keepalive_interval_seconds?: number;
+  restore_cwd_on_reconnect?: boolean;
 }
 
 /** ssh 表单子状态(凭据中的 password 走 useAssetCredential,不入此 state)。 */
@@ -37,6 +38,8 @@ export interface SSHFormState extends ConnectionFormFields {
   encryptedPrivateKeyPassphrase: string;
   /** 覆盖该资产的 SSH 空闲保活间隔(秒)。0 = 跟随全局默认。 */
   keepAliveIntervalSeconds: number;
+  /** 开启后断线手动重连时自动 cd 回上次目录(连接时自动启用目录同步追踪 cwd)。 */
+  restoreCwdOnReconnect: boolean;
 }
 
 export const SSH_DEFAULTS: SSHFormState = {
@@ -50,6 +53,7 @@ export const SSH_DEFAULTS: SSHFormState = {
   privateKeyPassphrase: "",
   encryptedPrivateKeyPassphrase: "",
   keepAliveIntervalSeconds: 0,
+  restoreCwdOnReconnect: false,
   ...CONNECTION_DEFAULTS,
 };
 
@@ -103,6 +107,11 @@ export function buildSSHConfig(state: SSHFormState, opts: SSHBuildOptions): stri
     cfg.keepalive_interval_seconds = state.keepAliveIntervalSeconds;
   }
 
+  // false = 关闭，不写入 config(omitempty 语义)。
+  if (state.restoreCwdOnReconnect) {
+    cfg.restore_cwd_on_reconnect = true;
+  }
+
   return JSON.stringify(cfg);
 }
 
@@ -124,6 +133,7 @@ export function parseSSHConfig(configJSON: string, assetTunnelId = 0): SSHFormSt
       privateKeyPassphrase: "", // passphrase 已加密,不回显
       encryptedPrivateKeyPassphrase: cfg.private_key_passphrase || "",
       keepAliveIntervalSeconds: cfg.keepalive_interval_seconds || 0,
+      restoreCwdOnReconnect: cfg.restore_cwd_on_reconnect || false,
       ...parseConnectionFields(cfg.proxy, tunnelId),
     };
   } catch {

--- a/frontend/src/components/asset/SSHConfigSection.tsx
+++ b/frontend/src/components/asset/SSHConfigSection.tsx
@@ -10,6 +10,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Switch,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -376,6 +377,21 @@ export const SSHConfigSection = forwardRef<AssetFormHandle, ConfigSectionProps>(
               </Field>
             );
           },
+        },
+        {
+          kind: "custom",
+          render: (s, patchState) => (
+            <Field label={t("asset.sshRestoreCwdOnReconnect")}>
+              <div className="space-y-1.5">
+                <Switch
+                  checked={s.restoreCwdOnReconnect}
+                  onCheckedChange={(v) => patchState({ restoreCwdOnReconnect: v })}
+                  data-testid="ssh-restore-cwd-switch"
+                />
+                <p className="text-xs text-muted-foreground">{t("asset.sshRestoreCwdOnReconnectHint")}</p>
+              </div>
+            </Field>
+          ),
         },
       ],
     },

--- a/frontend/src/components/asset/__tests__/SSHConfigSection.config.test.ts
+++ b/frontend/src/components/asset/__tests__/SSHConfigSection.config.test.ts
@@ -143,6 +143,19 @@ describe("buildSSHConfig (锁旧 save/test 序:host→port→username→auth_typ
       );
     });
   });
+
+  describe("restoreCwdOnReconnect 覆盖(false 不写入)", () => {
+    it("true → 写 restore_cwd_on_reconnect(位于 keepalive 之后)", () => {
+      expect(buildSSHConfig(base({ keepAliveIntervalSeconds: 45, restoreCwdOnReconnect: true }), NO_SECRETS)).toBe(
+        '{"host":"1.2.3.4","port":22,"username":"root","auth_type":"password","keepalive_interval_seconds":45,"restore_cwd_on_reconnect":true}'
+      );
+    });
+    it("false → 省略", () => {
+      expect(buildSSHConfig(base({ restoreCwdOnReconnect: false }), NO_SECRETS)).toBe(
+        '{"host":"1.2.3.4","port":22,"username":"root","auth_type":"password"}'
+      );
+    });
+  });
 });
 
 describe("parseSSHConfig (镜像旧 loadSSHConfig)", () => {
@@ -211,6 +224,16 @@ describe("parseSSHConfig (镜像旧 loadSSHConfig)", () => {
     expect(
       parseSSHConfig('{"host":"h","port":22,"username":"u","auth_type":"password"}').keepAliveIntervalSeconds
     ).toBe(0);
+  });
+
+  it("restore_cwd_on_reconnect → restoreCwdOnReconnect;缺省为 false", () => {
+    expect(
+      parseSSHConfig('{"host":"h","port":22,"username":"u","auth_type":"password","restore_cwd_on_reconnect":true}')
+        .restoreCwdOnReconnect
+    ).toBe(true);
+    expect(parseSSHConfig('{"host":"h","port":22,"username":"u","auth_type":"password"}').restoreCwdOnReconnect).toBe(
+      false
+    );
   });
 
   it("缺字段用默认", () => {

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -584,6 +584,8 @@
     "tabAdvanced": "Advanced",
     "sshKeepAliveInterval": "Idle keep-alive interval",
     "sshKeepAliveIntervalPlaceholder": "Follow global default ({{seconds}}s)",
+    "sshRestoreCwdOnReconnect": "Restore last directory on reconnect",
+    "sshRestoreCwdOnReconnectHint": "After a manual reconnect, drop back into the directory you were in instead of cd-ing there again. Works with bash/zsh/ksh/mksh; turns on directory sync when connecting to track the path.",
     "tabSchemaRegistry": "Schema Registry",
     "tabConnect": "Connect",
     "addDescription": "Add description"

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -584,6 +584,8 @@
     "tabAdvanced": "高级",
     "sshKeepAliveInterval": "空闲保活间隔",
     "sshKeepAliveIntervalPlaceholder": "跟随全局默认（{{seconds}} 秒）",
+    "sshRestoreCwdOnReconnect": "重连恢复上次目录",
+    "sshRestoreCwdOnReconnectHint": "断线手动重连时自动回到上次所在目录，省去重新 cd。仅支持 bash/zsh/ksh/mksh，开启后连接即启用目录同步来追踪路径。",
     "tabSchemaRegistry": "Schema Registry",
     "tabConnect": "Connect",
     "addDescription": "添加备注"

--- a/frontend/src/stores/terminalStore.ts
+++ b/frontend/src/stores/terminalStore.ts
@@ -40,7 +40,10 @@ function disposeTerminalInstance(sessionId: string): void {
 export type TerminalTransport = "ssh" | "serial" | "local";
 
 interface TransportSpec {
-  connectAsync: (assetId: number, opts: { cols: number; rows: number; password: string }) => Promise<string>;
+  connectAsync: (
+    assetId: number,
+    opts: { cols: number; rows: number; password: string; initialWorkdir?: string }
+  ) => Promise<string>;
   write: (sessionId: string, dataB64: string) => Promise<void>;
   resize: (sessionId: string, cols: number, rows: number) => Promise<void>;
   disconnect: (sessionId: string) => void;
@@ -81,8 +84,17 @@ export function orderedBySession(
 // 取代散落各处的 isSerial 二分支。新增 transport 只需在此登记一行。
 export const TRANSPORTS: Record<TerminalTransport, TransportSpec> = {
   ssh: {
-    connectAsync: (assetId, { cols, rows, password }) =>
-      ConnectSSHAsync(new ssh_models.SSHConnectRequest({ assetId, password, key: "", cols, rows })),
+    connectAsync: (assetId, { cols, rows, password, initialWorkdir }) =>
+      ConnectSSHAsync(
+        new ssh_models.SSHConnectRequest({
+          assetId,
+          password,
+          key: "",
+          cols,
+          rows,
+          initialWorkdir: initialWorkdir ?? "",
+        })
+      ),
     write: orderedBySession(WriteSSH),
     resize: ResizeSSH,
     disconnect: DisconnectSSH,
@@ -145,6 +157,8 @@ export interface TerminalPane {
   transport: TerminalTransport;
   connected: boolean;
   connectedAt: number;
+  /** 断开时对最后已知 cwd 的快照。sessionSync 随监听注销被清空,pane 长存,故用于重连恢复目录。 */
+  lastCwd?: string;
 }
 
 export interface TerminalDirectorySyncState {
@@ -664,13 +678,18 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       pane?.transport ?? (asset ? transportForAsset(asset.Type) : inferTransportFromSessionId(sessionId));
     const spec = TRANSPORTS[transport];
 
+    // 断线重连恢复上次目录:优先取掉线时 markClosed/disconnect 快照在 pane 上的 cwd
+    // (那时 sessionSync 已随监听注销被清空);仍连接时(手动重连活会话)回退读 sessionSync。
+    // 传给新会话;是否真正 cd 由后端按资产的 RestoreCwdOnReconnect 开关权威决定,cwd 未知即空串。
+    const lastCwd = pane?.lastCwd ?? get().sessionSync[sessionId]?.cwd ?? "";
+
     unregisterSessionSyncListener(sessionId);
     if (pane?.connected) {
       spec.disconnect(sessionId);
     }
 
     spec
-      .connectAsync(meta.assetId, { cols: 80, rows: 24, password: "" })
+      .connectAsync(meta.assetId, { cols: 80, rows: 24, password: "", initialWorkdir: lastCwd })
       .then((connectionId: string) => {
         // Dispose the old persistent xterm; the slot is replaced by a "connecting" node.
         disposeTerminalInstance(sessionId);
@@ -864,6 +883,8 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   },
 
   disconnect: (sessionId) => {
+    // 与 markClosed 一致:清空 sessionSync 前先把 cwd 快照到 pane,供后续重连恢复目录。
+    const lastCwd = get().sessionSync[sessionId]?.cwd;
     unregisterSessionSyncListener(sessionId);
     const transport =
       Object.values(get().tabData)
@@ -878,7 +899,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
             ...data,
             panes: {
               ...data.panes,
-              [sessionId]: { ...data.panes[sessionId], connected: false },
+              [sessionId]: { ...data.panes[sessionId], connected: false, ...(lastCwd ? { lastCwd } : {}) },
             },
           };
         }
@@ -888,6 +909,8 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   },
 
   markClosed: (sessionId) => {
+    // 快照 cwd 到 pane:必须在 unregisterSessionSyncListener 清空 sessionSync 之前取。
+    const lastCwd = get().sessionSync[sessionId]?.cwd;
     unregisterSessionSyncListener(sessionId);
     set((state) => {
       const newTabData = { ...state.tabData };
@@ -897,7 +920,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
             ...data,
             panes: {
               ...data.panes,
-              [sessionId]: { ...data.panes[sessionId], connected: false },
+              [sessionId]: { ...data.panes[sessionId], connected: false, ...(lastCwd ? { lastCwd } : {}) },
             },
           };
         }

--- a/internal/app/ssh/ssh_ops.go
+++ b/internal/app/ssh/ssh_ops.go
@@ -31,6 +31,9 @@ type SSHConnectRequest struct {
 	Key      string `json:"key"`
 	Cols     int    `json:"cols"`
 	Rows     int    `json:"rows"`
+	// InitialWorkdir 仅重连时由前端携带上次已知 cwd，请求新会话 cd 回该目录；
+	// 首次连接为空。是否真正恢复由资产的 RestoreCwdOnReconnect 开关决定。
+	InitialWorkdir string `json:"initialWorkdir"`
 }
 
 // ConnectSSH 连接 SSH 服务器，返回会话 ID
@@ -72,6 +75,8 @@ func (s *SSH) ConnectSSH(req SSHConnectRequest) (string, error) {
 		Proxy:                    s.decryptProxyPassword(sshCfg.Proxy),
 		HostKeyVerifyFunc:        ssh_svc.AutoTrustFirstRejectChangeVerifyFunc(),
 		KeepAliveIntervalSeconds: sshCfg.KeepAliveIntervalSeconds,
+		RestoreCwdOnReconnect:    sshCfg.RestoreCwdOnReconnect,
+		InitialWorkdir:           req.InitialWorkdir,
 		OnData: func(sid string, data []byte) {
 			wailsRuntime.EventsEmit(s.ctx, "ssh:data:"+sid, base64.StdEncoding.EncodeToString(data))
 		},
@@ -177,6 +182,8 @@ func (s *SSH) ConnectSSHAsync(req SSHConnectRequest) (string, error) {
 			Rows:                     req.Rows,
 			Proxy:                    s.decryptProxyPassword(sshCfg.Proxy),
 			KeepAliveIntervalSeconds: sshCfg.KeepAliveIntervalSeconds,
+			RestoreCwdOnReconnect:    sshCfg.RestoreCwdOnReconnect,
+			InitialWorkdir:           req.InitialWorkdir,
 			OnData: func(sid string, data []byte) {
 				wailsRuntime.EventsEmit(s.ctx, "ssh:data:"+sid, base64.StdEncoding.EncodeToString(data))
 			},

--- a/internal/model/entity/asset_entity/asset.go
+++ b/internal/model/entity/asset_entity/asset.go
@@ -116,6 +116,9 @@ type SSHConfig struct {
 	// KeepAliveIntervalSeconds 覆盖该资产的 SSH 空闲保活心跳间隔（秒）。
 	// 0/缺省 = 跟随全局默认（System 设置里的保活间隔）。
 	KeepAliveIntervalSeconds int `json:"keepalive_interval_seconds,omitempty"`
+	// RestoreCwdOnReconnect 开启后，该资产 SSH 终端断线手动重连时自动 cd 回上次目录，
+	// 并在连接时自动启用目录同步以持续追踪 cwd（仅 bash/zsh/ksh/mksh）。
+	RestoreCwdOnReconnect bool `json:"restore_cwd_on_reconnect,omitempty"`
 }
 
 // ProxyConfig 代理配置

--- a/internal/model/entity/asset_entity/asset_test.go
+++ b/internal/model/entity/asset_entity/asset_test.go
@@ -76,10 +76,11 @@ func TestAsset_SSHConfig(t *testing.T) {
 		convey.Convey("SetSSHConfig后GetSSHConfig应返回相同内容", func() {
 			a := &Asset{Name: "test", Type: AssetTypeSSH}
 			cfg := &SSHConfig{
-				Host:     "10.0.0.1",
-				Port:     2222,
-				Username: "admin",
-				AuthType: AuthTypeKey,
+				Host:                  "10.0.0.1",
+				Port:                  2222,
+				Username:              "admin",
+				AuthType:              AuthTypeKey,
+				RestoreCwdOnReconnect: true,
 			}
 			err := a.SetSSHConfig(cfg)
 			assert.NoError(t, err)
@@ -90,6 +91,7 @@ func TestAsset_SSHConfig(t *testing.T) {
 			assert.Equal(t, cfg.Port, got.Port)
 			assert.Equal(t, cfg.Username, got.Username)
 			assert.Equal(t, cfg.AuthType, got.AuthType)
+			assert.Equal(t, cfg.RestoreCwdOnReconnect, got.RestoreCwdOnReconnect)
 		})
 
 		convey.Convey("非SSH类型调用GetSSHConfig应返回错误", func() {

--- a/internal/service/ssh_svc/dirsync.go
+++ b/internal/service/ssh_svc/dirsync.go
@@ -94,6 +94,17 @@ func (s *Session) ChangeDirectoryDirect(targetPath string) error {
 	return s.writeInternal([]byte(buildDirectoryChangeCommand(targetPath)))
 }
 
+// RestoreWorkingDirectory moves the freshly-started shell into dir when dir is
+// non-empty. Used on reconnect to land the user back where they were. An empty
+// dir (cwd was never known — unsupported shell / sync not yet populated) is a
+// no-op, not an error, so the reconnect just opens at the shell's home.
+func (s *Session) RestoreWorkingDirectory(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	return s.ChangeDirectoryDirect(dir)
+}
+
 // ChangeDirectoryTo switches the terminal to targetPath and treats expectedPath
 // as the canonical cwd reported by the remote shell after the change.
 func (s *Session) ChangeDirectoryTo(targetPath, expectedPath string) error {

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -281,6 +281,13 @@ type ConnectConfig struct {
 	// KeepAliveIntervalSeconds 覆盖此连接的 SSH 空闲保活心跳间隔（秒）。
 	// 0 = 跟随全局默认（sshtuning）。
 	KeepAliveIntervalSeconds int
+
+	// RestoreCwdOnReconnect 为该资产开启「重连恢复上次目录」时为真：连接建立后
+	// 自动启用目录同步以持续追踪 cwd，并在 InitialWorkdir 非空时 cd 回上次目录。
+	RestoreCwdOnReconnect bool
+	// InitialWorkdir 仅在重连路径由前端携带上次已知 cwd；首次连接为空。
+	// 实际是否恢复由 RestoreCwdOnReconnect 权威闸门决定。
+	InitialWorkdir string
 }
 
 // JumpHostEntry 跳板机连接信息
@@ -370,7 +377,37 @@ func (m *Manager) Connect(cfg ConnectConfig) (string, error) {
 		return "", err
 	}
 
+	if cfg.RestoreCwdOnReconnect {
+		if sess, ok := m.GetSession(sessionID); ok {
+			// 恢复：重连时 cd 回上次目录（首次连接 InitialWorkdir 为空 → no-op）。
+			if err := sess.RestoreWorkingDirectory(cfg.InitialWorkdir); err != nil {
+				logger.Default().Warn("restore cwd on reconnect failed",
+					zap.String("sessionID", sessionID), zap.String("cwd", cfg.InitialWorkdir), zap.Error(err))
+			}
+			// 捕获：延迟后自动启用目录同步，持续追踪 cwd 供下次重连。
+			go m.autoEnableDirectorySync(sess)
+		}
+	}
+
 	return sessionID, nil
+}
+
+// autoSyncSettleDelay 是自动启用目录同步前的等待，让 sshd 的 motd/首个 prompt 先落地，
+// 避免注入的 hook 脚本与其交错。设为变量便于测试缩短。
+var autoSyncSettleDelay = 1 * time.Second
+
+// autoEnableDirectorySync 在会话稳定后自动启用目录同步（用于「重连恢复上次目录」的 cwd 捕获）。
+// best-effort：不支持的 shell / 超时只记 Warn，不影响会话本身。
+func (m *Manager) autoEnableDirectorySync(sess *Session) {
+	time.Sleep(autoSyncSettleDelay)
+	if sess.IsClosed() {
+		return
+	}
+	logger.Default().Info("auto-enable directory sync for cwd restore", zap.String("sessionID", sess.ID))
+	if err := sess.EnableSync(); err != nil {
+		logger.Default().Warn("auto-enable directory sync failed",
+			zap.String("sessionID", sess.ID), zap.Error(err))
+	}
 }
 
 // createSession 在 sharedClient 上创建新的 SSH 会话（PTY + shell）

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -561,6 +561,28 @@ func TestSession_DirectDirectoryChangeWritesOnlyCdCommand(t *testing.T) {
 	assert.NotEmpty(t, sess.echoSuppressions)
 }
 
+func TestSession_RestoreWorkingDirectory(t *testing.T) {
+	t.Run("empty dir writes nothing", func(t *testing.T) {
+		stdin := &recordingWriteCloser{}
+		sess := &Session{stdin: stdin}
+
+		err := sess.RestoreWorkingDirectory("")
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, stdin.writeCount())
+	})
+
+	t.Run("non-empty dir cd's into it", func(t *testing.T) {
+		stdin := &recordingWriteCloser{}
+		sess := &Session{stdin: stdin}
+
+		err := sess.RestoreWorkingDirectory("/srv/app")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "builtin cd -- '/srv/app'\r", string(stdin.lastWrite()))
+	})
+}
+
 func TestSession_EnableSyncDoesNotWriteUserVisibleHookSource(t *testing.T) {
 	stdin := &recordingWriteCloser{}
 	sess := &Session{


### PR DESCRIPTION
closes #195

## 背景

关联 #195。keepalive/TCP 调优部分已由 #204 完成，本 PR 补上另一半——**断线重连恢复上次工作目录**：SSH 终端常因服务端 `TMOUT` / `ClientAlive*` 空闲登出掉线，重连后落在 home，用户还得手动 `cd` 回去。

## 方案

每资产高级设置新增开关「重连恢复上次目录」（默认关）：

- **捕获**：开启后 SSH 终端连接即在后台（1s settle 延迟）自动 `EnableSync`，复用现有目录同步机制持续追踪 cwd。best-effort，不支持的 shell 静默跳过。
- **快照**：掉线时 `markClosed`/`disconnect` 在监听注销清空 `sessionSync` **之前**，把 cwd 快照到 `pane.lastCwd`（pane 长存）。
- **恢复**：手动重连（按 Enter）时读回 `pane.lastCwd`，作为 `InitialWorkdir` 传后端；由后端 `RestoreCwdOnReconnect` 权威闸门决定是否 `cd`（复用已抑制回显的 `ChangeDirectoryDirect`，用户直接落回原目录）。

## 决策

- 捕获机制：开启时自动启用目录同步（复用优先）。
- 重连方式：保持现有手动重连，仅恢复路径（不加自动重连，超 issue 范围）。
- 开关默认关（自动注入 hook 属行为变更）。

## 限制

- 仅支持 bash/zsh/ksh/mksh；不支持的 shell 静默不恢复。
- 分屏 `NewSessionFrom` 不走 `Connect`，本期不为分屏 pane 自动捕获（已知缺口）。
- 目录已删除时 `cd` 失败，shell 自报错并落在 home，不特殊处理。

## 测试

- 后端：`go test` 3 包全过、golangci-lint 0 issues；新增 `TestSession_RestoreWorkingDirectory`、SSHConfig 往返补 `RestoreCwdOnReconnect`。
- 前端：1572 tests 全过、eslint 干净；新增 config build/parse + reconnect（含**掉线快照后仍恢复**）用例。
- `SSHConnectRequest` 已由 `wails generate module` 重生（`initialWorkdir`；gitignore 产物不入库）。

## 建议真机验证

`Manager.Connect` 编排无 fake SSH server 可端到端单测。建议真机：开开关 → cd 某目录 → 等 TMOUT 掉线 → 按 Enter 重连 → 应落回原目录，并查 `logs/opskat.log` 的 auto-sync 日志。

设计文档见 `docs/superpowers/specs/2026-07-02-restore-cwd-on-reconnect-design.md`。