### PR TITLE
✨ 代码片段接入 Ctrl+P 命令面板 (#202)

### DIFF
--- a/docs/superpowers/specs/2026-07-02-snippet-command-palette-design.md
+++ b/docs/superpowers/specs/2026-07-02-snippet-command-palette-design.md
@@ -1,0 +1,149 @@
+# Design — Code snippets in the Ctrl+P command palette (#202)
+
+## Problem
+
+Running a code snippet today requires the mouse: open the Snippets page (or a
+per-tool `SnippetPopover`), find the snippet, pick a host in `SnippetAssetDrawer`,
+click Run. Issue #202 asks for a keyboard-first path. Two options were proposed
+(per-snippet custom shortcuts + host binding, or a Ctrl+P dropdown). The
+maintainer chose **Ctrl+P** and the reporter agreed.
+
+## Key finding: reuse, don't build
+
+A command palette already exists and is already bound to **⌘P / Ctrl+P**
+(`command.quickopen` in `shortcutStore.ts`). `CommandPalette.tsx` renders a
+fuzzy/pinyin-searchable dropdown listing **open tabs + recent/matching assets**.
+This feature **adds a Snippets section to that existing palette** — it does not
+build a new launcher.
+
+All backend IPC and run primitives already exist; **this is a frontend-only
+change**:
+- `ListSnippets`, `RecordSnippetUse`, `SetSnippetLastAssets`, `GetSnippetLastAssets` (bindings).
+- `runSnippetOnAsset(asset, content)` — opens/reuses the right tool tab and
+  inserts content, **never auto-executing**. For SSH it reuses an already
+  connected pane via `findExistingConnectedPane`.
+- `SnippetAssetDrawer` — the full pick-host → run → `SetLastAssets` →
+  `RecordUse` flow.
+
+## Scope
+
+**In scope**
+- New **Snippets** section in `CommandPalette`.
+- Pick a snippet → resolve target → insert its content (never execute).
+- Only **runnable** snippets appear (see runnable set below).
+
+**Out of scope** (dropped from the original proposal / YAGNI)
+- Per-snippet custom keyboard shortcuts.
+- Static snippet→host binding.
+- Extending run support to redis / k8s / prompt categories (they are not
+  runnable via `runSnippetOnAsset` anywhere today).
+- Auto-execute (Shift+Enter = insert+run) — noted as a future enhancement.
+- Backend changes.
+
+## Runnable set (mirror the Snippets page)
+
+`SnippetsPage.tsx` gates its Run button on
+`RUNNABLE_ASSET_TYPES = {ssh, database, mongodb}`. The palette mirrors this
+exactly: only snippets whose category `assetType` is in that set are listed.
+This naturally excludes `prompt` (assetType `""`) and `redis`/`k8s`, and avoids
+the `runSnippetOnAsset` "unsupported asset type" throw.
+
+To avoid a second copy of this rule, the definition is **extracted** from
+`SnippetsPage.tsx` into `snippetRun.ts` and both consumers import it:
+- `snippetRun.ts` exports `RUNNABLE_ASSET_TYPES` and
+  `isRunnableCategoryId(categoryId, categories): boolean`.
+- `SnippetsPage.tsx` drops its local `RUNNABLE_ASSET_TYPES`/`isRunnable` and
+  imports the shared helper (in-scope refactor of the producer).
+
+## Behavior (approved decisions)
+
+1. **Placement:** extend the existing unified ⌘P palette.
+2. **Target resolution — active tab first, else pick host.**
+3. **Insert only** — never auto-execute (matches every other snippet path).
+
+### Target resolution
+
+A pure helper `resolveSnippetTarget({ snippet, activeTab, assetsById, categories })`
+in `frontend/src/lib/snippetTarget.ts` returns one of:
+
+- `{ kind: "active", asset }` — the active tab matches the snippet's category
+  asset type, and that tab's asset is known:
+  - terminal tab ⇒ matches an `ssh` snippet;
+  - query tab ⇒ matches when `activeTab.meta.assetType === category.assetType`
+    (`database` / `mongodb`).
+- `{ kind: "pick" }` — no active-tab match (or the asset can't be resolved from
+  the store).
+
+On activation the palette does:
+- **active** → `runSnippetOnAsset(asset, snippet.Content)` then `recordUse(id)` +
+  `setLastAssets(id, [asset.ID])`; close palette. (For SSH this reuses the
+  connected pane; for query it opens/reuses the query editor — all insert-only.)
+- **pick** → `useSnippetStore.getState().requestHostPick(snippet)`; close palette.
+  App renders `SnippetAssetDrawer` for the pending snippet (pre-filled with
+  last-used assets), reusing the existing run flow.
+
+No `terminalStore` refactor is needed: `runSnippetOnAsset` already targets the
+active connected SSH pane, so the "active terminal" case is covered by reuse.
+
+## Components & data flow
+
+```
+Ctrl+P ──> CommandPalette
+             ├─ reads snippetStore.all (runnable-filtered) + categories
+             ├─ Snippets section:
+             │    empty query  → top ~5 (already ordered by recency/use)
+             │    typed query  → pinyinMatch(name|description)
+             └─ activate(snippet):
+                  resolveSnippetTarget(...)
+                    active → runSnippetOnAsset + recordUse + setLastAssets
+                    pick   → snippetStore.requestHostPick(snippet)
+                  onClose()
+
+App (top level)
+  └─ {snippetStore.runTarget && <SnippetAssetDrawer snippet=runTarget onClose=clearHostPick/>}
+```
+
+### `snippetStore` additions
+- `all: Snippet[]` and `loadAll()` — fetch all snippets (empty filter, default
+  recency order) into a **separate** field so the Snippets-page `list`/`filter`
+  is untouched. Guarded by a monotonic request id like `loadList`.
+- `runTarget: Snippet | null`, `requestHostPick(snippet)`, `clearHostPick()` —
+  drives the app-level drawer for the palette's pick path. (Adding transient
+  snippet-run UI state to the snippet domain store is consistent with it already
+  holding `filter`.)
+
+### `CommandPalette` additions
+- On open: `loadCategories()` + `loadAll()` (categories are needed for the
+  runnable filter and the resolver; freshness matters for newly created snippets).
+- New `SnippetRow` kind; rows render category badge + `FileCode` icon +
+  highlighted name + description preview, consistent with existing rows.
+- Snippets section placed after Opened / Assets (or Recent on empty query).
+- Placeholder copy updated to mention snippets.
+
+## Error handling
+- `resolveSnippetTarget` never throws; unknown asset ⇒ `pick`.
+- The active-run path relies on `runSnippetOnAsset`, which already throws only
+  for unsupported types — impossible here since the list is runnable-filtered.
+- `recordUse` is fire-and-forget (existing behavior). `setLastAssets` failures
+  surface as before (drawer path) or are best-effort on the active path.
+
+## Testing (TDD, vitest)
+- `snippetTarget.test.ts` (new): terminal+ssh → active; query+database → active;
+  query assetType mismatch → pick; active asset missing from store → pick; no
+  active tab → pick.
+- `snippetRun` runnable helper: true for ssh/database/mongodb; false for
+  redis/k8s/prompt/unknown.
+- `commandPalette.test.tsx` (extend): only runnable snippets listed; empty query
+  shows recent snippets capped at ~5; typed query matches by name (incl. pinyin);
+  Enter on an active-match calls `runSnippetOnAsset` (mocked) and not the drawer;
+  Enter on a no-match calls `requestHostPick`.
+
+## Files touched
+- `frontend/src/components/snippet/snippetRun.ts` — export runnable helper.
+- `frontend/src/components/snippet/SnippetsPage.tsx` — use shared helper.
+- `frontend/src/lib/snippetTarget.ts` — **new** resolver.
+- `frontend/src/stores/snippetStore.ts` — `all`/`loadAll`, `runTarget`/`requestHostPick`/`clearHostPick`.
+- `frontend/src/components/command/CommandPalette.tsx` — Snippets section + activation.
+- `frontend/src/App.tsx` — app-level `SnippetAssetDrawer` from `snippetStore.runTarget`.
+- `frontend/src/i18n/locales/{en,zh-CN}/common.json` — `commandPalette.section.snippets`, placeholder copy.
+- Tests as above.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { SideAssistantPanel } from "@/components/ai/SideAssistantPanel";
 import { WindowControls } from "@/components/layout/WindowControls";
 import { TopBar } from "@/components/layout/TopBar";
 import { CommandPaletteDialog } from "@/components/command/CommandPaletteDialog";
