### PR TITLE
🐛 修复 SFTP 目录符号链接无法进入 #239

### DIFF
--- a/frontend/src/components/terminal/file-manager/PathToolbar.tsx
+++ b/frontend/src/components/terminal/file-manager/PathToolbar.tsx
@@ -95,6 +95,7 @@ export function PathToolbar({
         <Home className="h-3.5 w-3.5" />
       </Button>
       <Input
+        data-testid="sftp-path-input"
         className="h-6 text-xs flex-1 min-w-0"
         value={pathInput}
         onChange={(e) => onPathInputChange(e.target.value)}

--- a/internal/service/sftp_svc/sftp.go
+++ b/internal/service/sftp_svc/sftp.go
@@ -219,13 +219,19 @@ func (s *Service) ListDir(sessionID, dirPath string) ([]FileEntry, error) {
 	// 排序：目录在前，文件在后，各自按名称排序
 	var dirs, files []FileEntry
 	for _, info := range infos {
+		isDir := info.IsDir()
+		if info.Mode()&os.ModeSymlink != 0 {
+			if targetInfo, statErr := sftpClient.Stat(path.Join(dirPath, info.Name())); statErr == nil {
+				isDir = targetInfo.IsDir()
+			}
+		}
 		entry := FileEntry{
 			Name:    info.Name(),
 			Size:    info.Size(),
-			IsDir:   info.IsDir(),
+			IsDir:   isDir,
 			ModTime: info.ModTime().Unix(),
 		}
-		if info.IsDir() {
+		if isDir {
 			dirs = append(dirs, entry)
 		} else {
 			files = append(files, entry)

--- a/internal/service/sftp_svc/sftp_test.go
+++ b/internal/service/sftp_svc/sftp_test.go
@@ -1,0 +1,50 @@
+package sftp_svc
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListDirTreatsSymlinkToDirectoryAsDirectory(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	require.NoError(t, os.Mkdir(target, 0o700))
+	require.NoError(t, os.Symlink("target", filepath.Join(root, "data")))
+
+	clientConn, serverConn := net.Pipe()
+	server, err := sftp.NewServer(serverConn, sftp.WithServerWorkingDirectory(root))
+	require.NoError(t, err)
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- server.Serve()
+	}()
+
+	client, err := sftp.NewClientPipe(clientConn, clientConn)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+		require.NoError(t, server.Close())
+		<-serverDone
+	})
+
+	service := NewService(nil)
+	service.clients.Store("session", client)
+
+	entries, err := service.ListDir("session", ".")
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	var dataEntry *FileEntry
+	for i := range entries {
+		if entries[i].Name == "data" {
+			dataEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, dataEntry)
+	require.True(t, dataEntry.IsDir, "a symlink whose target is a directory must be navigable")
+}


### PR DESCRIPTION
## 问题

SFTP `ReadDir` 返回符号链接自身的类型。目录符号链接因此被标记为普通文件，双击时前端错误进入 external edit；后端 `Stat` 跟随链接后发现目标是目录，最终提示“仅支持打开常规文本文件”。手动输入路径则能正常读取链接目标目录。

## 修复

- 目录列表只对 `ModeSymlink` 条目追加一次跟随目标的 `Stat`
- 使用链接目标类型决定条目是否可导航、排序及展示为目录
- 普通文件和实体目录不增加额外远端请求
- 断链或不可访问链接不会拖垮整个目录列表
- 为 SFTP 路径输入框增加稳定的 E2E test id

## 测试

- 新增真实 SFTP 协议级回归测试，创建 `data -> target` 目录链接并通过 `Service.ListDir` 验证
- `go test ./internal/service/sftp_svc -count=1`
- `golangci-lint run ./internal/service/sftp_svc/...`
- `pnpm --dir frontend test --run src/__tests__/FileManagerPanel.test.tsx`（32 tests passed）
- frontend lint passed

## 真实机器 E2E

使用 `.env` 中配置的真实 SSH key-auth 测试机，经过真实 Wails IPC、SSH 握手、host-key 确认和 SFTP：

1. 创建临时目录、目标目录和目录符号链接
2. 从资产右键菜单打开文件管理器
3. 输入临时父目录路径
4. 确认 symlink 条目识别为目录
5. 双击进入并看到目标目录中的 marker 文件
6. 确认未出现“仅支持打开常规文本文件”

结果：Playwright scratch E2E `1 passed`。远端临时 fixture 已删除。

Fixes #239
