### PR TITLE
✨ 终端支持 OSC 52 剪贴板透传并补齐本地真彩

### DIFF
--- a/frontend/src/__tests__/TerminalPasteSuppression.test.tsx
+++ b/frontend/src/__tests__/TerminalPasteSuppression.test.tsx
@@ -35,6 +35,10 @@ const hoisted = vi.hoisted(() => {
       setEnabled: vi.fn(),
       setColor: vi.fn(),
     },
+    clipboardOsc52: {
+      setEnabled: vi.fn(),
+      dispose: vi.fn(),
+    },
   };
   return {
     copyBehavior: "popover-menu",

--- a/frontend/src/__tests__/terminalOsc52.test.ts
+++ b/frontend/src/__tests__/terminalOsc52.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Terminal } from "@xterm/xterm";
+import { parseOsc52, attachTerminalClipboardOsc52 } from "@/components/terminal/terminalOsc52";
+
+// base64 of a UTF-8 string, as a terminal/tmux emits it in an OSC 52 payload.
+function b64(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
+describe("parseOsc52", () => {
+  it("decodes a clipboard write payload to UTF-8 text", () => {
+    expect(parseOsc52(`c;${b64("hello world")}`)).toEqual({ kind: "write", text: "hello world" });
+  });
+
+  it("decodes multibyte UTF-8 correctly", () => {
+    expect(parseOsc52(`c;${b64("你好，clipboard")}`)).toEqual({ kind: "write", text: "你好，clipboard" });
+  });
+
+  it("treats any selection target the same (c / p / multiple)", () => {
+    expect(parseOsc52(`p;${b64("primary")}`)).toEqual({ kind: "write", text: "primary" });
+    expect(parseOsc52(`cp;${b64("both")}`)).toEqual({ kind: "write", text: "both" });
+    // An empty Pc defaults to the clipboard per the OSC 52 spec.
+    expect(parseOsc52(`;${b64("default-target")}`)).toEqual({ kind: "write", text: "default-target" });
+  });
+
+  it("flags a read request (Pd === '?') so the caller can refuse it", () => {
+    // SECURITY: honoring this would leak the local clipboard to a remote session.
+    expect(parseOsc52("c;?")).toEqual({ kind: "read" });
+    expect(parseOsc52("p;?")).toEqual({ kind: "read" });
+  });
+
+  it("ignores malformed payloads instead of throwing", () => {
+    expect(parseOsc52("")).toEqual({ kind: "ignore" });
+    expect(parseOsc52("c")).toEqual({ kind: "ignore" }); // no separator
+    expect(parseOsc52("c;!!!not-base64!!!")).toEqual({ kind: "ignore" });
+  });
+});
+
+describe("attachTerminalClipboardOsc52 against real @xterm/xterm", () => {
+  it("writes decoded text to the clipboard when a full OSC 52 sequence is parsed", async () => {
+    const term = new Terminal({ cols: 80, rows: 24 });
+    const writes: string[] = [];
+    const ctrl = attachTerminalClipboardOsc52(term, { enabled: true, write: (t) => writes.push(t) });
+    await new Promise<void>((resolve) => term.write(`\x1b]52;c;${b64("clip-me")}\x07`, () => resolve()));
+    expect(writes).toEqual(["clip-me"]);
+    ctrl.dispose();
+    term.dispose();
+  });
+
+  it("does NOT touch the clipboard when disabled", async () => {
+    const term = new Terminal({ cols: 80, rows: 24 });
+    const writes: string[] = [];
+    const ctrl = attachTerminalClipboardOsc52(term, { enabled: false, write: (t) => writes.push(t) });
+    await new Promise<void>((resolve) => term.write(`\x1b]52;c;${b64("blocked")}\x07`, () => resolve()));
+    expect(writes).toEqual([]);
+    ctrl.dispose();
+    term.dispose();
+  });
+
+  it("never writes for a read-back request (clipboard is not leaked)", async () => {
+    const term = new Terminal({ cols: 80, rows: 24 });
+    const writes: string[] = [];
+    const ctrl = attachTerminalClipboardOsc52(term, { enabled: true, write: (t) => writes.push(t) });
+    await new Promise<void>((resolve) => term.write(`\x1b]52;c;?\x07`, () => resolve()));
+    expect(writes).toEqual([]);
+    ctrl.dispose();
+    term.dispose();
+  });
+
+  it("honors setEnabled toggled at runtime", async () => {
+    const term = new Terminal({ cols: 80, rows: 24 });
+    const writes: string[] = [];
+    const ctrl = attachTerminalClipboardOsc52(term, { enabled: false, write: (t) => writes.push(t) });
+    ctrl.setEnabled(true);
+    await new Promise<void>((resolve) => term.write(`\x1b]52;c;${b64("now-on")}\x07`, () => resolve()));
+    expect(writes).toEqual(["now-on"]);
+    ctrl.dispose();
+    term.dispose();
+  });
+});

--- a/frontend/src/__tests__/terminalRegistry.test.ts
+++ b/frontend/src/__tests__/terminalRegistry.test.ts
@@ -134,6 +134,8 @@ vi.mock("@xterm/xterm", () => {
     });
     onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
     onRender = vi.fn(() => ({ dispose: vi.fn() }));
+    // OSC 52 剪贴板透传在 term.parser 上注册处理器（见 terminalOsc52）。
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
     attachCustomKeyEventHandler = vi.fn();
     textarea = document.createElement("textarea");
     registerLinkProvider = vi.fn((provider) => {

--- a/frontend/src/components/settings/AppearanceSection.tsx
+++ b/frontend/src/components/settings/AppearanceSection.tsx
@@ -120,6 +120,8 @@ export function TerminalSection() {
     webglError,
     highlightLinks,
     setHighlightLinks,
+    osc52ClipboardEnabled,
+    setOsc52ClipboardEnabled,
     copyBehavior,
     setCopyBehavior,
     customThemes,
@@ -325,6 +327,14 @@ export function TerminalSection() {
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">{t("terminal.copyBehaviorHint")}</p>
+          </div>
+
+          <div className="flex items-start justify-between gap-4">
+            <div className="grid gap-1">
+              <Label>{t("terminal.osc52Clipboard")}</Label>
+              <p className="text-xs text-muted-foreground">{t("terminal.osc52ClipboardHint")}</p>
+            </div>
+            <Switch checked={osc52ClipboardEnabled} onCheckedChange={setOsc52ClipboardEnabled} />
           </div>
 
           <Separator />

--- a/frontend/src/components/terminal/Terminal.tsx
+++ b/frontend/src/components/terminal/Terminal.tsx
@@ -74,6 +74,7 @@ export function Terminal({ sessionId, active, tabId, ref }: TerminalProps) {
   const scrollback = useTerminalThemeStore((s) => s.scrollback);
   const webglEnabled = useTerminalThemeStore((s) => s.webglEnabled);
   const highlightLinks = useTerminalThemeStore((s) => s.highlightLinks);
+  const osc52Clipboard = useTerminalThemeStore((s) => s.osc52ClipboardEnabled);
   const copyBehavior = useTerminalThemeStore((s) => s.copyBehavior);
   const selectedThemeId = useTerminalThemeStore((s) => s.selectedThemeId);
   const customThemes = useTerminalThemeStore((s) => s.customThemes);
@@ -156,6 +157,7 @@ export function Terminal({ sessionId, active, tabId, ref }: TerminalProps) {
       transport,
       webglEnabled,
       highlightLinks,
+      osc52Clipboard,
     });
     termRef.current = inst.term;
     fitAddonRef.current = inst.fitAddon;
@@ -243,9 +245,10 @@ export function Terminal({ sessionId, active, tabId, ref }: TerminalProps) {
     const inst = getTerminalInstance(sessionId);
     inst?.urlHighlighter.setEnabled(highlightLinks);
     inst?.urlHighlighter.setColor(terminalUrlHighlightColor(xtermTheme));
+    inst?.clipboardOsc52.setEnabled(osc52Clipboard);
     fitAddonRef.current?.fit();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [xtermTheme, fontSize, fontFamily, scrollback, highlightLinks]);
+  }, [xtermTheme, fontSize, fontFamily, scrollback, highlightLinks, osc52Clipboard]);
 
   useEffect(() => {
     const inst = getTerminalInstance(sessionId);

--- a/frontend/src/components/terminal/terminalOsc52.ts
+++ b/frontend/src/components/terminal/terminalOsc52.ts
@@ -1,0 +1,61 @@
+import type { Terminal as XTerminal } from "@xterm/xterm";
+
+// OSC 52 是终端"选中缓冲区/剪贴板"操作序列：`ESC ] 52 ; Pc ; Pd ST`。
+//   Pc = 目标缓冲区(c=clipboard、p=primary、s/0-7=cut buffer，可多字符)——我们只有一个
+//        系统剪贴板，写哪个都归一到系统剪贴板。
+//   Pd = base64 编码的内容；特例 Pd === "?" 是**读回请求**，要求终端把当前剪贴板回传给
+//        程序。tmux `set-clipboard on`、vim `"+y`、以及远端 TUI 用它把内容送进本地剪贴板。
+export type Osc52Action = { kind: "write"; text: string } | { kind: "read" } | { kind: "ignore" };
+
+function decodeBase64Utf8(b64: string): string | null {
+  try {
+    const binary = atob(b64.trim());
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  } catch {
+    // atob 遇到非 base64 字符会抛 —— 恶意/损坏序列，忽略而不是让解析器崩掉。
+    return null;
+  }
+}
+
+// parseOsc52 只吃 OSC 标识符 `52;` 之后的部分，即 `Pc;Pd`（xterm registerOscHandler
+// 回调拿到的 data）。纯函数，便于单测覆盖安全语义。
+export function parseOsc52(payload: string): Osc52Action {
+  const sep = payload.indexOf(";");
+  if (sep === -1) return { kind: "ignore" };
+  const data = payload.slice(sep + 1);
+  if (data === "?") return { kind: "read" };
+  const text = decodeBase64Utf8(data);
+  if (text === null || text === "") return { kind: "ignore" };
+  return { kind: "write", text };
+}
+
+export interface TerminalClipboardOsc52Controller {
+  setEnabled(enabled: boolean): void;
+  dispose(): void;
+}
+
+// 在终端解析器上挂一个 OSC 52 处理器：启用时把远端写入的内容解码后送进系统剪贴板。
+// 安全约束：**永不响应读回请求**（parseOsc52 的 "read" 分支被丢弃），否则远端会话能
+// 反向读走本地剪贴板。启用状态由调用方通过 enabled/setEnabled 联动设置项。
+export function attachTerminalClipboardOsc52(
+  term: XTerminal,
+  opts: { enabled: boolean; write: (text: string) => void }
+): TerminalClipboardOsc52Controller {
+  let enabled = opts.enabled;
+  const disposable = term.parser.registerOscHandler(52, (payload) => {
+    // 关闭时返回 false = 未处理，xterm 直接丢弃该序列（无默认处理器），等价 no-op。
+    if (!enabled) return false;
+    const action = parseOsc52(payload);
+    if (action.kind === "write") opts.write(action.text);
+    // read / ignore：吞掉序列但不做任何事（尤其绝不回写剪贴板给远端）。
+    return true;
+  });
+  return {
+    setEnabled: (next) => {
+      enabled = next;
+    },
+    dispose: () => disposable.dispose(),
+  };
+}

--- a/frontend/src/components/terminal/terminalRegistry.ts
+++ b/frontend/src/components/terminal/terminalRegistry.ts
@@ -5,7 +5,13 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 import { toast } from "sonner";
-import { BrowserOpenURL, EventsOn, EventsOff, ClipboardGetText } from "../../../wailsjs/runtime/runtime";
+import {
+  BrowserOpenURL,
+  EventsOn,
+  EventsOff,
+  ClipboardGetText,
+  ClipboardSetText,
+} from "../../../wailsjs/runtime/runtime";
 import { bytesToBase64 } from "@/lib/terminalEncode";
 import { useTerminalStore, TRANSPORTS, type TerminalTransport } from "@/stores/terminalStore";
 import { useShortcutStore } from "@/stores/shortcutStore";
@@ -16,6 +22,7 @@ import { createTerminalInputBridge, type TerminalInputBridge } from "./terminalI
 import { createZmodemController, type ZmodemController } from "./zmodem/zmodemSession";
 import { attachXtermRolloverGuard } from "./xtermRolloverGuard";
 import { attachTerminalUrlHighlighter, type TerminalUrlHighlighterController } from "./terminalUrlHighlighter";
+import { attachTerminalClipboardOsc52, type TerminalClipboardOsc52Controller } from "./terminalOsc52";
 import { normalizeHttpUrl } from "./terminalUrlScan";
 
 const PENDING_RZ_UPLOAD_TTL_MS = 10_000;
@@ -27,6 +34,7 @@ export interface TerminalInstance {
   container: HTMLDivElement;
   bridge: TerminalInputBridge;
   urlHighlighter: TerminalUrlHighlighterController;
+  clipboardOsc52: TerminalClipboardOsc52Controller;
 }
 
 interface InternalInstance extends TerminalInstance {
@@ -48,6 +56,7 @@ export function getOrCreateTerminal(
     transport?: TerminalTransport;
     webglEnabled?: boolean;
     highlightLinks?: boolean;
+    osc52Clipboard?: boolean;
   }
 ): TerminalInstance {
   const cached = registry.get(sessionId);
@@ -87,6 +96,14 @@ export function getOrCreateTerminal(
   const urlHighlighter = attachTerminalUrlHighlighter(term, {
     enabled: init.highlightLinks === true,
     color: terminalUrlHighlightColor(init.theme),
+  });
+  // OSC 52 剪贴板透传：远端(tmux set-clipboard / vim "+y)写入的内容 → 系统剪贴板。
+  // 写侧走 Wails 原生 ClipboardSetText（与选区复制 copyText 同源）；读回请求被内部拒绝。
+  const clipboardOsc52 = attachTerminalClipboardOsc52(term, {
+    enabled: init.osc52Clipboard === true,
+    write: (text) => {
+      ClipboardSetText(text).catch(console.error);
+    },
   });
 
   // 优先用调用方传入的 transport；首次挂载若没拿到（罕见），退回 session id 前缀。
@@ -258,6 +275,7 @@ export function getOrCreateTerminal(
     container,
     bridge,
     urlHighlighter,
+    clipboardOsc52,
     isClosed: false,
     suppressNextNativePaste,
     uploadFilesWithRz,
@@ -266,6 +284,7 @@ export function getOrCreateTerminal(
       // 必须在 term.dispose 之前调用,避免 dispose 后访问已释放对象。
       bridge.dispose();
       urlHighlighter.dispose();
+      clipboardOsc52.dispose();
       rolloverGuard.dispose();
       zmodem?.dispose();
       onDataDispose.dispose();

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1304,6 +1304,8 @@
     "copyBehaviorSmartRightClick": "Smart Right-click Copy / Paste",
     "copyBehaviorSelectCopyRightPaste": "Copy on Selection / Right-click Paste",
     "copyBehaviorHint": "Default shows a copy popover for selected text and keeps the right-click menu. You can switch to right-click copy/paste or copy-on-selection.",
+    "osc52Clipboard": "OSC 52 Clipboard Write",
+    "osc52ClipboardHint": "Let remote programs write to your system clipboard via OSC 52 (tmux set-clipboard, vim \"+y). On by default; only writes pass through and read-back is never allowed, so the worst case is a malicious remote overwriting your clipboard — turn it off for untrusted hosts.",
     "default": "Default",
     "builtinThemes": "Built-in Themes",
     "customThemes": "Custom Themes",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1304,6 +1304,8 @@
     "copyBehaviorSmartRightClick": "右键智能复制 / 粘贴",
     "copyBehaviorSelectCopyRightPaste": "选中即复制 / 右键粘贴",
     "copyBehaviorHint": "默认显示选区复制浮窗并保留右键菜单；可按个人习惯切换为右键复制/粘贴或选中即复制。",
+    "osc52Clipboard": "OSC 52 剪贴板写入",
+    "osc52ClipboardHint": "允许远端程序通过 OSC 52 把内容写入系统剪贴板（如 tmux set-clipboard、vim \"+y）。默认开启；只透传写入、读取始终禁止，最坏情况仅是恶意远端篡改你的剪贴板——连接不受信主机时可关闭。",
     "default": "默认",
     "builtinThemes": "预置配色",
     "customThemes": "自定义配色",

--- a/frontend/src/stores/terminalThemeStore.ts
+++ b/frontend/src/stores/terminalThemeStore.ts
@@ -35,6 +35,10 @@ interface TerminalThemeState {
   scrollback: number;
   webglEnabled: boolean;
   highlightLinks: boolean;
+  // OSC 52 剪贴板写入：允许 tmux `set-clipboard on` / vim `"+y` / 远端 TUI 把内容送进
+  // 系统剪贴板。默认开启（多数现代终端如此）；仅"写入"透传，读回请求始终被拒绝，所以
+  // 最坏情况是恶意远端覆盖剪贴板，连接不受信主机时可在设置里关掉。
+  osc52ClipboardEnabled: boolean;
   copyBehavior: TerminalCopyBehavior;
   // 分屏窗格顶部工具条：true = 固定常驻；false = 隐藏，鼠标移到窗格顶部时向下滑出。
   toolbarPinned: boolean;
@@ -49,6 +53,7 @@ interface TerminalThemeState {
   setScrollback: (lines: number) => void;
   setWebglEnabled: (enabled: boolean) => void;
   setHighlightLinks: (enabled: boolean) => void;
+  setOsc52ClipboardEnabled: (enabled: boolean) => void;
   setCopyBehavior: (behavior: TerminalCopyBehavior) => void;
   setToolbarPinned: (pinned: boolean) => void;
   reportWebglFailure: (failure: WebglFailure) => void;
@@ -84,6 +89,7 @@ export const useTerminalThemeStore = create<TerminalThemeState>()(
       scrollback: SCROLLBACK_DEFAULT,
       webglEnabled: true,
       highlightLinks: false,
+      osc52ClipboardEnabled: true,
       copyBehavior: "popover-menu",
       toolbarPinned: true,
       webglError: null,
@@ -93,6 +99,7 @@ export const useTerminalThemeStore = create<TerminalThemeState>()(
       // （手动关掉不该写入 webglError，但也不主动清——下次自动关掉的错误能继续展示）。
       setWebglEnabled: (enabled) => set(enabled ? { webglEnabled: true, webglError: null } : { webglEnabled: false }),
       setHighlightLinks: (enabled) => set({ highlightLinks: enabled }),
+      setOsc52ClipboardEnabled: (enabled) => set({ osc52ClipboardEnabled: enabled }),
       setCopyBehavior: (behavior) => set({ copyBehavior: behavior }),
       setToolbarPinned: (pinned) => set({ toolbarPinned: pinned }),
       reportWebglFailure: (failure) => set({ webglError: failure }),

--- a/internal/service/localterm_svc/pty_unix.go
+++ b/internal/service/localterm_svc/pty_unix.go
@@ -34,7 +34,10 @@ func startPTY(spec ptySpec) (ptyProcess, error) {
 	}
 	cmd := exec.Command(shell, spec.Args...) //nolint:gosec // G204: 启动用户在本地终端资产里选择的 shell 是本功能的核心意图
 	cmd.Dir = cwd
-	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+	// COLORTERM=truecolor：TERM=xterm-256color 的能力位只到 256 色，部分 TUI 会据此
+	// 关掉 24-bit 输出。补这个变量让"看 COLORTERM 才发真彩 SGR"的程序也能出真彩；
+	// 前端 xterm 本就按 24-bit 渲染，两端对齐。
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color", "COLORTERM=truecolor")
 
 	cols, rows := clampSize(spec.Cols, spec.Rows)
 	f, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)})

--- a/internal/service/localterm_svc/pty_unix_test.go
+++ b/internal/service/localterm_svc/pty_unix_test.go
@@ -52,6 +52,46 @@ func TestStartPTYEchoesInput(t *testing.T) {
 	}
 }
 
+// TestStartPTYExportsTruecolorEnv 验证本地 PTY 会给 shell 注入 COLORTERM=truecolor,
+// 这样只按 COLORTERM 判断是否发 24-bit SGR 的 TUI 程序也能输出真彩,而不是被
+// TERM=xterm-256color 的 256 色能力位限制住。
+func TestStartPTYExportsTruecolorEnv(t *testing.T) {
+	proc, err := startPTY(ptySpec{Shell: "/bin/sh", Cols: 80, Rows: 24})
+	require.NoError(t, err)
+	defer func() { _ = proc.Close() }()
+
+	_, err = proc.Write([]byte("printenv COLORTERM\n"))
+	require.NoError(t, err)
+
+	out := make(chan string, 2)
+	go func() {
+		r := bufio.NewReader(readerFunc(proc.Read))
+		var sb strings.Builder
+		buf := make([]byte, 1024)
+		for {
+			n, e := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+				if strings.Contains(sb.String(), "truecolor") {
+					out <- sb.String()
+					return
+				}
+			}
+			if e != nil {
+				out <- sb.String()
+				return
+			}
+		}
+	}()
+
+	select {
+	case s := <-out:
+		require.Contains(t, s, "truecolor")
+	case <-time.After(5 * time.Second):
+		t.Fatal("PTY 未在超时内输出 COLORTERM=truecolor")
+	}
+}
+
 func TestStartPTYResizeNoError(t *testing.T) {
 	proc, err := startPTY(ptySpec{Shell: "/bin/sh"})
 	require.NoError(t, err)


### PR DESCRIPTION
## 背景

排查"tmux 里样式发闷 + 复制不出来"后确认：opskat 自带终端（xterm.js）本身渲染真彩、且选区复制已走系统剪贴板，不受影响。唯一缺口是 **OSC 52 剪贴板写入** 没处理——远端 `tmux set-clipboard on` / vim `"+y` / TUI 通过 OSC 52 往剪贴板写时会被丢弃。本 PR 补齐这条路径，并顺带补本地 PTY 的真彩环境变量。

## 改动

**OSC 52 剪贴板透传（默认开启，可在设置关闭）**
- 新增 `terminalOsc52.ts`：在 `term.parser` 上注册 OSC 52 处理器，解码 base64→UTF-8 后走 Wails `ClipboardSetText` 写入系统剪贴板。
- **安全**：永不响应读回请求（`Pd="?"`），远端无法反向读走本地剪贴板；只透传写入，最坏情况仅是恶意远端篡改剪贴板——连接不受信主机时可在设置关闭。
- 开关持久化于 `terminalThemeStore`（`osc52ClipboardEnabled`），沿用 `highlightLinks` 同一路径：创建时传入 + 运行时热更新，改设置即时生效。
- 设置面板「终端」分组新增开关 + 中英文案。

**本地 PTY 追加 `COLORTERM=truecolor`**：`TERM=xterm-256color` 能力位只到 256 色，补该变量让只看 `COLORTERM` 才发 24-bit SGR 的程序也能出真彩，与前端 xterm 的 24-bit 渲染对齐。

## 测试

- `terminalOsc52.test.ts`：`parseOsc52` 覆盖写入解码 / 读回拒绝 / 禁用门禁 / 坏 base64 / 多字节 UTF-8，另有真实 xterm 端到端集成。
- 后端 `pty_unix_test.go`：验证 PTY 向 shell 注入 `COLORTERM=truecolor`。
- 全绿：前端 2037 测试通过、`tsc`/eslint 干净；后端 `localterm_svc` 测试通过、`golangci-lint` 0 issues。
- 两处 test double 补齐代码新用到的 `parser` / `clipboardOsc52` 接口面。

## 自测方式

设置里确认开关开启 → 终端跑 tmux 开 `set-clipboard on`、或 vim `"+y` → 内容应进 macOS 系统剪贴板。