+import { SnippetAssetDrawer } from "@/components/snippet/SnippetAssetDrawer";
 import { EdgeRevealStrip } from "@/components/layout/EdgeRevealStrip";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { LeftPanel } from "@/components/layout/LeftPanel";
@@ -28,6 +29,7 @@ import { useQueryStore } from "@/stores/queryStore";
 import { useSFTPStore } from "@/stores/sftpStore";
 import { getAssetType } from "@/lib/assetTypes";
 import { useTabStore } from "@/stores/tabStore";
+import { useSnippetStore } from "@/stores/snippetStore";
 import { useExtensionStore } from "@/extension";
 import { bootstrapExtensions } from "@/extension/init";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -136,6 +138,9 @@ function App() {
   );
   const [aiPanelCollapsed, setAiPanelCollapsed] = useState(() => localStorage.getItem("ai_panel_collapsed") === "true");
   const [commandOpen, setCommandOpen] = useState(false);
+  // Snippet chosen in the command palette that needs a host picked before it runs.
+  const snippetRunTarget = useSnippetStore((s) => s.runTarget);
+  const clearSnippetHostPick = useSnippetStore((s) => s.clearHostPick);
   const [assetTreeWidth, setAssetTreeWidth] = useState(() => {
     const saved = localStorage.getItem("asset_tree_width");
     return saved ? Math.max(160, Math.min(480, Number(saved))) : 224;
@@ -522,6 +527,7 @@ function App() {
           </Suspense>
           <PermissionDialog />
           <OpsctlApprovalDialog />
+          {snippetRunTarget && <SnippetAssetDrawer snippet={snippetRunTarget} onClose={clearSnippetHostPick} />}
           <Toaster richColors />
         </TooltipProvider>
       </ErrorBoundary>

--- a/frontend/src/__tests__/commandPalette.test.tsx
+++ b/frontend/src/__tests__/commandPalette.test.tsx
@@ -1,11 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { asset_entity } from "../../wailsjs/go/models";
+import { asset_entity, snippet_entity, snippet_svc } from "../../wailsjs/go/models";
 import { useTabStore } from "../stores/tabStore";
 import { useAssetStore } from "../stores/assetStore";
 import { useRecentAssetStore } from "../stores/recentAssetStore";
+import { useSnippetStore } from "../stores/snippetStore";
 import { CommandPalette } from "../components/command/CommandPalette";
 import * as openAssetDefaultModule from "../lib/openAssetDefault";
+import { ListSnippets, ListSnippetCategories } from "../../wailsjs/go/extension/Extension";
+import { runSnippetOnAsset } from "../components/snippet/snippetRun";
+
+// Keep the real runnable helpers; stub only the side-effecting runner.
+vi.mock("../components/snippet/snippetRun", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../components/snippet/snippetRun")>();
+  return { ...actual, runSnippetOnAsset: vi.fn() };
+});
 
 // ──────────────────────────────────────────────
 // Helpers
@@ -61,6 +70,21 @@ function makeAITab(id: string, label: string) {
   };
 }
 
+function makeSnippet(id: number, name: string, category: string, description = ""): snippet_entity.Snippet {
+  return new snippet_entity.Snippet({
+    ID: id,
+    Name: name,
+    Category: category,
+    Content: `run ${name}`,
+    Description: description,
+    Source: "user",
+  });
+}
+
+function makeCategory(id: string, assetType: string): snippet_svc.Category {
+  return { id, assetType, label: id.toUpperCase(), source: "builtin" } as snippet_svc.Category;
+}
+
 function makePageTab(id: string, pageId: string) {
   return {
     id,
@@ -91,6 +115,10 @@ describe("CommandPalette", () => {
     useTabStore.setState({ tabs: [], activeTabId: null });
     useAssetStore.setState({ assets: [], groups: [] });
     useRecentAssetStore.setState({ recentIds: [] });
+    useSnippetStore.setState({ all: [], categories: [], runTarget: null });
+    vi.mocked(ListSnippets).mockResolvedValue([]);
+    vi.mocked(ListSnippetCategories).mockResolvedValue([]);
+    vi.mocked(runSnippetOnAsset).mockResolvedValue(undefined);
   });
 
   // 1. Closed dialog renders nothing observable
@@ -290,5 +318,74 @@ describe("CommandPalette", () => {
     // icon is the builtin Settings icon, not the default Server fallback
     expect(container.querySelector("svg.lucide-settings")).not.toBeNull();
     expect(container.querySelector("svg.lucide-server")).toBeNull();
+  });
+
+  // ── Snippets section ─────────────────────────────
+
+  // Seed snippet-store state AND make loadAll (fired on open) resolve the SAME
+  // array ref, so useSyncExternalStore bails out (no re-render outside act).
+  function seedSnippets(all: snippet_entity.Snippet[], categories: snippet_svc.Category[]) {
+    useSnippetStore.setState({ all, categories });
+    vi.mocked(ListSnippets).mockResolvedValue(all);
+  }
+
+  it("snippets: empty query lists only runnable snippets", () => {
+    seedSnippets(
+      [makeSnippet(1, "deploy-app", "shell"), makeSnippet(2, "flush-cache", "redis")],
+      [makeCategory("shell", "ssh"), makeCategory("redis", "redis")]
+    );
+
+    renderPalette(true);
+
+    expect(screen.getByText("commandPalette.section.snippets")).toBeDefined();
+    // runnable (ssh) snippet shown
+    expect(screen.getByText("deploy-app")).toBeDefined();
+    // non-runnable (redis) snippet excluded
+    expect(screen.queryByText("flush-cache")).toBeNull();
+  });
+
+  it("snippets: typed query filters snippets by name", () => {
+    seedSnippets(
+      [makeSnippet(1, "deploy-web", "shell"), makeSnippet(2, "restart-db", "shell")],
+      [makeCategory("shell", "ssh")]
+    );
+
+    renderPalette(true);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "deploy" } });
+
+    // The matched name is highlighted (split into <mark> + text nodes), so assert
+    // on the aggregated text content rather than a single text node.
+    const allText = document.body.textContent ?? "";
+    expect(allText).toContain("deploy-web");
+    expect(allText).not.toContain("restart-db");
+  });
+
+  it("snippets: enter on a snippet matching the active terminal tab runs on that asset (no host pick)", () => {
+    const asset = makeAsset(7, "myhost", "ssh");
+    useAssetStore.setState({ assets: [asset], groups: [] });
+    useTabStore.setState({ tabs: [makeTerminalTab("tab-1", "myhost", 7)], activeTabId: "tab-1" });
+    seedSnippets([makeSnippet(10, "deploy-app", "shell")], [makeCategory("shell", "ssh")]);
+
+    renderPalette(true);
+    // Query so only the snippet row remains (the terminal tab label "myhost" won't match).
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "deploy" } });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+
+    expect(runSnippetOnAsset).toHaveBeenCalledWith(asset, "run deploy-app");
+    expect(useSnippetStore.getState().runTarget).toBeNull(); // did not fall back to host picker
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("snippets: enter on a snippet with no matching active tab requests a host pick", () => {
+    useTabStore.setState({ tabs: [], activeTabId: null });
+    seedSnippets([makeSnippet(11, "deploy-app", "shell")], [makeCategory("shell", "ssh")]);
+
+    renderPalette(true);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "deploy" } });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+
+    expect(runSnippetOnAsset).not.toHaveBeenCalled();
+    expect(useSnippetStore.getState().runTarget?.ID).toBe(11);
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/snippetRun.test.ts
+++ b/frontend/src/__tests__/snippetRun.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { RUNNABLE_ASSET_TYPES, isRunnableCategoryId } from "../components/snippet/snippetRun";
+
+type Cat = { id: string; assetType: string };
+
+const CATEGORIES: Cat[] = [
+  { id: "shell", assetType: "ssh" },
+  { id: "sql", assetType: "database" },
+  { id: "mongo", assetType: "mongodb" },
+  { id: "redis", assetType: "redis" },
+  { id: "k8s", assetType: "k8s" },
+  { id: "prompt", assetType: "" },
+];
+
+describe("isRunnableCategoryId", () => {
+  it("is true for ssh / database / mongodb backed categories", () => {
+    expect(isRunnableCategoryId("shell", CATEGORIES)).toBe(true);
+    expect(isRunnableCategoryId("sql", CATEGORIES)).toBe(true);
+    expect(isRunnableCategoryId("mongo", CATEGORIES)).toBe(true);
+  });
+
+  it("is false for non-runnable categories (redis / k8s / prompt)", () => {
+    expect(isRunnableCategoryId("redis", CATEGORIES)).toBe(false);
+    expect(isRunnableCategoryId("k8s", CATEGORIES)).toBe(false);
+    expect(isRunnableCategoryId("prompt", CATEGORIES)).toBe(false);
+  });
+
+  it("is false for an unknown category id", () => {
+    expect(isRunnableCategoryId("does-not-exist", CATEGORIES)).toBe(false);
+  });
+
+  it("exposes the canonical runnable asset-type set", () => {
+    expect(RUNNABLE_ASSET_TYPES.has("ssh")).toBe(true);
+    expect(RUNNABLE_ASSET_TYPES.has("database")).toBe(true);
+    expect(RUNNABLE_ASSET_TYPES.has("mongodb")).toBe(true);
+    expect(RUNNABLE_ASSET_TYPES.has("redis")).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/snippetStore.test.ts
+++ b/frontend/src/__tests__/snippetStore.test.ts
@@ -21,6 +21,8 @@ describe("snippetStore", () => {
       categoriesLoading: false,
       list: [],
       listLoading: false,
+      all: [],
+      runTarget: null,
       filter: { categories: [], keyword: "" },
     });
     vi.mocked(ListSnippetCategories).mockResolvedValue([]);
@@ -197,6 +199,67 @@ describe("snippetStore", () => {
       useSnippetStore.getState().recordUse(7);
       await new Promise((r) => setTimeout(r, 0));
       expect(RecordSnippetUse).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe("loadAll (palette source)", () => {
+    it("fetches all snippets with an empty filter and stores them in `all`", async () => {
+      vi.mocked(ListSnippets).mockResolvedValue([
+        { ID: 1, Name: "a", Category: "shell", Source: "user" } as any,
+        { ID: 2, Name: "b", Category: "sql", Source: "user" } as any,
+      ]);
+      await useSnippetStore.getState().loadAll();
+      expect(ListSnippets).toHaveBeenCalledTimes(1);
+      const arg = vi.mocked(ListSnippets).mock.calls[0][0] as any;
+      expect(arg.categories).toEqual([]);
+      expect(arg.keyword).toBe("");
+      expect(useSnippetStore.getState().all.map((s) => s.ID)).toEqual([1, 2]);
+    });
+
+    it("does not touch the page `list`/`filter`", async () => {
+      useSnippetStore.setState({
+        list: [{ ID: 99, Name: "page-item" } as any],
+        filter: { categories: ["shell"], keyword: "kept" },
+      });
+      vi.mocked(ListSnippets).mockResolvedValue([{ ID: 1, Name: "a" } as any]);
+      await useSnippetStore.getState().loadAll();
+      expect(useSnippetStore.getState().list.map((s) => s.ID)).toEqual([99]);
+      expect(useSnippetStore.getState().filter).toEqual({ categories: ["shell"], keyword: "kept" });
+    });
+
+    it("handles null response as empty array", async () => {
+      vi.mocked(ListSnippets).mockResolvedValue(null as any);
+      await useSnippetStore.getState().loadAll();
+      expect(useSnippetStore.getState().all).toEqual([]);
+    });
+
+    it("discards a stale loadAll response when a newer request is in flight", async () => {
+      let releaseFirst!: (v: any[]) => void;
+      const firstPromise = new Promise<any[]>((r) => {
+        releaseFirst = r;
+      });
+      vi.mocked(ListSnippets)
+        .mockImplementationOnce(() => firstPromise as any)
+        .mockResolvedValueOnce([{ ID: 2, Name: "B" } as any]);
+
+      const store = useSnippetStore.getState();
+      const first = store.loadAll();
+      const second = store.loadAll();
+      await second; // all = [B]
+      releaseFirst([{ ID: 1, Name: "A" } as any]); // stale — must be discarded
+      await first;
+
+      expect(useSnippetStore.getState().all.map((s) => s.ID)).toEqual([2]);
+    });
+  });
+
+  describe("host-pick target (palette → drawer)", () => {
+    it("requestHostPick sets runTarget and clearHostPick resets it", () => {
+      const snip = { ID: 5, Name: "deploy", Category: "shell" } as any;
+      useSnippetStore.getState().requestHostPick(snip);
+      expect(useSnippetStore.getState().runTarget).toBe(snip);
+      useSnippetStore.getState().clearHostPick();
+      expect(useSnippetStore.getState().runTarget).toBeNull();
     });
   });
 

--- a/frontend/src/__tests__/snippetTarget.test.ts
+++ b/frontend/src/__tests__/snippetTarget.test.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect } from "vitest";
+import { resolveSnippetTarget } from "../lib/snippetTarget";
+import type { Tab } from "../stores/tabStore";
+import type { asset_entity, snippet_entity, snippet_svc } from "../../wailsjs/go/models";
+
+type Asset = asset_entity.Asset;
+
+const CATEGORIES = [
+  { id: "shell", assetType: "ssh", label: "Shell", source: "builtin" },
+  { id: "sql", assetType: "database", label: "SQL", source: "builtin" },
+  { id: "mongo", assetType: "mongodb", label: "Mongo", source: "builtin" },
+  { id: "prompt", assetType: "", label: "Prompt", source: "builtin" },
+] as snippet_svc.Category[];
+
+function snippet(category: string): snippet_entity.Snippet {
+  return { ID: 1, Name: "s", Category: category, Content: "echo hi", Source: "user" } as any;
+}
+
+function asset(id: number, type: string): Asset {
+  return { ID: id, Name: `asset-${id}`, Type: type } as any;
+}
+
+function terminalTab(assetId: number): Tab {
+  return {
+    id: "t1",
+    type: "terminal",
+    label: "term",
+    meta: { type: "terminal", assetId, assetName: "x", assetIcon: "", host: "h", port: 22, username: "u" },
+  } as Tab;
+}
+
+function queryTab(assetId: number, assetType: string): Tab {
+  return {
+    id: "q1",
+    type: "query",
+    label: "query",
+    meta: { type: "query", assetId, assetName: "x", assetIcon: "", assetType: assetType as any },
+  } as Tab;
+}
+
+function aiTab(): Tab {
+  return { id: "a1", type: "ai", label: "ai", meta: { type: "ai", conversationId: null, title: "ai" } } as Tab;
+}
+
+describe("resolveSnippetTarget", () => {
+  it("shell snippet + active terminal tab whose asset is known → active", () => {
+    const a = asset(7, "ssh");
+    const res = resolveSnippetTarget({
+      snippet: snippet("shell"),
+      activeTab: terminalTab(7),
+      assetsById: new Map([[7, a]]),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "active", asset: a });
+  });
+
+  it("sql snippet + active database query tab whose asset is known → active", () => {
+    const a = asset(9, "database");
+    const res = resolveSnippetTarget({
+      snippet: snippet("sql"),
+      activeTab: queryTab(9, "database"),
+      assetsById: new Map([[9, a]]),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "active", asset: a });
+  });
+
+  it("sql snippet + active redis query tab → pick (type mismatch)", () => {
+    const res = resolveSnippetTarget({
+      snippet: snippet("sql"),
+      activeTab: queryTab(9, "redis"),
+      assetsById: new Map([[9, asset(9, "redis")]]),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "pick" });
+  });
+
+  it("shell snippet + matching terminal tab but asset missing from store → pick", () => {
+    const res = resolveSnippetTarget({
+      snippet: snippet("shell"),
+      activeTab: terminalTab(7),
+      assetsById: new Map(),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "pick" });
+  });
+
+  it("no active tab → pick", () => {
+    const res = resolveSnippetTarget({
+      snippet: snippet("shell"),
+      activeTab: undefined,
+      assetsById: new Map([[7, asset(7, "ssh")]]),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "pick" });
+  });
+
+  it("active tab of an unrelated kind (ai) → pick", () => {
+    const res = resolveSnippetTarget({
+      snippet: snippet("shell"),
+      activeTab: aiTab(),
+      assetsById: new Map([[7, asset(7, "ssh")]]),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "pick" });
+  });
+
+  it("snippet whose category has no asset type (prompt) → pick", () => {
+    const res = resolveSnippetTarget({
+      snippet: snippet("prompt"),
+      activeTab: terminalTab(7),
+      assetsById: new Map([[7, asset(7, "ssh")]]),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "pick" });
+  });
+});

--- a/frontend/src/components/command/CommandPalette.tsx
+++ b/frontend/src/components/command/CommandPalette.tsx
@@ -1,16 +1,26 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Server, MessageSquare } from "lucide-react";
+import { Server, MessageSquare, FileCode } from "lucide-react";
+import { toast } from "sonner";
 import { Input, ScrollArea, cn } from "@opskat/ui";
 import { getIconComponent, getIconColor } from "@/components/asset/IconPicker";
 import { filterAssets } from "@/lib/assetSearch";
 import { highlightMatch, type HighlightSegment } from "@/lib/highlightMatch";
+import { pinyinMatch } from "@/lib/pinyin";
 import { openAssetDefault } from "@/lib/openAssetDefault";
+import { resolveSnippetTarget } from "@/lib/snippetTarget";
+import { isRunnableCategoryId, runSnippetOnAsset } from "@/components/snippet/snippetRun";
 import { useAssetStore } from "@/stores/assetStore";
 import { useRecentAssetStore } from "@/stores/recentAssetStore";
+import { useSnippetStore } from "@/stores/snippetStore";
 import { useTabStore, type Tab, type InfoTabMeta, type PageTabMeta } from "@/stores/tabStore";
 import { resolveTabLabel, getBuiltinPageMeta } from "@/components/layout/pageTabMeta";
-import type { asset_entity } from "../../../wailsjs/go/models";
+import type { asset_entity, snippet_entity } from "../../../wailsjs/go/models";
+
+// Max snippets shown in the palette: a small recency list when idle, a wider
+// set while searching.
+const SNIPPETS_EMPTY_LIMIT = 5;
+const SNIPPETS_QUERY_LIMIT = 20;
 
 // ──────────────────────────────────────────────
 // Props
@@ -39,7 +49,13 @@ interface AssetRow {
   groupPath: string;
 }
 
-type Row = TabRow | AssetRow;
+interface SnippetRow {
+  kind: "snippet";
+  id: string;
+  snippet: snippet_entity.Snippet;
+}
+
+type Row = TabRow | AssetRow | SnippetRow;
 
 interface Section {
   label: string;
@@ -123,9 +139,12 @@ export function CommandPalette({ open, onClose, onConnectAsset }: CommandPalette
 
   // Store subscriptions
   const tabs = useTabStore((s) => s.tabs);
+  const activeTabId = useTabStore((s) => s.activeTabId);
   const assets = useAssetStore((s) => s.assets);
   const groups = useAssetStore((s) => s.groups);
   const recentIds = useRecentAssetStore((s) => s.recentIds);
+  const snippets = useSnippetStore((s) => s.all);
+  const snippetCategories = useSnippetStore((s) => s.categories);
 
   // Local state
   const [query, setQuery] = useState("");
@@ -140,6 +159,19 @@ export function CommandPalette({ open, onClose, onConnectAsset }: CommandPalette
       setActiveIndex(0);
       // Focus on next tick to win against Radix focus management
       requestAnimationFrame(() => inputRef.current?.focus());
+      // Refresh snippets each open (they change on the Snippets page); load
+      // categories only if we have none yet — they're needed to tell which
+      // snippets are runnable.
+      void useSnippetStore
+        .getState()
+        .loadAll()
+        .catch((e) => console.error(e));
+      if (useSnippetStore.getState().categories.length === 0) {
+        void useSnippetStore
+          .getState()
+          .loadCategories()
+          .catch((e) => console.error(e));
+      }
     }
     prevOpen.current = open;
   }, [open]);
@@ -156,6 +188,13 @@ export function CommandPalette({ open, onClose, onConnectAsset }: CommandPalette
   const sections = useMemo((): Section[] => {
     const assetById = new Map(assets.map((a) => [a.ID, a]));
 
+    const runnableSnippets = snippets.filter((s) => isRunnableCategoryId(s.Category, snippetCategories));
+    const toSnippetRow = (s: snippet_entity.Snippet): SnippetRow => ({
+      kind: "snippet",
+      id: `snippet-${s.ID}`,
+      snippet: s,
+    });
+
     if (!query.trim()) {
       const openedRows: TabRow[] = tabs.map((tab) => ({ kind: "tab", id: `tab-${tab.id}`, tab }));
       const openedAssetIds = new Set(tabs.map(tabAssetId).filter((id): id is number => id !== null));
@@ -167,12 +206,17 @@ export function CommandPalette({ open, onClose, onConnectAsset }: CommandPalette
           return { kind: "asset", id: `asset-recent-${id}`, asset, groupPath: "" };
         });
 
+      const snippetRows = runnableSnippets.slice(0, SNIPPETS_EMPTY_LIMIT).map(toSnippetRow);
+
       const result: Section[] = [];
       if (openedRows.length > 0) {
         result.push({ label: t("commandPalette.section.opened"), rows: openedRows });
       }
       if (recentRows.length > 0) {
         result.push({ label: t("commandPalette.section.recent"), rows: recentRows });
+      }
+      if (snippetRows.length > 0) {
+        result.push({ label: t("commandPalette.section.snippets"), rows: snippetRows });
       }
       return result;
     }
@@ -197,6 +241,11 @@ export function CommandPalette({ open, onClose, onConnectAsset }: CommandPalette
       .filter(({ asset }) => !openedAssetIds.has(asset.ID))
       .map(({ asset, groupPath }) => ({ kind: "asset", id: `asset-${asset.ID}`, asset, groupPath }));
 
+    const snippetRows = runnableSnippets
+      .filter((s) => pinyinMatch(s.Name, query) || (!!s.Description && pinyinMatch(s.Description, query)))
+      .slice(0, SNIPPETS_QUERY_LIMIT)
+      .map(toSnippetRow);
+
     const result: Section[] = [];
     if (openedRows.length > 0) {
       result.push({ label: t("commandPalette.section.opened"), rows: openedRows });
@@ -204,8 +253,11 @@ export function CommandPalette({ open, onClose, onConnectAsset }: CommandPalette
     if (assetRows.length > 0) {
       result.push({ label: t("commandPalette.section.assets"), rows: assetRows });
     }
+    if (snippetRows.length > 0) {
+      result.push({ label: t("commandPalette.section.snippets"), rows: snippetRows });
+    }
     return result;
-  }, [query, tabs, assets, groups, recentIds, t]);
+  }, [query, tabs, assets, groups, recentIds, snippets, snippetCategories, t]);
 
   const flatRows = useMemo(() => sections.flatMap((s) => s.rows), [sections]);
 
@@ -241,11 +293,33 @@ export function CommandPalette({ open, onClose, onConnectAsset }: CommandPalette
     }
   };
 
+  const activateSnippet = (snippet: snippet_entity.Snippet) => {
+    const assetsById = new Map(assets.map((a) => [a.ID, a]));
+    const activeTab = tabs.find((tb) => tb.id === activeTabId);
+    const target = resolveSnippetTarget({ snippet, activeTab, assetsById, categories: snippetCategories });
+    if (target.kind === "active") {
+      // Land the snippet in the active tool tab (insert only, never executes).
+      void runSnippetOnAsset(target.asset, snippet.Content ?? "").catch((e) => {
+        toast.error(e instanceof Error ? e.message : String(e));
+      });
+      useSnippetStore.getState().recordUse(snippet.ID);
+      void useSnippetStore
+        .getState()
+        .setLastAssets(snippet.ID, [target.asset.ID])
+        .catch((e) => console.error(e));
+    } else {
+      // No matching active tab — hand off to the asset-picker drawer (App-level).
+      useSnippetStore.getState().requestHostPick(snippet);
+    }
+  };
+
   const activateRow = (row: Row) => {
     if (row.kind === "tab") {
       useTabStore.getState().activateTab(row.tab.id);
-    } else {
+    } else if (row.kind === "asset") {
       openAssetDefault(row.asset, onConnectAsset);
+    } else {
+      activateSnippet(row.snippet);
     }
     onClose();
   };
@@ -356,6 +430,40 @@ export function CommandPalette({ open, onClose, onConnectAsset }: CommandPalette
                           {key && (
                             <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
                               {t(key)}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    }
+
+                    if (row.kind === "snippet") {
+                      const { snippet } = row;
+                      const category = snippetCategories.find((c) => c.id === snippet.Category);
+                      const segments = highlightMatch(snippet.Name, query);
+                      return (
+                        <button
+                          key={row.id}
+                          type="button"
+                          role="option"
+                          data-active-index={idx}
+                          aria-selected={isActive}
+                          className={cn(
+                            "flex w-full items-center gap-2.5 px-3 py-2 cursor-pointer select-none rounded-sm mx-1 text-left",
+                            isActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+                          )}
+                          onClick={() => activateRow(row)}
+                          onMouseEnter={() => setActiveIndex(idx)}
+                        >
+                          <FileCode className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <span className="flex-1 min-w-0 truncate text-sm">
+                            <HighlightedText segments={segments} />
+                            {snippet.Description && (
+                              <span className="ml-2 text-xs text-muted-foreground">{snippet.Description}</span>
+                            )}
+                          </span>
+                          {category && (
+                            <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                              {category.label}
                             </span>
                           )}
                         </button>

--- a/frontend/src/components/snippet/SnippetsPage.tsx
+++ b/frontend/src/components/snippet/SnippetsPage.tsx
@@ -19,13 +19,7 @@ import { useSnippetStore } from "@/stores/snippetStore";
 import { snippet_entity } from "../../../wailsjs/go/models";
 import { SnippetFormDialog } from "./SnippetFormDialog";
 import { SnippetAssetDrawer } from "./SnippetAssetDrawer";
-
-const RUNNABLE_ASSET_TYPES = new Set(["ssh", "database", "mongodb"]);
-
-function isRunnable(cat: string, cats: { id: string; assetType: string }[]): boolean {
-  const c = cats.find((x) => x.id === cat);
-  return !!c && RUNNABLE_ASSET_TYPES.has(c.assetType);
-}
+import { isRunnableCategoryId } from "./snippetRun";
 
 // Stable per-category badge styling. Order must be deterministic so a given
 // category always renders with the same hue across reloads.
@@ -354,7 +348,7 @@ export function SnippetsPage() {
                   <td className="px-4 py-2 text-xs font-mono text-muted-foreground">{s.Source || "user"}</td>
                   <td className="px-4 py-2">
                     <div className="flex items-center justify-end gap-1">
-                      {isRunnable(s.Category, categories) && (
+                      {isRunnableCategoryId(s.Category, categories) && (
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button

--- a/frontend/src/components/snippet/snippetRun.ts
+++ b/frontend/src/components/snippet/snippetRun.ts
@@ -6,6 +6,23 @@ import { WriteSSH } from "../../../wailsjs/go/ssh/SSH";
 import { bytesToBase64 } from "@/lib/terminalEncode";
 
 /**
+ * Asset types a snippet can actually be "run" on today — i.e. the types
+ * runSnippetOnAsset knows how to land content into. Categories bound to any
+ * other asset type (redis / k8s) or none (prompt) are not runnable.
+ */
+export const RUNNABLE_ASSET_TYPES = new Set(["ssh", "database", "mongodb"]);
+
+/**
+ * Whether a snippet category can be run, given the current category registry.
+ * A category is runnable when its bound asset type is one runSnippetOnAsset
+ * supports.
+ */
+export function isRunnableCategoryId(categoryId: string, categories: { id: string; assetType: string }[]): boolean {
+  const c = categories.find((x) => x.id === categoryId);
+  return !!c && RUNNABLE_ASSET_TYPES.has(c.assetType);
+}
+
+/**
  * Open the right tab for an asset and land the snippet content in its editor.
  * Never auto-executes.
  */

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1080,11 +1080,12 @@
     "command.quickopen": "Quick Open"
   },
   "commandPalette": {
-    "placeholder": "Search assets or open tabs...",
+    "placeholder": "Search assets, tabs, or snippets...",
     "section": {
       "opened": "Open",
       "recent": "Recent",
-      "assets": "Assets"
+      "assets": "Assets",
+      "snippets": "Snippets"
     },
     "empty": {
       "noContent": "No items. Add an asset first.",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1080,11 +1080,12 @@
     "command.quickopen": "快速打开"
   },
   "commandPalette": {
-    "placeholder": "搜索资产或已打开的标签...",
+    "placeholder": "搜索资产、标签或代码片段...",
     "section": {
       "opened": "已打开",
       "recent": "最近",
-      "assets": "资产"
+      "assets": "资产",
+      "snippets": "代码片段"
     },
     "empty": {
       "noContent": "暂无内容，先在左侧添加资产",

--- a/frontend/src/lib/snippetTarget.ts
+++ b/frontend/src/lib/snippetTarget.ts
@@ -1,0 +1,47 @@
+import type { Tab } from "@/stores/tabStore";
+import type { asset_entity, snippet_entity, snippet_svc } from "../../wailsjs/go/models";
+
+type Asset = asset_entity.Asset;
+type Snippet = snippet_entity.Snippet;
+type Category = snippet_svc.Category;
+
+/**
+ * Where a snippet chosen from the command palette should run:
+ * - "active": the currently focused tab already targets a matching asset, so
+ *   insert straight into it (no host picker).
+ * - "pick": open the asset-picker drawer to choose host(s).
+ */
+export type SnippetTarget = { kind: "active"; asset: Asset } | { kind: "pick" };
+
+/** Asset type implied by the active tab's tool, or null if it targets no asset. */
+function activeTabAsset(tab: Tab): { assetType: string; assetId: number } | null {
+  if (tab.meta.type === "terminal") return { assetType: "ssh", assetId: tab.meta.assetId };
+  if (tab.meta.type === "query") return { assetType: tab.meta.assetType, assetId: tab.meta.assetId };
+  return null;
+}
+
+/**
+ * Decide the target for running a snippet from the command palette.
+ * "active tab first, else pick host": if the focused tab matches the snippet's
+ * category asset type and that asset is known, run there; otherwise pick a host.
+ * Pure — never throws.
+ */
+export function resolveSnippetTarget(params: {
+  snippet: Snippet;
+  activeTab: Tab | undefined;
+  assetsById: Map<number, Asset>;
+  categories: Category[];
+}): SnippetTarget {
+  const { snippet, activeTab, assetsById, categories } = params;
+
+  const assetType = categories.find((c) => c.id === snippet.Category)?.assetType ?? "";
+  if (!assetType || !activeTab) return { kind: "pick" };
+
+  const active = activeTabAsset(activeTab);
+  if (!active || active.assetType !== assetType) return { kind: "pick" };
+
+  const asset = assetsById.get(active.assetId);
+  if (!asset) return { kind: "pick" };
+
+  return { kind: "active", asset };
+}

--- a/frontend/src/stores/snippetStore.ts
+++ b/frontend/src/stores/snippetStore.ts
@@ -20,6 +20,10 @@ type Category = snippet_svc.Category;
 // must not clobber the UI with stale data.
 let loadListReqId = 0;
 
+// Separate monotonic counter for loadAll (the command-palette source), so a
+// slow palette fetch never clobbers a newer one on rapid re-opens.
+let loadAllReqId = 0;
+
 export type SnippetFilter = {
   categories: string[]; // empty = all
   keyword: string;
@@ -32,9 +36,16 @@ interface SnippetState {
   listLoading: boolean;
   filter: SnippetFilter;
 
+  // Command-palette state, independent of the page list/filter above.
+  all: Snippet[];
+  runTarget: Snippet | null;
+
   loadCategories: () => Promise<void>;
   loadList: () => Promise<void>;
+  loadAll: () => Promise<void>;
   setFilter: (patch: Partial<SnippetFilter>) => void;
+  requestHostPick: (snippet: Snippet) => void;
+  clearHostPick: () => void;
 
   create: (req: snippet_svc.CreateReq) => Promise<Snippet>;
   update: (req: snippet_svc.UpdateReq) => Promise<Snippet>;
@@ -50,6 +61,8 @@ export const useSnippetStore = create<SnippetState>()((set, get) => ({
   categoriesLoading: false,
   list: [],
   listLoading: false,
+  all: [],
+  runTarget: null,
   filter: { categories: [], keyword: "" },
 
   loadCategories: async () => {
@@ -86,6 +99,24 @@ export const useSnippetStore = create<SnippetState>()((set, get) => ({
       throw e;
     }
   },
+
+  loadAll: async () => {
+    const myId = ++loadAllReqId;
+    const req: snippet_svc.ListReq = {
+      categories: [],
+      keyword: "",
+      limit: 0,
+      offset: 0,
+      orderBy: "",
+    } as unknown as snippet_svc.ListReq;
+    const items = await ListSnippets(req);
+    if (myId !== loadAllReqId) return; // a newer palette fetch owns the state
+    set({ all: items ?? [] });
+  },
+
+  requestHostPick: (snippet) => set({ runTarget: snippet }),
+
+  clearHostPick: () => set({ runTarget: null }),
 
   setFilter: (patch) => {
     const cur = get().filter;


### PR DESCRIPTION
## 背景

closes #202

代码片段此前只能靠鼠标运行（片段页 / 工具条 Popover → 选主机 → 运行）。本 PR 把代码片段接入已有的 **Ctrl+P / ⌘P 命令面板**，实现键盘优先的快速运行。方案取自 issue 讨论（维护者选定 Ctrl+P 方案，放弃"每片段自定义快捷键 + 静态绑定主机"）。

## 改动

命令面板新增「代码片段」分区：

- 仅展示**可运行**片段（分类 assetType ∈ `ssh` / `database` / `mongodb`，与片段页 Run 按钮口径一致；`prompt`/`redis`/`k8s` 天然排除，也避免 `runSnippetOnAsset` 抛错）。
- 空输入 → 按最近使用展示前 ~5 个；有输入 → 对名称/描述做拼音+文本搜索。
- 回车运行：**活动标签优先** —— 若当前聚焦的标签页已是匹配会话（SSH 终端 / SQL、Mongo 查询）则直接把内容送入该会话，无需再选主机；否则复用现有 `SnippetAssetDrawer` 选择主机（预填最近使用）。
- **仅插入、绝不自动执行**，与全站片段行为一致。

后端零改动，复用现有 IPC 与 `runSnippetOnAsset` / `SnippetAssetDrawer`。

### 主要文件
- `snippetRun.ts`：抽出 `RUNNABLE_ASSET_TYPES` / `isRunnableCategoryId`，`SnippetsPage` 复用（去重）。
- `lib/snippetTarget.ts`（新）：纯函数 `resolveSnippetTarget`（活动标签优先，否则选主机）。
- `stores/snippetStore.ts`：新增 `all` / `loadAll`（面板数据源，独立于片段页的 list/filter）+ `runTarget` / `requestHostPick` / `clearHostPick`。
- `components/command/CommandPalette.tsx`：片段分区渲染与激活。
- `App.tsx`：顶层挂载 `SnippetAssetDrawer`（由 `snippetStore.runTarget` 驱动）。
- i18n：`commandPalette.section.snippets` 与占位符文案（en / zh-CN）。

## 测试

- TDD：新增 20 个测试（`snippetRun` 4、`snippetTarget` 7、`snippetStore` 5、`commandPalette` 4）。
- 全量前端测试 **1586 通过 / 0 失败**；ESLint 干净；改动文件 `tsc` 类型检查干净。

## 设计说明

`docs/superpowers/specs/2026-07-02-snippet-command-palette-design.md`