### PR TITLE
🐛 修复内置 AI 多轮对话丢弃工具历史导致编造结果 #230

### DIFF
--- a/frontend/src/__tests__/aiStore.test.ts
+++ b/frontend/src/__tests__/aiStore.test.ts
@@ -1638,9 +1638,11 @@ describe("DeepSeek-v4 多轮 tool 调用历史展开", () => {
     expect(finalAssistant.tool_calls).toBeUndefined();
   });
 
-  it("非 DeepSeek-v4 模型：保持原有塌缩行为，不展开 tool_calls，不带 reasoning_content", async () => {
+  it("非 DeepSeek-v4 模型：也展开 tool_calls + 工具结果（#230），但不回放 reasoning_content", async () => {
+    // 回归 #230：塌缩历史会丢掉工具结构，长对话里模型跨 turn 看不到自己调过工具、开始编造。
+    // 修复后所有 provider 都展开 tool_calls/结果；reasoning_content 仍仅 deepseek-v4 回放。
     useAIStore.setState({
-      modelName: "deepseek-chat",
+      modelName: "gpt-4o",
       sidebarTabs: [buildSidebarTabFor(101)],
       activeSidebarTabId: "sidebar-101",
       conversationMessages: { 101: buildHistory() },
@@ -1652,15 +1654,70 @@ describe("DeepSeek-v4 多轮 tool 调用历史展开", () => {
     const args = vi.mocked(SendAIMessage).mock.calls.at(-1)!;
     const apiMsgs = args[1] as any[];
 
-    // 只有 user / assistant / user / user（assistant 是塌缩后单条，不展开）
-    const roles = apiMsgs.map((m) => m.role);
-    expect(roles).toEqual(["user", "assistant", "user", "user"]);
+    // user / assistant(tool_calls) / tool / assistant(final text) / user / user
+    expect(apiMsgs.map((m) => m.role)).toEqual(["user", "assistant", "tool", "assistant", "user", "user"]);
 
-    const assistantMsg = apiMsgs[1];
-    expect(assistantMsg.content).toBe("找到 2 台");
-    expect(assistantMsg.tool_calls).toBeUndefined();
-    expect(assistantMsg.reasoning_content).toBeUndefined();
-    expect(assistantMsg.thinking).toBeUndefined();
+    const toolCallAssistant = apiMsgs[1];
+    expect(toolCallAssistant.tool_calls).toHaveLength(1);
+    expect(toolCallAssistant.tool_calls[0].id).toBe("call_001");
+    expect(toolCallAssistant.tool_calls[0].function.name).toBe("list_assets");
+    // 非 deepseek-v4：不带 reasoning_content / thinking
+    expect(toolCallAssistant.reasoning_content).toBeUndefined();
+    expect(toolCallAssistant.thinking).toBeUndefined();
+
+    expect(apiMsgs[2].tool_call_id).toBe("call_001");
+    expect(apiMsgs[2].content).toBe('[{"id":1}]');
+
+    const finalAssistant = apiMsgs[3];
+    expect(finalAssistant.content).toBe("找到 2 台");
+    expect(finalAssistant.tool_calls).toBeUndefined();
+    expect(finalAssistant.reasoning_content).toBeUndefined();
+  });
+
+  it("存盘/重载会话保留 tool block 的 toolCallId（#230：重载后仍能展开工具历史）", async () => {
+    // 存盘侧：toDisplayMessages 必须写出 toolCallId
+    useAIStore.setState({
+      modelName: "gpt-4o",
+      sidebarTabs: [buildSidebarTabFor(103)],
+      activeSidebarTabId: "sidebar-103",
+      conversationMessages: { 103: buildHistory() },
+      conversationStreaming: { 103: { sending: false, pendingQueue: [] } },
+    });
+    await useAIStore.getState().sendFromSidebarTab("sidebar-103", "再看 redis");
+
+    const savedBlocks = vi
+      .mocked(SaveConversationMessages)
+      .mock.calls.flatMap((c) => (c[1] as any[]).flatMap((m) => m.blocks || []));
+    const savedTool = savedBlocks.find((b) => b.type === "tool");
+    expect(savedTool).toBeDefined();
+    expect(savedTool.toolCallId).toBe("call_001");
+
+    // 重载侧：convertDisplayMessages 必须还原 toolCallId
+    vi.mocked(LoadConversationMessages).mockResolvedValue([
+      { role: "user", content: "查 SSH", blocks: [] },
+      {
+        role: "assistant",
+        content: "找到 2 台",
+        blocks: [
+          {
+            type: "tool",
+            content: '[{"id":1}]',
+            toolName: "list_assets",
+            toolInput: "{}",
+            toolCallId: "call_777",
+            status: "completed",
+          },
+          { type: "text", content: "找到 2 台" },
+        ],
+      },
+    ] as any);
+    useAIStore.setState({ conversations: [{ ID: 104, Title: "t" } as any] });
+
+    await useAIStore.getState().openConversationTab(104);
+
+    const loaded = useAIStore.getState().conversationMessages[104];
+    const loadedTool = loaded.flatMap((m) => m.blocks).find((b) => b.type === "tool");
+    expect(loadedTool?.toolCallId).toBe("call_777");
   });
 
   it("DeepSeek-v4 模型 + 老数据（tool block 缺 toolCallId）：兜底为塌缩消息，不抛错", async () => {

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -577,6 +577,9 @@ function toDisplayMessages(msgs: ChatMessage[], includeStreaming = false): ai.Co
                 content: b.content,
                 toolName: b.toolName,
                 toolInput: b.toolInput,
+                // #230: 持久化 toolCallId，否则重载会话后 expandToAPIMessages 无法配对
+                // tool_use↔tool_result，会退化回塌缩，工具历史再次丢失。
+                toolCallId: b.toolCallId,
                 status: includeStreaming ? normalizeSnapshotStatus(b.status) : b.status,
                 errorKind: b.errorKind,
                 errorDetail: b.errorDetail,
@@ -597,6 +600,7 @@ function convertDisplayMessages(displayMsgs: ai.ConversationDisplayMessage[]): C
       content: b.content,
       toolName: b.toolName,
       toolInput: b.toolInput,
+      toolCallId: b.toolCallId, // #230: 还原 toolCallId 以便重载后仍能展开 tool_calls 历史
       status: b.status as ContentBlock["status"],
       errorKind: b.errorKind as ErrorKind | undefined,
       errorDetail: b.errorDetail,
@@ -1424,12 +1428,15 @@ function handleStreamEvent(convId: number, event: StreamEventData) {
 // 把前端塌缩的 ChatMessage 还原成 OpenAI/Anthropic 标准的多条 LLM 消息：
 //   - 一次 user turn 对应一条 ChatMessage(assistant)，blocks 顺序为
 //     thinking_n -> tool_n(含 input/result) -> ... -> text(最终回复)
-//   - 展开后变成：assistant(thinking + tool_calls) + tool(result) + ... + assistant(text)
+//   - 展开后变成：assistant(thinking? + tool_calls) + tool(result) + ... + assistant(text)
 //   - 前置约束：tool block 必须带 toolCallId 才能展开；缺失的（旧数据）直接忽略 tool 块，回退到塌缩
 //
-// 这样跨 turn 时 DeepSeek/OpenAI 能看到上一 turn 的中间 tool_calls 与结果，
-// 同时也满足 DeepSeek thinking 模式"带 tool_calls 的 assistant 必须回传 reasoning_content"的强制要求。
-function expandToAPIMessages(messages: ChatMessage[]): runner.Message[] {
+// 所有支持工具调用的 provider 都需要看到上一 turn 的 tool_calls 与结果，否则模型跨 turn
+// 看不到自己曾经调过工具，长对话里会被自身"直接作答"的历史带偏、编造工具结果（issue #230）。
+// 因此 tool 结构无条件展开；而 reasoning_content/thinking 仅在 includeThinking=true 时回放
+// ——只有 DeepSeek thinking 模式强制要求"带 tool_calls 的 assistant 必须回传 reasoning_content"，
+// 其它 provider 不需要，且 Anthropic 会因缺 signature 拒绝未签名的 thinking，故默认不回放。
+function expandToAPIMessages(messages: ChatMessage[], includeThinking: boolean): runner.Message[] {
   const out: runner.Message[] = [];
   for (const m of messages) {
     if (m.role !== "assistant") {
@@ -1437,15 +1444,23 @@ function expandToAPIMessages(messages: ChatMessage[]): runner.Message[] {
       continue;
     }
 
+    // content-only 的 assistant 历史（无 block，如内存里刚构造或旧塌缩数据）：直接按 content
+    // 塌缩发送，避免下面基于 block 的展开把 content 丢掉（text 只从 text block 累加）。
+    if (m.blocks.length === 0) {
+      out.push(new runner.Message({ role: "assistant", content: m.content }));
+      continue;
+    }
+
     // assistant 累加器：在遇到 tool block 时刷出当前 assistant + 跟一条 tool 消息
     let thinking = "";
     let text = "";
+    let sawText = false;
     const pendingToolCalls: { id: string; type: string; function: { name: string; arguments: string } }[] = [];
 
     const flushAssistant = () => {
       if (!thinking && !text && pendingToolCalls.length === 0) return;
       const payload: Record<string, unknown> = { role: "assistant", content: text };
-      if (thinking) {
+      if (includeThinking && thinking) {
         payload.thinking = thinking;
         payload.reasoning_content = thinking;
       }
@@ -1471,7 +1486,7 @@ function expandToAPIMessages(messages: ChatMessage[]): runner.Message[] {
         .map((b) => b.content)
         .join("");
       const payload: Record<string, unknown> = { role: "assistant", content: m.content };
-      if (allThinking) {
+      if (includeThinking && allThinking) {
         payload.thinking = allThinking;
         payload.reasoning_content = allThinking;
       }
@@ -1484,6 +1499,7 @@ function expandToAPIMessages(messages: ChatMessage[]): runner.Message[] {
         thinking += b.content;
       } else if (b.type === "text") {
         text += b.content;
+        sawText = true;
       } else if (b.type === "tool" && b.toolCallId) {
         pendingToolCalls.push({
           id: b.toolCallId,
@@ -1502,6 +1518,9 @@ function expandToAPIMessages(messages: ChatMessage[]): runner.Message[] {
       // approval / agent / error 块不参与 LLM 历史还原，跳过。
       // error 块的归类标签和原始错误正文是 UI 显示用，不应作为历史 prompt 影响 LLM。
     }
+    // blocks 里没有 text block 但 content 有值（少见：最终回复只落在 content 上）时，
+    // 用 m.content 兜底最终 assistant 文本，避免把回复丢掉。
+    if (!sawText && !text && m.content) text = m.content;
     flushAssistant();
   }
   return out;
@@ -1581,14 +1600,13 @@ async function _sendForConversation(convId: number, content: string) {
     handleStreamEvent(convId, event);
   });
 
-  // 仅 DeepSeek-v4 thinking 模式强制要求"带 tool_calls 的 assistant 必须回传 reasoning_content"，
-  // 且需要历史中间 tool_calls 可见才能跨 turn 继续推理；其他 provider（Anthropic / OpenAI / Kimi 等）
-  // 保持原有塌缩行为，避免引入不必要的回归。
+  // #230: 每一轮都把上一 turn 的 tool_calls + 工具结果回放给 LLM（对所有 provider 生效）。
+  // 旧实现只对 deepseek-v4 展开、其余塌缩成 {role,content}，丢掉了工具结构——模型跨 turn
+  // 看不到自己调过工具，长对话里会被自身"直接作答"的历史带偏，从而不再发起真正的工具调用、
+  // 直接编造结果。reasoning_content 仍只对 deepseek-v4 回放（它强制要求带 tool_calls 时回传
+  // reasoning_content），其它 provider 不需要，Anthropic 还会拒绝未签名 thinking。
   const modelName = useAIStore.getState().modelName;
-  const needExpand = modelName.startsWith("deepseek-v4");
-  const apiMessages = needExpand
-    ? expandToAPIMessages(newMessages)
-    : newMessages.map((m) => new runner.Message({ role: m.role, content: m.content }));
+  const apiMessages = expandToAPIMessages(newMessages, modelName.startsWith("deepseek-v4"));
 
   // 收集当前 Tab 上下文
   const assets = useAssetStore.getState().assets;


### PR DESCRIPTION
## 问题 (closes #230)

内置 AI 在**较长的多轮对话**里会开始**编造工具结果**——声称"已调用接口/已修改配置"，但实际没有发起任何工具调用。现象与模型无关（换顶尖模型也躲不掉）、**和上下文强相关**、对话越长越容易出现。

## 根因（前端历史回放，两个缺陷）

回放会话历史时，`_sendForConversation` 对**除名字以 `deepseek-v4` 开头以外的所有模型**，把每一轮塌缩成 `{role, content}`，**丢掉了 assistant 的 `tool_calls` 与 `role:"tool"` 工具结果**（`frontend/src/stores/aiStore.ts`）。模型跨 turn 看不到自己曾经调用过工具，长对话里被自身"直接作答"的历史带偏，于是不再发起真正的工具调用、直接编造——正好解释了 issue 里"与模型无关、上下文强相关、顶尖模型也躲不掉"。

第二个缺陷：存盘/重载会话时 `toDisplayMessages` / `convertDisplayMessages` **未携带 `toolCallId`**，导致即便 `deepseek-v4`，切走再切回也会因 `canExpand=false` 退化回塌缩。

## 改动

- `expandToAPIMessages` 对**所有 provider** 展开 `tool_calls` + 工具结果；`reasoning_content` 仍仅对 `deepseek-v4` 回放（它强制要求带 tool_calls 时回传 reasoning_content，其它 provider 不需要，Anthropic 还会拒绝未签名 thinking）——用新参数 `includeThinking` 解耦。
- content-only / 无 text block 的 assistant 历史加兜底，展开时不丢回复文本。
- 持久化与重载都保留 `toolCallId`。

## 测试

- 新增/改写 2 个测试（非-deepseek 也展开工具结构、存盘+重载保留 `toolCallId`），**先对旧代码跑 → 2 个都 FAIL**（复现 bug），对修复跑 → 全绿。
- 前端全量 **2036 测试通过**，`pnpm lint` 干净。

## 附：GLM-5.2 等模型的流式畸形（单独的上游问题）

复现时发现 GLM-5.2 经 OpenAI 兼容代理在**流式**下会吐出错乱/空名的 tool-call 增量，被 cago 累加成空名 tool_use → `agent: tool not found`，是另一个独立的加重项。已验证 `parallel_tool_calls:false` **无效**（模型忽略该参数）；有效的修法是在 cago `agent/loop.go finalizeToolUses` 丢弃空名 tool_use。这属 cago 上游，不在本 PR 范围。