### PR TITLE
🐛 修复 cp 审计状态与上下文一致性

### DIFF
--- a/cmd/opsctl/command/cp.go
+++ b/cmd/opsctl/command/cp.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -44,17 +45,31 @@ func cmdCp(ctx context.Context, handlers map[string]tool.ToolHandlerFunc, args [
 	srcIsRemote := srcAssetID > 0
 	dstIsRemote := dstAssetID > 0
 
-	argsJSON := fmt.Sprintf(`{"src":%q,"dst":%q}`, src, dst)
-
 	if session != "" {
 		ctx = aictx.WithSessionID(ctx, session)
+	}
+	ctx = aictx.WithAuditSource(ctx, "opsctl")
+
+	primaryAssetID := dstAssetID
+	if primaryAssetID == 0 {
+		primaryAssetID = srcAssetID
+	}
+	argsJSON, err := buildCpAuditArgs(src, dst, srcAssetID, dstAssetID, primaryAssetID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
 	}
 
 	// 文件传输与执行命令等价（写 authorized_keys / cron / 被 systemd 引用的脚本都够
 	// 换来一次执行），因此必须与 exec 一样过审批。审批放在 proxy 与直连分支的共同上游，
 	// 否则走 proxy 的那条路径会漏。
-	approvalCtx, approvalResult, err := requireCpApproval(ctx, srcAssetID, srcPath, dstAssetID, dstPath, src, dst)
+	approvalCtx, approvalResult, approvalAssetID, err := requireCpApproval(ctx, srcAssetID, srcPath, dstAssetID, dstPath, src, dst)
 	if err != nil {
+		argsJSON, marshalErr := buildCpAuditArgs(src, dst, srcAssetID, dstAssetID, approvalAssetID)
+		if marshalErr != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", marshalErr)
+			return 1
+		}
 		writeOpsctlAudit(approvalCtx, "cp", argsJSON, "", err, approvalResult.ToCheckResult())
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
@@ -63,7 +78,7 @@ func cmdCp(ctx context.Context, handlers map[string]tool.ToolHandlerFunc, args [
 	decision := approvalResult.ToCheckResult()
 
 	// 尝试通过 proxy 执行文件传输
-	if proxy := getSSHProxyClient(); proxy != nil {
+	if proxy := cpSSHProxyClientFn(); proxy != nil {
 		exitCode := cmdCpViaProxy(proxy, srcAssetID, srcPath, dstAssetID, dstPath, srcIsRemote, dstIsRemote, src, dst)
 		var cpErr error
 		if exitCode != 0 {
@@ -118,13 +133,16 @@ func cmdCp(ctx context.Context, handlers map[string]tool.ToolHandlerFunc, args [
 // opsctlAuditWriter 同一套路：测试替换掉它，避免真的去连桌面端审批 socket。
 var cpApprovalFn = requireApproval
 
+// cpSSHProxyClientFn 允许单测显式关闭 proxy 探测，避免读取默认用户数据目录下的 socket/token。
+var cpSSHProxyClientFn = getSSHProxyClient
+
 // requireCpApproval 为一次传输发起审批，审批主体是**远端路径**（grant 按资产存，
 // 本地路径不属于任何资产，塞进 pattern 无法匹配）。
 //
 // 资产间传输（remote → remote）要审两次：先源端读，再目的端写。任一被拒即整体失败。
-// 返回的 ctx 带上审批分配的 sessionID，供审计归组。
-func requireCpApproval(ctx context.Context, srcAssetID int64, srcPath string, dstAssetID int64, dstPath, src, dst string) (context.Context, ApprovalResult, error) {
-	detail := fmt.Sprintf("opsctl cp %s %s", src, dst)
+// 返回的 ctx 带上审批分配的 sessionID，assetID 是最后审批或拒绝的远端资产，供审计归组和展示。
+func requireCpApproval(ctx context.Context, srcAssetID int64, srcPath string, dstAssetID int64, dstPath, src, dst string) (context.Context, ApprovalResult, int64, error) {
+	detail := fmt.Sprintf("opsctl cp %s → %s", src, dst)
 
 	type target struct {
 		assetID int64
@@ -154,10 +172,36 @@ func requireCpApproval(ctx context.Context, srcAssetID int64, srcPath string, ds
 			ctx = aictx.WithSessionID(ctx, result.SessionID)
 		}
 		if err != nil {
-			return ctx, result, err
+			return ctx, result, tg.assetID, err
 		}
 	}
-	return ctx, last, nil
+	lastAssetID := int64(0)
+	if len(targets) > 0 {
+		lastAssetID = targets[len(targets)-1].assetID
+	}
+	return ctx, last, lastAssetID, nil
+}
+
+type cpAuditArgs struct {
+	AssetID            int64  `json:"asset_id"`
+	Src                string `json:"src"`
+	Dst                string `json:"dst"`
+	SourceAssetID      int64  `json:"source_asset_id,omitempty"`
+	DestinationAssetID int64  `json:"destination_asset_id,omitempty"`
+}
+
+func buildCpAuditArgs(src, dst string, srcAssetID, dstAssetID, assetID int64) (string, error) {
+	data, err := json.Marshal(cpAuditArgs{
+		AssetID:            assetID,
+		Src:                src,
+		Dst:                dst,
+		SourceAssetID:      srcAssetID,
+		DestinationAssetID: dstAssetID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal cp audit arguments: %w", err)
+	}
+	return string(data), nil
 }
 
 // assetNameForApproval 取资产名用于审批弹窗展示。资产在 parseRemotePathCtx 里已经解析过

--- a/cmd/opsctl/command/cp_approval_test.go
+++ b/cmd/opsctl/command/cp_approval_test.go
@@ -27,8 +27,8 @@ type recordingAuditRepo struct {
 }
 
 func (r *recordingAuditRepo) Create(_ context.Context, log *audit_entity.AuditLog) error {
-	copy := *log
-	r.logs = append(r.logs, &copy)
+	entry := *log
+	r.logs = append(r.logs, &entry)
 	return nil
 }
 

--- a/cmd/opsctl/command/cp_approval_test.go
+++ b/cmd/opsctl/command/cp_approval_test.go
@@ -2,19 +2,43 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/opskat/opskat/internal/ai/aictx"
+	"github.com/opskat/opskat/internal/ai/audit"
 	"github.com/opskat/opskat/internal/ai/tool"
 	"github.com/opskat/opskat/internal/approval"
 	"github.com/opskat/opskat/internal/model/entity/asset_entity"
+	"github.com/opskat/opskat/internal/model/entity/audit_entity"
 	"github.com/opskat/opskat/internal/repository/asset_repo"
 	"github.com/opskat/opskat/internal/repository/asset_repo/mock_asset_repo"
+	"github.com/opskat/opskat/internal/repository/audit_repo"
+	"github.com/opskat/opskat/internal/sshpool"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+type recordingAuditRepo struct {
+	logs []*audit_entity.AuditLog
+}
+
+func (r *recordingAuditRepo) Create(_ context.Context, log *audit_entity.AuditLog) error {
+	copy := *log
+	r.logs = append(r.logs, &copy)
+	return nil
+}
+
+func (r *recordingAuditRepo) List(context.Context, audit_repo.ListOptions) ([]*audit_entity.AuditLog, int64, error) {
+	return nil, 0, nil
+}
+
+func (r *recordingAuditRepo) ListSessions(context.Context, int64) ([]audit_repo.SessionInfo, error) {
+	return nil, nil
+}
 
 // registerCpTestAsset 注册一个只认 assetID=1 的 mock asset repo，
 // 让 "1:/path" 形式的远端路径能解析。
@@ -36,6 +60,9 @@ func registerCpTestAsset(t *testing.T) {
 func TestCmdCpRequiresApproval(t *testing.T) {
 	Convey("cp 被拒时不得发起任何传输", t, func() {
 		registerCpTestAsset(t)
+		originalProxyClient := cpSSHProxyClientFn
+		cpSSHProxyClientFn = func() *sshpool.Client { return nil }
+		defer func() { cpSSHProxyClientFn = originalProxyClient }()
 
 		mockAudit := &mockAuditWriter{}
 		origWriter := opsctlAuditWriter
@@ -94,4 +121,116 @@ func TestCmdCpRequiresApproval(t *testing.T) {
 			So(called, ShouldBeTrue)
 		})
 	})
+}
+
+func TestCmdCpDeniedAuditIsComplete(t *testing.T) {
+	registerCpTestAsset(t)
+
+	recordingRepo := &recordingAuditRepo{}
+	originalRepo := audit_repo.Audit()
+	originalWriter := opsctlAuditWriter
+	originalApproval := cpApprovalFn
+	audit_repo.RegisterAudit(recordingRepo)
+	opsctlAuditWriter = audit.NewDefaultAuditWriter()
+	cpApprovalFn = func(_ context.Context, _ approval.ApprovalRequest) (ApprovalResult, error) {
+		return ApprovalResult{
+			Decision:       aictx.Deny,
+			DecisionSource: aictx.SourceUserDeny,
+			SessionID:      "opsctl-cp-deny",
+		}, errors.New("operation denied: user denied")
+	}
+	t.Cleanup(func() {
+		cpApprovalFn = originalApproval
+		opsctlAuditWriter = originalWriter
+		audit_repo.RegisterAudit(originalRepo)
+	})
+
+	exitCode := cmdCp(context.Background(), nil, []string{"/tmp/payload.bin", "1:/srv/payload.bin"}, "")
+	require.Equal(t, 1, exitCode)
+	require.Len(t, recordingRepo.logs, 1)
+
+	entry := recordingRepo.logs[0]
+	require.Equal(t, "opsctl", entry.Source)
+	require.Equal(t, "cp", entry.ToolName)
+	require.Equal(t, int64(1), entry.AssetID)
+	require.Equal(t, "web-01", entry.AssetName)
+	require.Equal(t, "cp /tmp/payload.bin → 1:/srv/payload.bin", entry.Command)
+	require.Equal(t, "deny", entry.Decision)
+	require.Equal(t, aictx.SourceUserDeny, entry.DecisionSource)
+	require.Zero(t, entry.Success)
+	require.NotEmpty(t, entry.Error)
+	require.Equal(t, "opsctl-cp-deny", entry.SessionID)
+}
+
+func TestCmdCpDirectAuditIsSingleAndConsistent(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerErr  error
+		wantExit    int
+		wantSuccess int
+	}{
+		{name: "success", wantExit: 0, wantSuccess: 1},
+		{name: "failure", handlerErr: errors.New("sftp write failed"), wantExit: 1, wantSuccess: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			registerCpTestAsset(t)
+
+			recordingRepo := &recordingAuditRepo{}
+			originalRepo := audit_repo.Audit()
+			originalWriter := opsctlAuditWriter
+			originalApproval := cpApprovalFn
+			originalProxyClient := cpSSHProxyClientFn
+			audit_repo.RegisterAudit(recordingRepo)
+			opsctlAuditWriter = audit.NewDefaultAuditWriter()
+			cpSSHProxyClientFn = func() *sshpool.Client { return nil }
+			cpApprovalFn = func(_ context.Context, _ approval.ApprovalRequest) (ApprovalResult, error) {
+				return ApprovalResult{
+					Decision:       aictx.Allow,
+					DecisionSource: aictx.SourceUserAllow,
+					SessionID:      "opsctl-cp-direct",
+				}, nil
+			}
+			t.Cleanup(func() {
+				cpSSHProxyClientFn = originalProxyClient
+				cpApprovalFn = originalApproval
+				opsctlAuditWriter = originalWriter
+				audit_repo.RegisterAudit(originalRepo)
+			})
+
+			handlers := map[string]tool.ToolHandlerFunc{
+				"upload_file": func(_ context.Context, _ map[string]any) (string, error) {
+					return `{"status":"completed"}`, tc.handlerErr
+				},
+			}
+			exitCode := cmdCp(context.Background(), handlers, []string{"/tmp/payload.bin", "1:/srv/payload.bin"}, "")
+			require.Equal(t, tc.wantExit, exitCode)
+			require.Len(t, recordingRepo.logs, 1, "cp must write exactly one audit row")
+
+			entry := recordingRepo.logs[0]
+			require.Equal(t, "opsctl", entry.Source)
+			require.Equal(t, "cp", entry.ToolName)
+			require.Equal(t, int64(1), entry.AssetID)
+			require.Equal(t, "web-01", entry.AssetName)
+			require.Equal(t, "upload /tmp/payload.bin → /srv/payload.bin", entry.Command)
+			require.Equal(t, "allow", entry.Decision)
+			require.Equal(t, aictx.SourceUserAllow, entry.DecisionSource)
+			require.Equal(t, tc.wantSuccess, entry.Success)
+			require.Equal(t, tc.handlerErr != nil, entry.Error != "")
+			require.Equal(t, "opsctl-cp-direct", entry.SessionID)
+		})
+	}
+}
+
+func TestBuildCpAuditArgsIncludesBothRemoteAssets(t *testing.T) {
+	argsJSON, err := buildCpAuditArgs("1:/srv/source.bin", "2:/srv/destination.bin", 1, 2, 2)
+	require.NoError(t, err)
+
+	var args map[string]any
+	require.NoError(t, json.Unmarshal([]byte(argsJSON), &args))
+	require.Equal(t, float64(2), args["asset_id"])
+	require.Equal(t, float64(1), args["source_asset_id"])
+	require.Equal(t, float64(2), args["destination_asset_id"])
+	require.Equal(t, "cp 1:/srv/source.bin → 2:/srv/destination.bin", audit.ExtractCommandForAudit("cp", args))
 }

--- a/frontend/src/__tests__/AuditLogPage.test.tsx
+++ b/frontend/src/__tests__/AuditLogPage.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuditLogPage } from "@/components/audit/AuditLogPage";
+import { ListAuditLogs, ListAuditSessions } from "../../wailsjs/go/system/System";
+
+describe("AuditLogPage result status", () => {
+  beforeEach(() => {
+    vi.mocked(ListAuditSessions).mockResolvedValue([]);
+  });
+
+  it("renders a denied, unsuccessful audit row with the failure icon", async () => {
+    vi.mocked(ListAuditLogs).mockResolvedValue({
+      items: [
+        {
+          ID: 1,
+          Source: "opsctl",
+          ToolName: "cp",
+          AssetID: 7,
+          AssetName: "controlled-sftp",
+          Command: "cp /tmp/payload.bin → controlled-sftp:/srv/payload.bin",
+          Request: "{}",
+          Result: "",
+          Error: "operation denied: user denied",
+          Success: 0,
+          ConversationID: 0,
+          GrantSessionID: "",
+          SessionID: "opsctl-cp-deny",
+          Decision: "deny",
+          DecisionSource: "user_deny",
+          MatchedPattern: "",
+          Createtime: 1,
+        },
+      ],
+      total: 1,
+    } as never);
+
+    render(<AuditLogPage />);
+
+    expect(await screen.findByText("cp")).toBeInTheDocument();
+    expect(screen.getByLabelText("audit.failed")).toBeInTheDocument();
+    expect(screen.queryByLabelText("audit.success")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/ToolBlock.test.tsx
+++ b/frontend/src/__tests__/ToolBlock.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ToolBlock } from "@/components/ai/ToolBlock";
+
+describe("ToolBlock result status", () => {
+  it("renders an error icon for a denied tool result instead of a success icon", () => {
+    render(
+      <ToolBlock
+        block={{
+          type: "tool",
+          toolName: "upload_file",
+          content: "USER DENIED: transfer rejected",
+          status: "error",
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText("toolBlock.failed")).toBeInTheDocument();
+    expect(screen.queryByLabelText("toolBlock.succeeded")).not.toBeInTheDocument();
+  });
+
+  it("renders a success icon only for a completed tool result", () => {
+    render(
+      <ToolBlock
+        block={{
+          type: "tool",
+          toolName: "upload_file",
+          content: "uploaded",
+          status: "completed",
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText("toolBlock.succeeded")).toBeInTheDocument();
+    expect(screen.queryByLabelText("toolBlock.failed")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/aiStore.test.ts
+++ b/frontend/src/__tests__/aiStore.test.ts
@@ -2049,6 +2049,24 @@ describe("retry/error handling", () => {
     expect(useAIStore.getState().conversationMessages[402].at(-1)?.retryStatus).toBeUndefined();
   });
 
+  it("tool_result 的结构化 is_error 将工具块标记为 error", async () => {
+    const cbs = await startStreamingConv(407);
+    cbs[0]?.({ type: "tool_start", tool_name: "upload_file", tool_input: "{}", tool_call_id: "cp-deny" });
+    cbs[0]?.({
+      type: "tool_result",
+      tool_name: "upload_file",
+      tool_call_id: "cp-deny",
+      content: "USER DENIED: transfer rejected",
+      is_error: true,
+    });
+
+    const toolBlock = useAIStore
+      .getState()
+      .conversationMessages[407].at(-1)
+      ?.blocks.find((block) => block.type === "tool");
+    expect(toolBlock?.status).toBe("error");
+  });
+
   it("error 事件 push 一个 ErrorBlock 并 classify 分类", async () => {
     const cbs = await startStreamingConv(403);
     cbs[0]?.({ type: "error", error: "401 unauthorized: invalid api key" });

--- a/frontend/src/components/ai/ToolBlock.tsx
+++ b/frontend/src/components/ai/ToolBlock.tsx
@@ -78,10 +78,12 @@ export const ToolBlock = memo(function ToolBlock({ block }: ToolBlockProps) {
           <code className="min-w-0 truncate text-muted-foreground font-mono text-[10px] ml-0.5">{block.toolInput}</code>
         )}
         <span className="ml-auto shrink-0">
-          {isError && <XCircle className="h-3.5 w-3.5 text-destructive/70" />}
-          {isCancelled && <XCircle className="h-3.5 w-3.5 text-muted-foreground/50" />}
+          {isError && <XCircle aria-label={t("toolBlock.failed")} className="h-3.5 w-3.5 text-destructive/70" />}
+          {isCancelled && (
+            <XCircle aria-label={t("toolBlock.cancelled")} className="h-3.5 w-3.5 text-muted-foreground/50" />
+          )}
           {!isRunning && !isError && !isCancelled && hasOutput && (
-            <CheckCircle2 className="h-3.5 w-3.5 text-success/70" />
+            <CheckCircle2 aria-label={t("toolBlock.succeeded")} className="h-3.5 w-3.5 text-success/70" />
           )}
         </span>
       </button>

--- a/frontend/src/components/audit/AuditLogPage.tsx
+++ b/frontend/src/components/audit/AuditLogPage.tsx
@@ -433,9 +433,9 @@ export function AuditLogPage() {
                       </td>
                       <td className="px-4 py-2 text-center">
                         {log.Success === 1 ? (
-                          <CheckCircle2 className="h-4 w-4 text-success mx-auto" />
+                          <CheckCircle2 aria-label={t("audit.success")} className="h-4 w-4 text-success mx-auto" />
                         ) : (
-                          <XCircle className="h-4 w-4 text-destructive mx-auto" />
+                          <XCircle aria-label={t("audit.failed")} className="h-4 w-4 text-destructive mx-auto" />
                         )}
                       </td>
                       <td className="px-4 py-2">

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -101,7 +101,10 @@
   },
   "toolBlock": {
     "arguments": "Arguments",
-    "output": "Output"
+    "output": "Output",
+    "succeeded": "Tool succeeded",
+    "failed": "Tool failed",
+    "cancelled": "Tool cancelled"
   },
   "tab": {
     "close": "Close",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -101,7 +101,10 @@
   },
   "toolBlock": {
     "arguments": "参数",
-    "output": "输出"
+    "output": "输出",
+    "succeeded": "工具执行成功",
+    "failed": "工具执行失败",
+    "cancelled": "工具执行已取消"
   },
   "tab": {
     "close": "关闭",

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -111,6 +111,7 @@ interface StreamEventData {
   tool_name?: string;
   tool_input?: string;
   tool_call_id?: string;
+  is_error?: boolean;
   confirm_id?: string;
   error?: string;
   agent_role?: string;
@@ -1121,6 +1122,7 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
     }
 
     case "tool_result": {
+      const resultStatus: ContentBlock["status"] = event.is_error ? "error" : "completed";
       const updated = updateLastAssistant(msgs, (msg) => {
         const newBlocks = [...msg.blocks];
 
@@ -1154,7 +1156,7 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
           const children = [...(agentBlock.childBlocks || [])];
           const matchIdx = findToolMatch(children);
           if (matchIdx !== -1) {
-            children[matchIdx] = { ...children[matchIdx], content: event.content || "", status: "completed" };
+            children[matchIdx] = { ...children[matchIdx], content: event.content || "", status: resultStatus };
             agentBlock.childBlocks = children;
             newBlocks[agentIdx] = agentBlock;
             return { ...msg, blocks: newBlocks };
@@ -1164,7 +1166,7 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
         // 顶层工具块匹配
         const matchIdx = findToolMatch(newBlocks);
         if (matchIdx !== -1) {
-          newBlocks[matchIdx] = { ...newBlocks[matchIdx], content: event.content || "", status: "completed" };
+          newBlocks[matchIdx] = { ...newBlocks[matchIdx], content: event.content || "", status: resultStatus };
         }
         return { ...msg, blocks: newBlocks };
       });

--- a/internal/ai/audit/audit.go
+++ b/internal/ai/audit/audit.go
@@ -69,10 +69,19 @@ func (w *DefaultAuditWriter) WriteToolCall(ctx context.Context, info ToolCallInf
 		success = 0
 		errMsg = info.Error.Error()
 	}
+	if info.Decision != nil && info.Decision.Decision == aictx.Deny {
+		success = 0
+		if errMsg == "" {
+			errMsg = info.Decision.Message
+		}
+		if errMsg == "" {
+			errMsg = info.Result
+		}
+	}
 
 	entry := &audit_entity.AuditLog{
 		Source:         aictx.GetAuditSource(ctx),
-		ToolName:       info.ToolName,
+		ToolName:       ToolNameForAudit(info.ToolName),
 		AssetID:        assetID,
 		AssetName:      assetName,
 		Command:        command,

--- a/internal/ai/audit/audit_integration_test.go
+++ b/internal/ai/audit/audit_integration_test.go
@@ -1,0 +1,128 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/cago-frame/cago/database/db"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/opskat/opskat/internal/ai/aictx"
+	"github.com/opskat/opskat/internal/model/entity/asset_entity"
+	"github.com/opskat/opskat/internal/model/entity/audit_entity"
+	"github.com/opskat/opskat/internal/repository/asset_repo"
+	"github.com/opskat/opskat/internal/repository/audit_repo"
+	"github.com/opskat/opskat/migrations"
+)
+
+func TestDefaultAuditWriterPersistsToolAuditSemantics(t *testing.T) {
+	dataDir := t.TempDir()
+	gdb, err := gorm.Open(sqlite.Open(filepath.Join(dataDir, "opskat.db")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, migrations.RunMigrations(gdb, dataDir))
+
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	originalAssetRepo := asset_repo.Asset()
+	originalAuditRepo := audit_repo.Audit()
+	db.SetDefault(gdb)
+	asset_repo.RegisterAsset(asset_repo.NewAsset())
+	audit_repo.RegisterAudit(audit_repo.NewAudit())
+	t.Cleanup(func() {
+		audit_repo.RegisterAudit(originalAuditRepo)
+		asset_repo.RegisterAsset(originalAssetRepo)
+		require.NoError(t, sqlDB.Close())
+	})
+
+	asset := &asset_entity.Asset{
+		Name:   "controlled-sftp",
+		Type:   asset_entity.AssetTypeSSH,
+		Status: asset_entity.StatusActive,
+	}
+	require.NoError(t, gdb.Create(asset).Error)
+
+	tests := []struct {
+		name         string
+		toolName     string
+		argsJSON     string
+		execErr      error
+		result       string
+		decision     aictx.CheckResult
+		wantToolName string
+		wantCommand  string
+		wantSuccess  int
+		wantErrorSet bool
+	}{
+		{
+			name:         "upload denied",
+			toolName:     "upload_file",
+			argsJSON:     `{"asset_id":1,"local_path":"/tmp/deny.bin","remote_path":"/srv/deny.bin"}`,
+			execErr:      errors.New("USER DENIED: transfer rejected"),
+			decision:     aictx.CheckResult{Decision: aictx.Deny, DecisionSource: aictx.SourceUserDeny},
+			wantToolName: "cp",
+			wantCommand:  "upload /tmp/deny.bin → /srv/deny.bin",
+			wantSuccess:  0,
+			wantErrorSet: true,
+		},
+		{
+			name:         "upload allowed",
+			toolName:     "upload_file",
+			argsJSON:     `{"asset_id":1,"local_path":"/tmp/upload.bin","remote_path":"/srv/upload.bin"}`,
+			decision:     aictx.CheckResult{Decision: aictx.Allow, DecisionSource: aictx.SourceUserAllow},
+			wantToolName: "cp",
+			wantCommand:  "upload /tmp/upload.bin → /srv/upload.bin",
+			wantSuccess:  1,
+		},
+		{
+			name:         "download allowed",
+			toolName:     "download_file",
+			argsJSON:     `{"asset_id":1,"remote_path":"/srv/download.bin","local_path":"/tmp/download.bin"}`,
+			decision:     aictx.CheckResult{Decision: aictx.Allow, DecisionSource: aictx.SourceUserAllow},
+			wantToolName: "cp",
+			wantCommand:  "download /srv/download.bin → /tmp/download.bin",
+			wantSuccess:  1,
+		},
+		{
+			name:         "command denied without handler error",
+			toolName:     "run_command",
+			argsJSON:     `{"asset_id":1,"command":"cat /etc/shadow"}`,
+			decision:     aictx.CheckResult{Decision: aictx.Deny, DecisionSource: aictx.SourceUserDeny},
+			result:       "USER DENIED: command rejected",
+			wantToolName: "run_command",
+			wantCommand:  "cat /etc/shadow",
+			wantSuccess:  0,
+			wantErrorSet: true,
+		},
+	}
+
+	writer := NewDefaultAuditWriter()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := aictx.WithAuditSource(context.Background(), "ai")
+			ctx = aictx.WithSessionID(ctx, tc.name)
+			writer.WriteToolCall(ctx, ToolCallInfo{
+				ToolName: tc.toolName,
+				ArgsJSON: tc.argsJSON,
+				Result:   tc.result,
+				Error:    tc.execErr,
+				Decision: &tc.decision,
+			})
+
+			var stored audit_entity.AuditLog
+			require.NoError(t, gdb.Where("session_id = ?", tc.name).First(&stored).Error)
+			require.Equal(t, "ai", stored.Source)
+			require.Equal(t, tc.wantToolName, stored.ToolName)
+			require.Equal(t, asset.ID, stored.AssetID)
+			require.Equal(t, asset.Name, stored.AssetName)
+			require.Equal(t, tc.wantCommand, stored.Command)
+			require.Equal(t, tc.wantSuccess, stored.Success)
+			require.Equal(t, tc.decision.DecisionString(), stored.Decision)
+			require.Equal(t, tc.decision.DecisionSource, stored.DecisionSource)
+			require.Equal(t, tc.wantErrorSet, stored.Error != "")
+		})
+	}
+}

--- a/internal/ai/audit/extractor.go
+++ b/internal/ai/audit/extractor.go
@@ -6,8 +6,9 @@ import "sync"
 type CommandExtractorFunc func(args map[string]any) string
 
 var (
-	extractorsMu sync.RWMutex
-	extractors   = map[string]CommandExtractorFunc{}
+	extractorsMu   sync.RWMutex
+	extractors     = map[string]CommandExtractorFunc{}
+	auditToolNames = map[string]string{}
 )
 
 // RegisterExtractor 注册工具名 → 命令摘要提取器。
@@ -16,6 +17,25 @@ func RegisterExtractor(toolName string, fn CommandExtractorFunc) {
 	extractorsMu.Lock()
 	defer extractorsMu.Unlock()
 	extractors[toolName] = fn
+}
+
+// RegisterToolAlias 注册执行工具名到持久化审计工具名的映射。
+// 它只改变 audit_logs.tool_name，不改变实际工具 dispatch 名或 provider schema。
+func RegisterToolAlias(toolName, alias string) {
+	extractorsMu.Lock()
+	defer extractorsMu.Unlock()
+	auditToolNames[toolName] = alias
+}
+
+// ToolNameForAudit 返回工具在持久化审计中的分类名，未注册别名时保持原名。
+func ToolNameForAudit(toolName string) string {
+	extractorsMu.RLock()
+	alias, ok := auditToolNames[toolName]
+	extractorsMu.RUnlock()
+	if ok {
+		return alias
+	}
+	return toolName
 }
 
 // ExtractCommandForAudit 调用已注册的提取器返回命令摘要，未注册返回空串。

--- a/internal/ai/audit/extractor_default.go
+++ b/internal/ai/audit/extractor_default.go
@@ -9,11 +9,16 @@ import (
 // 注册非协议特有的常见工具提取器；协议特有(kafka_*, exec_k8s)在各自子包 init() 注册。
 func init() {
 	RegisterExtractor("run_command", func(a map[string]any) string { return aictx.ArgString(a, "command") })
+	RegisterToolAlias("upload_file", "cp")
 	RegisterExtractor("upload_file", func(a map[string]any) string {
 		return "upload " + aictx.ArgString(a, "local_path") + " → " + aictx.ArgString(a, "remote_path")
 	})
+	RegisterToolAlias("download_file", "cp")
 	RegisterExtractor("download_file", func(a map[string]any) string {
 		return "download " + aictx.ArgString(a, "remote_path") + " → " + aictx.ArgString(a, "local_path")
+	})
+	RegisterExtractor("cp", func(a map[string]any) string {
+		return "cp " + aictx.ArgString(a, "src") + " → " + aictx.ArgString(a, "dst")
 	})
 	RegisterExtractor("exec_sql", func(a map[string]any) string { return aictx.ArgString(a, "sql") })
 	RegisterExtractor("exec_redis", func(a map[string]any) string { return aictx.ArgString(a, "command") })

--- a/internal/ai/runner/audit_hook_test.go
+++ b/internal/ai/runner/audit_hook_test.go
@@ -174,3 +174,48 @@ func TestAuditMiddleware_CapturesRecordedDecision(t *testing.T) {
 		So(entry.MatchedPattern, ShouldEqual, "uptime")
 	})
 }
+
+func TestAuditMiddleware_DeniedDecisionIsToolError(t *testing.T) {
+	Convey("a recorded deny is a failed tool result even when the handler returns nil error", t, func() {
+		mockRepo := &mockAuditRepo{}
+		origRepo := audit_repo.Audit()
+		audit_repo.RegisterAudit(mockRepo)
+		t.Cleanup(func() {
+			audit_repo.RegisterAudit(origRepo)
+		})
+
+		tool := &recordingTool{
+			name: "run_command",
+			fill: &aictx.CheckResult{
+				Decision:       aictx.Deny,
+				DecisionSource: aictx.SourceUserDeny,
+			},
+			out: func() (*agent.ToolResultBlock, error) {
+				return &agent.ToolResultBlock{
+					Content: []agent.ContentBlock{agent.TextBlock{Text: "USER DENIED: command rejected"}},
+				}, nil
+			},
+		}
+		dispatcher := &agent.ToolDispatcher{
+			Tools: []agent.Tool{tool},
+			Middleware: []agent.ToolHookEntry[agent.ToolMiddleware]{
+				{Matcher: ".*", Fn: auditMiddleware},
+			},
+		}
+
+		result := dispatcher.Run(context.Background(), agent.DispatchInput{
+			ToolName:  "run_command",
+			ToolUseID: "tu_deny",
+			Input:     map[string]any{"asset_id": float64(1), "command": "cat /etc/shadow"},
+		})
+
+		So(result.Output, ShouldNotBeNil)
+		So(result.Output.IsError, ShouldBeTrue)
+		waitForAudit(t, mockRepo, 1)
+		entry := mockRepo.logs[0]
+		So(entry.Decision, ShouldEqual, "deny")
+		So(entry.DecisionSource, ShouldEqual, aictx.SourceUserDeny)
+		So(entry.Success, ShouldEqual, 0)
+		So(entry.Error, ShouldEqual, "USER DENIED: command rejected")
+	})
+}

--- a/internal/ai/runner/hooks.go
+++ b/internal/ai/runner/hooks.go
@@ -29,6 +29,11 @@ func auditMiddleware(c *agent.ToolContext) {
 	c.WithContext(aictx.WithCheckResultSlot(c.Context(), slot))
 
 	c.Next()
+	// Deny 是工具调用的失败终态，即使具体 handler 按 agent 协议把拒绝说明作为
+	// 普通文本返回。统一在 middleware 边界标记，事件、UI 与审计由同一结构化语义驱动。
+	if slot.Decision == aictx.Deny && c.Output != nil {
+		c.Output.IsError = true
+	}
 
 	argsJSON, err := json.Marshal(c.Input)
 	if err != nil {

--- a/internal/ai/runner/provider.go
+++ b/internal/ai/runner/provider.go
@@ -55,6 +55,7 @@ type StreamEvent struct {
 	ToolName   string `json:"tool_name,omitempty"`    // type=tool_start/tool_result 时的工具名
 	ToolInput  string `json:"tool_input,omitempty"`   // type=tool_start 时的输入摘要
 	ToolCallID string `json:"tool_call_id,omitempty"` // type=tool_start/tool_result 时的工具调用 ID，前端用于跨 turn 还原 tool_calls 历史
+	IsError    bool   `json:"is_error,omitempty"`     // type=tool_result 时表示工具拒绝或执行失败
 	ConfirmID  string `json:"confirm_id,omitempty"`   // type=approval_request/approval_result 时的确认请求 ID
 	Error      string `json:"error,omitempty"`        // type=error 时的错误信息
 	AgentRole  string `json:"agent_role,omitempty"`   // type=agent_start/approval_request 时的角色描述

--- a/internal/ai/runner/stream_event.go
+++ b/internal/ai/runner/stream_event.go
@@ -73,6 +73,7 @@ func (t *EventTranslator) Translate(ev agent.Event, emit func(StreamEvent)) {
 			ToolName:   ev.Tool.Name,
 			ToolCallID: ev.Tool.ToolUseID,
 			Content:    extractToolResultText(ev.Tool.Output),
+			IsError:    ev.Tool.Output != nil && ev.Tool.Output.IsError,
 		})
 
 	case agent.EventTurnEnd:

--- a/internal/ai/runner/stream_event_test.go
+++ b/internal/ai/runner/stream_event_test.go
@@ -88,6 +88,28 @@ func TestEventTranslator_PostToolUse(t *testing.T) {
 	})
 }
 
+func TestEventTranslator_PostToolUsePreservesErrorState(t *testing.T) {
+	Convey("EventPostToolUse preserves ToolResultBlock.IsError", t, func() {
+		out := drain(NewStreamTranslator(), agent.Event{
+			Kind: agent.EventPostToolUse,
+			Tool: &agent.ToolEvent{
+				ToolUseID: "tu_denied",
+				Name:      "upload_file",
+				Output: &agent.ToolResultBlock{
+					IsError: true,
+					Content: []agent.ContentBlock{
+						agent.TextBlock{Text: "USER DENIED: transfer rejected"},
+					},
+				},
+			},
+		})
+
+		So(out, ShouldHaveLength, 1)
+		So(out[0].Type, ShouldEqual, "tool_result")
+		So(out[0].IsError, ShouldBeTrue)
+	})
+}
+
 func TestEventTranslator_TurnEndUsage(t *testing.T) {
 	Convey("EventTurnEnd（带 Usage）→ usage", t, func() {
 		out := drain(NewStreamTranslator(),

--- a/internal/model/entity/audit_entity/audit.go
+++ b/internal/model/entity/audit_entity/audit.go
@@ -11,7 +11,7 @@ type AuditLog struct {
 	Request        string `gorm:"column:request;type:text"`
 	Result         string `gorm:"column:result;type:text"`
 	Error          string `gorm:"column:error;type:text"`
-	Success        int    `gorm:"column:success;default:1"` // 1=成功, 0=失败
+	Success        int    `gorm:"column:success"` // 1=成功, 0=失败
 	ConversationID int64  `gorm:"column:conversation_id;default:0;index"`
 	GrantSessionID string `gorm:"column:grant_session_id;type:varchar(36)"`
 	SessionID      string `gorm:"column:session_id;type:varchar(64);index"` // opsctl/AI 会话 ID

--- a/internal/repository/audit_repo/audit_test.go
+++ b/internal/repository/audit_repo/audit_test.go
@@ -1,0 +1,53 @@
+package audit_repo
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/cago-frame/cago/database/db"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/opskat/opskat/internal/model/entity/audit_entity"
+	"github.com/opskat/opskat/migrations"
+)
+
+func TestAuditRepoCreatePreservesExplicitSuccess(t *testing.T) {
+	dataDir := t.TempDir()
+	gdb, err := gorm.Open(sqlite.Open(filepath.Join(dataDir, "opskat.db")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, migrations.RunMigrations(gdb, dataDir))
+
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	db.SetDefault(gdb)
+	t.Cleanup(func() {
+		require.NoError(t, sqlDB.Close())
+	})
+
+	var databaseDefault string
+	require.NoError(t, gdb.Raw(
+		"SELECT dflt_value FROM pragma_table_info('audit_logs') WHERE name = 'success'",
+	).Scan(&databaseDefault).Error)
+	require.Equal(t, "1", databaseDefault, "the production schema must retain its historical default")
+
+	repo := NewAudit()
+	for _, success := range []int{0, 1} {
+		t.Run("success="+strconv.Itoa(success), func(t *testing.T) {
+			entry := &audit_entity.AuditLog{
+				Source:     "ai",
+				ToolName:   "exec",
+				Success:    success,
+				Createtime: 1,
+			}
+			require.NoError(t, repo.Create(context.Background(), entry))
+
+			var stored audit_entity.AuditLog
+			require.NoError(t, gdb.First(&stored, entry.ID).Error)
+			require.Equal(t, success, stored.Success)
+		})
+	}
+}


### PR DESCRIPTION
## 背景

PR #251 合并后的真实 Wails / SQLite / SSH-SFTP E2E 暴露了几处审计语义不一致：

- AI `upload_file` / `download_file` 的审批面是 `cp`，但审计仍记录原始工具名；
- GORM model default 会把显式 `success=0` 写成成功；
- `opsctl cp` 拒绝行缺少统一的 source、资产和方向命令上下文；
- 拒绝结果的结构化失败状态在事件链中丢失，导致工具卡/审计页可能显示绿色成功。

## 修复

- 去掉 `AuditLog.Success` 的 GORM model default，保留数据库 schema default，并新增真实 migration + GORM + SQLite 回读测试；
- 为 AI 文件传输增加仅作用于持久化审计分类的 `cp` alias，不改变 provider schema、dispatch 名或 grant 隔离；
- 统一 `opsctl cp` 审计 source、资产 ID/name、`src → dst` 命令摘要及拒绝错误；
- 规定 `Decision=Deny` 必须持久化为失败，并将 `ToolResultBlock.IsError` 贯通到 Wails stream event 和前端 store；
- 工具卡与审计结果图标改用结构化状态，并补充可访问标签及回归测试。

## 验证

- `go test ./... -count=1` ✅
- 前端 `pnpm test`：219 files / 2028 tests ✅
- `pnpm lint` ✅
- 定向前端回归：4 files / 88 tests ✅
- `git diff --check` ✅
- 真实 E2E：`xvfb-run -a pnpm run test:scratch opskat-pr251-real-e2e.spec.ts --trace=off`：6/6 ✅

真实 E2E 使用隔离 SQLite、loopback OpenAI-compatible fixture 与真实 SSH/SFTP fixture，确认：

- 拒绝发生在任何 SSH/SFTP 副作用前，拒绝后零远端副作用；
- 允许的 upload/download 字节数与 SHA-256 一致；
- `cp:*` grant 不会授权 `exec`；
- AI/opsctl 拒绝审计均为 `success=0`、error 非空、上下文完整；
- 拒绝工具卡和审计行均显示失败状态。

Relates to #251.
