### PR TITLE
🐛 修复 GitHub 登录重启后误失效 #229

### DIFF
--- a/frontend/src/__tests__/BackupSection.github-auth.test.tsx
+++ b/frontend/src/__tests__/BackupSection.github-auth.test.tsx
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { BackupSection } from "@/components/settings/BackupSection";
+import {
+  ClearGitHubToken,
+  GetGitHubToken,
+  GetGitHubUser,
+  GetStoredGitHubUser,
+  GetWebDAVConfig,
+  ListBackupGists,
+} from "../../wailsjs/go/system/System";
+
+describe("BackupSection GitHub auth restore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(GetGitHubToken).mockResolvedValue("stored-token");
+    vi.mocked(GetStoredGitHubUser).mockResolvedValue("stored-user");
+    vi.mocked(GetWebDAVConfig).mockResolvedValue(undefined);
+    vi.mocked(ListBackupGists).mockResolvedValue([]);
+  });
+
+  it("keeps the stored login when GitHub validation fails transiently", async () => {
+    vi.mocked(GetGitHubUser).mockRejectedValue(new Error("GitHub API 错误: 503"));
+
+    render(<BackupSection />);
+
+    expect(await screen.findByText("backup.gistLoggedIn")).toBeInTheDocument();
+    await waitFor(() => expect(GetGitHubUser).toHaveBeenCalledWith("stored-token"));
+    expect(ClearGitHubToken).not.toHaveBeenCalled();
+  });
+
+  it("clears the stored login only when GitHub explicitly rejects the token", async () => {
+    vi.mocked(GetGitHubUser).mockRejectedValue(new Error("[GITHUB_TOKEN_INVALID] GitHub API 错误: 401"));
+
+    render(<BackupSection />);
+
+    await waitFor(() => expect(ClearGitHubToken).toHaveBeenCalledOnce());
+    expect(screen.getByText("backup.gistLogin")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/settings/BackupSection.tsx
+++ b/frontend/src/components/settings/BackupSection.tsx
@@ -70,6 +70,7 @@ import { useShortcutStore } from "@/stores/shortcutStore";
 import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 
 const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e));
+const githubTokenInvalidMarker = "[GITHUB_TOKEN_INVALID]";
 
 const emptyWebDAVExportDefaults: WebDAVExportDefaults = {
   configured: false,
@@ -182,10 +183,12 @@ export function BackupSection() {
               setGhUser(u.login);
               SaveGitHubToken(token, u.login).catch(() => {});
             })
-            .catch(() => {
-              setGhToken("");
-              setGhUser("");
-              ClearGitHubToken().catch(() => {});
+            .catch((e: unknown) => {
+              if (errMsg(e).includes(githubTokenInvalidMarker)) {
+                setGhToken("");
+                setGhUser("");
+                ClearGitHubToken().catch(() => {});
+              }
             });
         }
       } catch {

--- a/internal/service/backup_svc/github.go
+++ b/internal/service/backup_svc/github.go
@@ -17,6 +17,9 @@ import (
 const (
 	githubClientID     = "Ov23liydPaSoHVMqecz9"
 	gistBackupFilename = "opskat-backup.encrypted.json"
+	// githubTokenInvalidMarker 跨 Wails IPC 传递明确的凭据失效状态。
+	// 只有 GitHub API 返回 401 时才能使用；网络错误、5xx 和限流都不代表 token 失效。
+	githubTokenInvalidMarker = "[GITHUB_TOKEN_INVALID]"
 )
 
 // 可在测试中覆盖的 base URL
@@ -217,7 +220,10 @@ func GetGitHubUser(token string) (*GitHubUser, error) {
 		}
 	}()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("%s GitHub API 错误: %d", githubTokenInvalidMarker, resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API 错误: %d", resp.StatusCode)
 	}
 

--- a/internal/service/backup_svc/github_test.go
+++ b/internal/service/backup_svc/github_test.go
@@ -366,13 +366,23 @@ func TestGetGitHubUser(t *testing.T) {
 			})
 		})
 
-		Convey("非 200 返回错误", func() {
+		Convey("401 明确标记 token 已失效", func() {
 			withTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
 			}), func() {
 				_, err := GetGitHubUser("bad-token")
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "401")
+				So(err.Error(), ShouldContainSubstring, githubTokenInvalidMarker)
+			})
+		})
+
+		Convey("5xx 不标记 token 失效", func() {
+			withTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}), func() {
+				_, err := GetGitHubUser("still-valid-token")
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldNotContainSubstring, githubTokenInvalidMarker)
 			})
 		})
 	})


### PR DESCRIPTION
## 问题

备份设置在应用重启后会读取已持久化的 GitHub token，并调用 GitHub `/user` 接口刷新用户信息。原逻辑把任意请求失败都视为 token 失效，网络中断、代理异常、限流或 GitHub 5xx 都会触发 `ClearGitHubToken()`，导致登录状态被永久清除。

## 修复

- 仅在 GitHub API 明确返回 `401 Unauthorized` 时标记 token 已失效
- 网络错误、403、限流、5xx 和响应异常不再清除已保存 token
- 重启恢复时先使用本地 token 和用户名恢复登录态，再异步校验
- 增加前后端回归测试，覆盖 401 清除和 503 保留两种场景

## 验证

- `go test ./internal/service/backup_svc ./internal/app/system`
- `pnpm exec vitest run src/__tests__/BackupSection.github-auth.test.tsx`
- `pnpm exec eslint src/components/settings/BackupSection.tsx src/__tests__/BackupSection.github-auth.test.tsx`
- `git diff --check`

closes #229