### PR TITLE
🐛 修复切换标签页导致 RDP 重新连接

### DIFF
--- a/frontend/src/__tests__/MainPanel.rdp.test.tsx
+++ b/frontend/src/__tests__/MainPanel.rdp.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MainPanel } from "@/components/layout/MainPanel";
+import { useAssetStore } from "@/stores/assetStore";
+import { useLayoutStore } from "@/stores/layoutStore";
+import { useTabStore } from "@/stores/tabStore";
+import { asset_entity } from "../../wailsjs/go/models";
+
+const unmounted = vi.fn();
+
+vi.mock("@/components/rdp/RDPPanel", async () => {
+  const React = await import("react");
+  return {
+    RDPPanel: ({ asset }: { asset: asset_entity.Asset }) => {
+      React.useEffect(() => () => unmounted(asset.ID), [asset.ID]);
+      return <div data-testid={`rdp-panel-${asset.ID}`} />;
+    },
+  };
+});
+
+vi.mock("@/components/settings/SettingsPage", () => ({
+  SettingsPage: () => <div data-testid="settings-page" />,
+}));
+
+describe("MainPanel RDP lifecycle", () => {
+  beforeEach(() => {
+    unmounted.mockReset();
+    useLayoutStore.setState({ tabBarLayout: "left" });
+    useAssetStore.setState({
+      assets: [new asset_entity.Asset({ ID: 1, Name: "RDP", Type: "rdp" })],
+      initialized: true,
+    });
+    useTabStore.setState({
+      tabs: [
+        { id: "rdp-1", type: "page", label: "RDP", meta: { type: "page", pageId: "rdp", assetId: 1 } },
+        { id: "settings", type: "page", label: "Settings", meta: { type: "page", pageId: "settings" } },
+      ],
+      activeTabId: "rdp-1",
+    });
+  });
+
+  it("keeps an RDP pane mounted while another tab is active", async () => {
+    render(<MainPanel onEditAsset={vi.fn()} onDeleteAsset={vi.fn()} onConnectAsset={vi.fn()} />);
+    expect(await screen.findByTestId("rdp-panel-1")).toBeVisible();
+
+    useTabStore.getState().activateTab("settings");
+
+    expect(await screen.findByTestId("settings-page")).toBeVisible();
+    await waitFor(() => expect(screen.getByTestId("rdp-panel-1")).not.toBeVisible());
+    expect(unmounted).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/MainPanel.tsx
+++ b/frontend/src/components/layout/MainPanel.tsx
@@ -50,6 +50,10 @@ const K8sClusterPage = lazy(() =>
 const VNCPanel = lazy(() => import("@/components/vnc/VNCPanel").then((m) => ({ default: m.VNCPanel })));
 const RDPPanel = lazy(() => import("@/components/rdp/RDPPanel").then((m) => ({ default: m.RDPPanel })));
 
+// Remote-desktop panes own a live backend session that their unmount cleanup closes,
+// so they render for every open tab and only toggle visibility — never active-only.
+const REMOTE_PANE_PAGE_IDS = new Set(["vnc", "rdp"]);
+
 interface MainPanelProps {
   onEditAsset: (asset: asset_entity.Asset) => void;
   onDeleteAsset: (id: number) => void;
@@ -111,7 +115,9 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPa
   const terminalTabs = tabs.filter((tab) => tab.type === "terminal");
   const aiTabs = tabs.filter((tab) => tab.type === "ai");
   const queryTabs = tabs.filter((tab) => tab.type === "query");
-  const vncTabs = tabs.filter((tab) => tab.type === "page" && (tab.meta as PageTabMeta).pageId === "vnc");
+  const remotePaneTabs = tabs.filter(
+    (tab) => tab.type === "page" && REMOTE_PANE_PAGE_IDS.has((tab.meta as PageTabMeta).pageId)
+  );
 
   function renderActiveContent() {
     if (!activeTab) return null;
@@ -161,11 +167,6 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPa
             const k8sAsset = meta.assetId ? assets.find((a) => a.ID === meta.assetId) : null;
             if (!k8sAsset) return null;
             return <K8sClusterPage asset={k8sAsset} />;
-          }
-          case "rdp": {
-            const rdpAsset = meta.assetId ? assets.find((a) => a.ID === meta.assetId) : null;
-            if (!rdpAsset) return null;
-            return <RDPPanel asset={rdpAsset} onEdit={() => onEditAsset(rdpAsset)} />;
           }
           default:
             if (meta.extensionName) {
@@ -291,7 +292,7 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPa
           );
         })}
 
-        {vncTabs.map((tab) => {
+        {remotePaneTabs.map((tab) => {
           const meta = tab.meta as PageTabMeta;
           const asset = meta.assetId ? assets.find((item) => item.ID === meta.assetId) : null;
           if (!asset) return null;
@@ -303,17 +304,23 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPa
               style={{ visibility: isActive ? "visible" : "hidden", pointerEvents: isActive ? "auto" : "none" }}
             >
               <LazySurface>
-                <VNCPanel tabId={tab.id} asset={asset} onEdit={() => onEditAsset(asset)} />
+                {meta.pageId === "vnc" ? (
+                  <VNCPanel tabId={tab.id} asset={asset} onEdit={() => onEditAsset(asset)} />
+                ) : (
+                  <RDPPanel asset={asset} onEdit={() => onEditAsset(asset)} />
+                )}
               </LazySurface>
             </div>
           );
         })}
 
-        {activeTab && activeTab.type === "page" && (activeTab.meta as PageTabMeta).pageId !== "vnc" && (
-          <div className="absolute inset-0 bg-background">
-            <LazySurface>{renderActiveContent()}</LazySurface>
-          </div>
-        )}
+        {activeTab &&
+          activeTab.type === "page" &&
+          !REMOTE_PANE_PAGE_IDS.has((activeTab.meta as PageTabMeta).pageId) && (
+            <div className="absolute inset-0 bg-background">
+              <LazySurface>{renderActiveContent()}</LazySurface>
+            </div>
+          )}
         {/* Query tabs: display-based — sticky thead would leak as a composited
             layer if the parent only toggled visibility. State is in zustand,
             so display:none is safe here. */}


### PR DESCRIPTION
## 问题

切换标签页后再切回，RDP 会重新连接（会话中断、重新握手）。

## 根因

`MainPanel.tsx` 中，终端 / AI / VNC 页签为**每个打开的标签常驻渲染**，只切换 CSS `visibility`；RDP 却落在「只渲染当前激活标签」的分支里（该分支写成硬编码的 `pageId !== "vnc"`）。

于是切走标签 → `RDPPanel` 被卸载 → cleanup（`RDPPanel.tsx:302-309`）调用 `CloseRDP` 关闭会话 → 切回时重新挂载并再次 `ConnectRDP`。

注意这**不是** effect 依赖不稳定导致的重跑：连接 effect 的依赖（`RDPPanel.tsx:313`）全是稳定的基础类型，重渲染不会触发它。纯粹是挂载/卸载。VNC 与 RDP 在同一个提交（bdcf547c）加入，VNC 走了常驻挂载，RDP 漏了。

## 改动

- RDP 改为与 VNC 相同的常驻挂载 + `visibility` 切换路径。
- 用单一来源 `REMOTE_PANE_PAGE_IDS` 同时驱动 keep-mounted 列表与 active-only 排除项，替换硬编码的 `pageId !== "vnc"`，避免两处漂移（而不是再复制一个近乎相同的渲染块）。
- 删除 `renderActiveContent` 中随之不可达的 `case "rdp"`。
- 面板组件仍在 MainPanel 内按 `pageId` 选择：VNCPanel / RDPPanel 都是 `lazy()` 加载，下沉到资产类型注册表会把 noVNC 拉进所有注册表使用方并破坏代码分割。

## 验证

- 新增 `frontend/src/__tests__/MainPanel.rdp.test.tsx`（对齐既有 `MainPanel.vnc.test.tsx`）。**修复前失败**：`Unable to find an element by: [data-testid="rdp-panel-1"]` —— 面板整个从 DOM 消失（而非仅隐藏），正是根因；修复后通过。
- 前端全量：211 个文件 / 1972 个测试全绿；`tsc --noEmit` 与 eslint 均干净。
- 一并核对了常驻挂载的两个风险点：按键转发绑在 canvas（`tabIndex` + `onKeyDown`），隐藏且 `pointerEvents:none` 的 canvas 无法获得焦点，不会把其它标签页的按键泄漏给远端；`CloseRDP` 仅由 `RDPPanel` 自己调用，关闭标签仍会卸载面板并正常结束会话，不会泄漏会话。

## 行为变化（需知悉）

标签页会持久化到 localStorage，因此**恢复的 RDP 标签现在会在启动时直接连接**，而不是等到被激活。这是「会话跨标签切换存活」的必然结果，且与 VNC 当前行为一致。