### PR TITLE
🐛 修复隐藏工具条后窗口按钮与 Tab 菜单重叠

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -467,6 +467,7 @@ function App() {
                 onEditAsset={handleEditAsset}
                 onDeleteAsset={handleDeleteAsset}
                 onConnectAsset={handleConnectAsset}
+                topBarHidden={sidebarHidden}
               />
               <SideAssistantPanel collapsed={aiPanelCollapsed} onToggle={toggleAIPanel} />
               {aiPanelCollapsed && <EdgeRevealStrip side="right" onClick={toggleAIPanel} />}

--- a/frontend/src/__tests__/TopTabBar.test.tsx
+++ b/frontend/src/__tests__/TopTabBar.test.tsx
@@ -1,0 +1,28 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TopTabBar } from "@/components/layout/TopTabBar";
+import { useTabStore } from "@/stores/tabStore";
+import { Environment } from "../../wailsjs/runtime/runtime";
+
+describe("TopTabBar window controls inset", () => {
+  beforeEach(() => {
+    vi.mocked(Environment).mockResolvedValue({ platform: "windows", buildType: "test", arch: "amd64" });
+    useTabStore.setState({
+      tabs: [
+        {
+          id: "settings",
+          type: "page",
+          label: "Settings",
+          meta: { type: "page", pageId: "settings" },
+        },
+      ],
+      activeTabId: "settings",
+    });
+  });
+
+  it("keeps tab actions clear of Windows window controls when it is the topmost bar", async () => {
+    const { container } = render(<TopTabBar topmost />);
+
+    await waitFor(() => expect(container.querySelector("[data-top-tabbar]")).toHaveClass("pr-[140px]"));
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -16,6 +16,7 @@ vi.mock("../../wailsjs/runtime/runtime", () => ({
   BrowserOpenURL: vi.fn(),
   Quit: vi.fn(),
   WindowIsFullscreen: vi.fn().mockResolvedValue(false),
+  Environment: vi.fn().mockResolvedValue({ platform: "other", buildType: "test", arch: "amd64" }),
   ClipboardGetText: vi.fn().mockResolvedValue(""),
   ClipboardSetText: vi.fn().mockResolvedValue(true),
 }));

--- a/frontend/src/components/layout/MainPanel.tsx
+++ b/frontend/src/components/layout/MainPanel.tsx
@@ -58,6 +58,7 @@ interface MainPanelProps {
   onEditAsset: (asset: asset_entity.Asset) => void;
   onDeleteAsset: (id: number) => void;
   onConnectAsset: (asset: asset_entity.Asset) => void;
+  topBarHidden?: boolean;
 }
 
 function PanelFallback() {
@@ -72,7 +73,7 @@ function LazySurface({ children }: { children: ReactNode }) {
   return <Suspense fallback={<PanelFallback />}>{children}</Suspense>;
 }
 
-export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPanelProps) {
+export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset, topBarHidden = false }: MainPanelProps) {
   const { t } = useTranslation();
 
   const tabs = useTabStore((s) => s.tabs);
@@ -224,7 +225,7 @@ export function MainPanel({ onEditAsset, onDeleteAsset, onConnectAsset }: MainPa
   return (
     <div className="flex flex-1 flex-col min-w-0">
       {/* Tab bar with integrated drag region (top layout only) */}
-      {hasTabs && tabBarLayout === "top" && <TopTabBar />}
+      {hasTabs && tabBarLayout === "top" && <TopTabBar topmost={topBarHidden} />}
 
       {/* Content area */}
       <div className="flex-1 relative min-h-0 overflow-hidden">

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { Search } from "lucide-react";
 import {
@@ -10,7 +10,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipTrigger, cn } from "@opskat/ui";
 import { CommandPalette } from "@/components/command/CommandPalette";
 import { useFullscreen } from "@/hooks/useFullscreen";
-import { Environment } from "../../../wailsjs/runtime/runtime";
+import { usePlatform } from "@/hooks/usePlatform";
 import type { asset_entity } from "../../../wailsjs/go/models";
 
 interface TopBarProps {
@@ -35,16 +35,7 @@ export function TopBar({
   const { t } = useTranslation();
   const isFullscreen = useFullscreen();
 
-  const [platform, setPlatform] = useState<"darwin" | "windows" | "other">("other");
-  useEffect(() => {
-    Environment()
-      .then((env) => {
-        if (env.platform === "darwin") setPlatform("darwin");
-        else if (env.platform === "windows") setPlatform("windows");
-        else setPlatform("other");
-      })
-      .catch(() => {});
-  }, []);
+  const platform = usePlatform();
 
   // macOS 红绿灯位（非全屏时预留 80px）；Windows 把 WindowControls 区域让出来
   const leftReserve = platform === "darwin" && !isFullscreen ? "pl-20" : "pl-2";

--- a/frontend/src/components/layout/TopTabBar.tsx
+++ b/frontend/src/components/layout/TopTabBar.tsx
@@ -17,6 +17,7 @@ import { TabPanelMenu } from "./TabPanelMenu";
 import { TabFilterPopover } from "./TabFilterPopover";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { getBuiltinPageMeta } from "./pageTabMeta";
+import { usePlatform } from "@/hooks/usePlatform";
 
 interface TabBarContextValue {
   tabs: Tab[];
@@ -137,7 +138,12 @@ function TabItem({
   );
 }
 
-export function TopTabBar() {
+interface TopTabBarProps {
+  topmost?: boolean;
+}
+
+export function TopTabBar({ topmost = false }: TopTabBarProps) {
+  const platform = usePlatform();
   const { t } = useTranslation();
 
   const tabs = useTabStore((s) => s.tabs);
@@ -281,7 +287,10 @@ export function TopTabBar() {
     <TabBarContext value={tabBarCtx}>
       <div
         data-top-tabbar
-        className="flex items-center border-b overflow-hidden bg-background"
+        className={cn(
+          "flex items-center border-b overflow-hidden bg-background",
+          topmost && platform === "windows" && "pr-[140px]"
+        )}
         style={{ "--wails-draggable": "drag" } as React.CSSProperties}
       >
         <div className="flex items-center min-w-0 flex-1">{tabs.map((tab) => renderTabItem(tab))}</div>

--- a/frontend/src/components/layout/WindowControls.tsx
+++ b/frontend/src/components/layout/WindowControls.tsx
@@ -1,22 +1,12 @@
 import React, { useState, useEffect } from "react";
 import { Minus, Square, Copy, X } from "lucide-react";
-import {
-  WindowMinimise,
-  WindowToggleMaximise,
-  WindowIsMaximised,
-  Quit,
-  Environment,
-} from "../../../wailsjs/runtime/runtime";
+import { WindowMinimise, WindowToggleMaximise, WindowIsMaximised, Quit } from "../../../wailsjs/runtime/runtime";
+import { usePlatform } from "@/hooks/usePlatform";
 
 export function WindowControls() {
-  const [isWindows, setIsWindows] = useState(false);
+  const platform = usePlatform();
   const [maximised, setMaximised] = useState(false);
-
-  useEffect(() => {
-    Environment().then((env) => {
-      setIsWindows(env.platform === "windows");
-    });
-  }, []);
+  const isWindows = platform === "windows";
 
   useEffect(() => {
     if (!isWindows) return;

--- a/frontend/src/hooks/usePlatform.ts
+++ b/frontend/src/hooks/usePlatform.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { Environment } from "../../wailsjs/runtime/runtime";
+
+export type Platform = "darwin" | "windows" | "other";
+
+export function usePlatform(): Platform {
+  const [platform, setPlatform] = useState<Platform>("other");
+
+  useEffect(() => {
+    Environment().then((env) => {
+      if (env.platform === "darwin") setPlatform("darwin");
+      else if (env.platform === "windows") setPlatform("windows");
+      else setPlatform("other");
+    });
+  }, []);
+
+  return platform;
+}


### PR DESCRIPTION
## 问题

Windows 下隐藏顶部工具条后，顶部 Tab 栏会上移到窗口顶端，但没有继续为固定在右上角的窗口控制按钮预留空间，导致关闭按钮与 Tab 更多菜单重叠。

## 修复

- 提取共享的 `usePlatform` hook，统一顶部工具条和窗口控制按钮的平台判断
- 当顶部工具条隐藏、TopTabBar 成为最顶层栏位时，仅在 Windows 下预留窗口控制区域
- 增加回归测试，验证顶层 Tab 栏会避开 Windows 窗口按钮

## 验证

- `pnpm exec vitest run src/__tests__/TopTabBar.test.tsx src/__tests__/MainPanel.rdp.test.tsx src/__tests__/MainPanel.vnc.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/hooks/usePlatform.ts src/components/layout/TopBar.tsx src/components/layout/WindowControls.tsx src/components/layout/TopTabBar.tsx src/components/layout/MainPanel.tsx src/App.tsx src/__tests__/TopTabBar.test.tsx src/__tests__/setup.ts`

Closes #233