### PR TITLE
🐛 修复 Windows 高 DPI 下路径下划线被裁剪

### DIFF
--- a/frontend/src/components/terminal/file-manager/PathToolbar.tsx
+++ b/frontend/src/components/terminal/file-manager/PathToolbar.tsx
@@ -96,7 +96,7 @@ export function PathToolbar({
       </Button>
       <Input
         data-testid="sftp-path-input"
-        className="h-6 text-xs flex-1 min-w-0"
+        className="h-6 py-0 text-xs flex-1 min-w-0"
         value={pathInput}
         onChange={(e) => onPathInputChange(e.target.value)}
         onKeyDown={(e) => {

--- a/frontend/src/components/terminal/file-manager/__tests__/PathToolbar.test.tsx
+++ b/frontend/src/components/terminal/file-manager/__tests__/PathToolbar.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PathToolbar } from "../PathToolbar";
+
+describe("PathToolbar", () => {
+  it("removes vertical padding from the compact path input", () => {
+    render(
+      <PathToolbar
+        activeSyncMode={null}
+        currentPath="/data_log"
+        directoryFollowMode="off"
+        onFollowToggle={vi.fn()}
+        onGoHome={vi.fn()}
+        onGoUp={vi.fn()}
+        onPathInputChange={vi.fn()}
+        onPathSubmit={vi.fn()}
+        onRefresh={vi.fn()}
+        onSyncPanelFromTerminal={vi.fn()}
+        onSyncTerminalToPath={vi.fn()}
+        paneConnected
+        pathInput="/data_log"
+      />
+    );
+
+    expect(screen.getByTestId("sftp-path-input")).toHaveClass("h-6", "py-0");
+  });
+});


### PR DESCRIPTION
## 问题

Windows 11 在 125% 显示缩放下，SFTP 路径输入框中的下划线会被裁剪；同一环境切回 100% 后显示正常。路径框高度为 24px，但继承了共享 Input 的上下 padding，高 DPI 像素取整后会压缩文字下沿。

## 修复

- 仅为 SFTP 紧凑路径输入框覆盖 `py-0`，保持总高度、宽度、字号、边框和工具栏布局不变
- 添加 PathToolbar 回归测试，锁定紧凑输入框不再继承垂直 padding

## 验证

- `pnpm exec vitest run src/components/terminal/file-manager/__tests__/PathToolbar.test.tsx --reporter=verbose`
- `pnpm test`（215 files / 2009 tests）
- `pnpm lint`
- 真实 Wails + SSH/SFTP scratch E2E；100% 与模拟 125% 下 `/data_log_y_g_p` 下沿显示完整

Closes #240