### PR TITLE
🐛 markdown 链接改由系统浏览器打开，不再劫持窗口 (#218)

### DIFF
--- a/frontend/src/__tests__/MarkdownLink.test.tsx
+++ b/frontend/src/__tests__/MarkdownLink.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, createEvent } from "@testing-library/react";
+import Markdown from "react-markdown";
+import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
+import { markdownComponents } from "../components/MarkdownLink";
+
+describe("markdown external links (#218)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("opens http(s) links in the system browser instead of navigating the webview", () => {
+    render(<Markdown components={markdownComponents}>{"[docs](https://opskat.dev)"}</Markdown>);
+
+    const link = screen.getByRole("link", { name: "docs" });
+    const clickEvent = createEvent.click(link);
+    fireEvent(link, clickEvent);
+
+    // preventDefault stops the Wails webview from replacing the whole app UI.
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(BrowserOpenURL).toHaveBeenCalledWith("https://opskat.dev");
+  });
+
+  it("blocks in-webview navigation for non-http links without opening them", () => {
+    render(<Markdown components={markdownComponents}>{"[mail](mailto:hi@opskat.dev)"}</Markdown>);
+
+    const link = screen.getByRole("link", { name: "mail" });
+    const clickEvent = createEvent.click(link);
+    fireEvent(link, clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(BrowserOpenURL).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/MarkdownLink.tsx
+++ b/frontend/src/components/MarkdownLink.tsx
@@ -1,0 +1,26 @@
+import type { Components } from "react-markdown";
+import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
+import { normalizeHttpUrl } from "./terminal/terminalUrlScan";
+
+// Wails 的 WebView 没有地址栏/后退按钮：点击 markdown 里的 <a href> 会用目标页面整页
+// 替换掉应用 UI，用户再也回不来（#218）。所有 markdown 渲染统一挂这个 components——
+// 拦截点击后只把 http/https 链接交给系统浏览器打开，与终端链接同一条路径
+// （见 terminalRegistry 的 normalizeHttpUrl + BrowserOpenURL）。模块级常量，引用稳定，
+// 不会让 <Markdown> 每次渲染都因为 components 换引用而重新解析。
+export const markdownComponents: Components = {
+  a({ href, children, node: _node, ...rest }) {
+    return (
+      <a
+        {...rest}
+        href={href}
+        onClick={(event) => {
+          event.preventDefault();
+          const url = href ? normalizeHttpUrl(href) : undefined;
+          if (url) BrowserOpenURL(url);
+        }}
+      >
+        {children}
+      </a>
+    );
+  },
+};

--- a/frontend/src/components/ai/AIChatContent.tsx
+++ b/frontend/src/components/ai/AIChatContent.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import { notifyCopied } from "@/lib/notify";
 import Markdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
+import { markdownComponents } from "@/components/MarkdownLink";
 import remarkGfm from "remark-gfm";
 import {
   Button,
@@ -68,7 +69,7 @@ const mdRehypePlugins = [rehypeSanitize];
 const MarkdownContent = memo(function MarkdownContent({ content }: { content: string }) {
   const deferred = useDeferredValue(content);
   return (
-    <Markdown remarkPlugins={mdRemarkPlugins} rehypePlugins={mdRehypePlugins}>
+    <Markdown remarkPlugins={mdRemarkPlugins} rehypePlugins={mdRehypePlugins} components={markdownComponents}>
       {deferred}
     </Markdown>
   );

--- a/frontend/src/components/asset/AssetDetail.tsx
+++ b/frontend/src/components/asset/AssetDetail.tsx
@@ -4,6 +4,7 @@ import { Server, Pencil, Trash2, TerminalSquare, Loader2 } from "lucide-react";
 import Markdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
+import { markdownComponents } from "@/components/MarkdownLink";
 import { Button, Separator, ConfirmDialog, Tooltip, TooltipContent, TooltipTrigger } from "@opskat/ui";
 import { toast } from "sonner";
 import { useAssetStore } from "@/stores/assetStore";
@@ -346,7 +347,11 @@ export function AssetDetail({ asset, isConnecting, onEdit, onDelete, onConnect }
             <div className="text-sm">
               <span className="text-muted-foreground">{t("asset.description")}</span>
               <div className="mt-1 prose prose-sm dark:prose-invert prose-p:my-1 prose-pre:my-1 prose-pre:overflow-x-auto max-w-none">
-                <Markdown remarkPlugins={[remarkBreaks]} rehypePlugins={[rehypeSanitize]}>
+                <Markdown
+                  remarkPlugins={[remarkBreaks]}
+                  rehypePlugins={[rehypeSanitize]}
+                  components={markdownComponents}
+                >
                   {asset.Description}
                 </Markdown>
               </div>


### PR DESCRIPTION
Closes #218

## 问题 (#218)

点击 AI 助手侧边栏里 AI 给出的链接后，目标网页占满整个程序、且没有地址栏/后退按钮，用户无法返回。

## 根因

AI 聊天内容（`AIChatContent.tsx`）与资产描述（`AssetDetail.tsx`）都用 react-markdown 渲染，且**没有给 `a` 配置自定义渲染器**。于是 `[text](url)` 和 remark-gfm 自动链接的裸 URL 都被渲染成普通 `<a href>`。在 Wails 的 WebView 里点击 `<a>` 会让整个 WebView 直接导航到该 URL，把 SPA 整页替换掉——桌面 WebView 没有浏览器外壳，于是卡死回不来。

Go 侧没有任何导航拦截，Wails 默认放行 `<a>` 导航。项目里外链的既有正确范式是终端的 `terminalRegistry.ts`：`normalizeHttpUrl(uri)` + `BrowserOpenURL(url)`。

## 修改

- 新增共享 `frontend/src/components/MarkdownLink.tsx`，导出 `markdownComponents`：拦截点击 → `preventDefault()`（阻止 WebView 内导航）→ 仅把 http/https 链接交给 `BrowserOpenURL` 走系统浏览器打开。复用既有 `normalizeHttpUrl`，与终端链接同一条路径。模块级常量，引用稳定，不会让 `<Markdown>` 每次渲染因 `components` 换引用而重解析。
- `AIChatContent.tsx`、`AssetDetail.tsx` 两处 `<Markdown>` 挂上 `components={markdownComponents}`（AssetDetail 是同类潜伏 bug，一并修）。

## 测试

- 新增 `MarkdownLink.test.tsx`（TDD，先红后绿）：通过真实 react-markdown 渲染，断言点击 http 链接 → `preventDefault` + `BrowserOpenURL` 被调用；非 http（mailto）→ 阻止导航但不打开。
- 全量前端测试 160 文件 / 1628 用例通过；`tsc --noEmit` 与 `eslint` 无 error/warning。

## 说明

- 仅放行 http/https（与终端链接一致的显式白名单）；其他 scheme 一律阻止 WebView 内导航、也不打开，避免被 `file://` 等劫持。