### PR TITLE
✨ 数据库资产支持单独配置查询超时 #257

### DIFF
--- a/frontend/src/components/asset/DatabaseConfigSection.config.ts
+++ b/frontend/src/components/asset/DatabaseConfigSection.config.ts
@@ -21,6 +21,7 @@ export interface DatabaseFormState extends ConnectionFormFields {
   readOnly: boolean;
   params: string;
   path: string;
+  queryTimeoutSeconds: number;
 }
 
 export const DATABASE_DEFAULTS: DatabaseFormState = {
@@ -35,6 +36,7 @@ export const DATABASE_DEFAULTS: DatabaseFormState = {
   readOnly: false,
   params: "",
   path: "",
+  queryTimeoutSeconds: 30,
   ...CONNECTION_DEFAULTS,
 };
 
@@ -50,6 +52,7 @@ interface DatabaseConfig {
   tls?: boolean;
   params?: string;
   read_only?: boolean;
+  query_timeout_seconds?: number;
   ssh_asset_id?: number;
   sqlite_source?: "local" | "remote_ssh_vfs";
   path?: string;
@@ -111,6 +114,7 @@ export function buildDatabaseConfig(
   if (state.database) cfg.database = state.database;
   if (state.readOnly) cfg.read_only = true;
   if (state.params) cfg.params = state.params;
+  if (state.queryTimeoutSeconds > 0) cfg.query_timeout_seconds = state.queryTimeoutSeconds;
   return JSON.stringify(cfg);
 }
 
@@ -131,6 +135,7 @@ export function parseDatabaseConfig(configJSON: string, assetTunnelId = 0): Data
       readOnly: cfg.read_only || false,
       params: cfg.params || "",
       path: cfg.path || "",
+      queryTimeoutSeconds: cfg.query_timeout_seconds || 30,
       ...parseConnectionFields(cfg.proxy, assetTunnelId || cfg.ssh_asset_id || 0, cfg.proxy_chain),
     };
   } catch {

--- a/frontend/src/components/asset/DatabaseConfigSection.tsx
+++ b/frontend/src/components/asset/DatabaseConfigSection.tsx
@@ -251,6 +251,15 @@ export function DatabaseConfigSection({ editAsset, onValidityChange, onIconChang
       fields: [
         { kind: "text", key: "params", label: "asset.params", placeholder: "asset.paramsPlaceholder" },
         { kind: "switch", key: "readOnly", label: "asset.readOnly" },
+        {
+          kind: "number",
+          key: "queryTimeoutSeconds",
+          label: "asset.queryTimeout",
+          min: 5,
+          max: 600,
+          width: "flex-1",
+          testid: "database-query-timeout-input",
+        },
       ],
     },
   ];

--- a/frontend/src/components/asset/__tests__/DatabaseConfigSection.config.test.ts
+++ b/frontend/src/components/asset/__tests__/DatabaseConfigSection.config.test.ts
@@ -22,6 +22,7 @@ const FULL_MYSQL: DatabaseFormState = {
   readOnly: true,
   params: "charset=utf8mb4",
   path: "",
+  queryTimeoutSeconds: 0,
   connectionType: "jumphost",
   sshTunnelId: 5,
 };
@@ -39,6 +40,7 @@ const FULL_PG: DatabaseFormState = {
   readOnly: false,
   params: "",
   path: "",
+  queryTimeoutSeconds: 0,
 };
 
 const FULL_MSSQL: DatabaseFormState = {
@@ -54,6 +56,7 @@ const FULL_MSSQL: DatabaseFormState = {
   readOnly: false,
   params: "",
   path: "",
+  queryTimeoutSeconds: 0,
 };
 
 const FULL_SQLITE: DatabaseFormState = {
@@ -69,6 +72,7 @@ const FULL_SQLITE: DatabaseFormState = {
   readOnly: true,
   params: "mode=ro",
   path: "/tmp/data.db",
+  queryTimeoutSeconds: 0,
   connectionType: "jumphost",
   sshTunnelId: 9,
 };
@@ -162,9 +166,9 @@ describe("buildDatabaseConfig (键序锁旧 save: driver→[sqlite:path | host/p
     }
   });
 
-  it("最小 mysql 态(host+port+username,空凭据)", () => {
+  it("最小 mysql 态(host+port+username,空凭据,默认查询超时 30)", () => {
     expect(buildDatabaseConfig({ ...DATABASE_DEFAULTS, host: "127.0.0.1", username: "u" }, {})).toBe(
-      '{"driver":"mysql","host":"127.0.0.1","port":3306,"username":"u"}'
+      '{"driver":"mysql","host":"127.0.0.1","port":3306,"username":"u","query_timeout_seconds":30}'
     );
   });
 
@@ -221,6 +225,32 @@ describe("buildDatabaseConfig (键序锁旧 save: driver→[sqlite:path | host/p
   });
 });
 
+describe("queryTimeoutSeconds (查询超时,镜像 Redis commandTimeoutSeconds)", () => {
+  it("默认 30", () => {
+    expect(DATABASE_DEFAULTS.queryTimeoutSeconds).toBe(30);
+  });
+
+  it(">0 时写 query_timeout_seconds(键序: params 后)", () => {
+    const json = buildDatabaseConfig({ ...FULL_MYSQL, params: "", queryTimeoutSeconds: 120 }, {});
+    expect(json).toContain('"read_only":true,"query_timeout_seconds":120}');
+  });
+
+  it("=0 时省略 query_timeout_seconds", () => {
+    const json = buildDatabaseConfig({ ...FULL_MYSQL, queryTimeoutSeconds: 0 }, {});
+    expect(json).not.toContain("query_timeout_seconds");
+  });
+
+  it("回填显式值", () => {
+    expect(parseDatabaseConfig('{"driver":"mysql","host":"h","query_timeout_seconds":90}').queryTimeoutSeconds).toBe(
+      90
+    );
+  });
+
+  it("缺字段回填默认 30(向后兼容旧资产)", () => {
+    expect(parseDatabaseConfig('{"driver":"mysql","host":"h"}').queryTimeoutSeconds).toBe(30);
+  });
+});
+
 describe("parseDatabaseConfig (镜像旧 loadDatabaseConfig 非凭据字段)", () => {
   it("mysql 全字段回填(无凭据)", () => {
     expect(
@@ -241,6 +271,7 @@ describe("parseDatabaseConfig (镜像旧 loadDatabaseConfig 非凭据字段)", (
       readOnly: true,
       params: "charset=utf8mb4",
       path: "",
+      queryTimeoutSeconds: 30,
       connectionType: "jumphost",
       sshTunnelId: 5,
       proxyChainLayers: [sshProxyLayer(5, "SSH Tunnel", "legacy-ssh-5")],
@@ -312,12 +343,12 @@ describe("parseDatabaseConfig (镜像旧 loadDatabaseConfig 非凭据字段)", (
   it("parse→build 往返(mysql 全字段,inline 密文沿用)", () => {
     const original =
       '{"driver":"mysql","host":"db.example.com","port":3306,"username":"root","password":"OLD",' +
-      '"ssh_asset_id":5,"tls":true,"database":"mydb","read_only":true,"params":"charset=utf8mb4"}';
+      '"ssh_asset_id":5,"tls":true,"database":"mydb","read_only":true,"params":"charset=utf8mb4","query_timeout_seconds":45}';
     const expected =
       '{"driver":"mysql","host":"db.example.com","port":3306,"username":"root","password":"OLD",' +
       '"ssh_asset_id":5,"tls":true,' +
       '"proxy_chain":{"layers":[{"id":"legacy-ssh-5","name":"SSH Tunnel","enabled":true,"type":"ssh","order":1,"ssh_asset_id":5}]},' +
-      '"database":"mydb","read_only":true,"params":"charset=utf8mb4"}';
+      '"database":"mydb","read_only":true,"params":"charset=utf8mb4","query_timeout_seconds":45}';
     const state = parseDatabaseConfig(original);
     expect(buildDatabaseConfig(state, { password: "OLD" })).toBe(expected);
   });
@@ -325,13 +356,14 @@ describe("parseDatabaseConfig (镜像旧 loadDatabaseConfig 非凭据字段)", (
   it("parse→build 往返(postgresql ssl_mode)", () => {
     const original =
       '{"driver":"postgresql","host":"pg.example.com","port":5432,"username":"postgres","password":"OLD",' +
-      '"ssl_mode":"require","database":"mydb"}';
+      '"ssl_mode":"require","database":"mydb","query_timeout_seconds":120}';
     const state = parseDatabaseConfig(original);
     expect(buildDatabaseConfig(state, { password: "OLD" })).toBe(original);
   });
 
   it("parse→build 往返(sqlite path)", () => {
-    const original = '{"driver":"sqlite","path":"/tmp/x.db","database":"main","read_only":true}';
+    const original =
+      '{"driver":"sqlite","path":"/tmp/x.db","database":"main","read_only":true,"query_timeout_seconds":300}';
     const state = parseDatabaseConfig(original);
     expect(buildDatabaseConfig(state, {})).toBe(original);
   });
@@ -340,12 +372,12 @@ describe("parseDatabaseConfig (镜像旧 loadDatabaseConfig 非凭据字段)", (
     const original =
       '{"driver":"mysql","host":"db.example.com","port":3306,"username":"root","password":"OLD",' +
       '"proxy":{"type":"socks5","host":"p.example.com","port":1081,"username":"pu","password":"PROXYENC"},' +
-      '"database":"mydb"}';
+      '"database":"mydb","query_timeout_seconds":60}';
     const expected =
       '{"driver":"mysql","host":"db.example.com","port":3306,"username":"root","password":"OLD",' +
       '"proxy":{"type":"socks5","host":"p.example.com","port":1081,"username":"pu","password":"PROXYENC"},' +
       '"proxy_chain":{"layers":[{"id":"legacy-socks5-proxy","name":"SOCKS5 Proxy","enabled":true,"type":"socks5","order":1,"host":"p.example.com","port":1081,"username":"pu","password":"PROXYENC"}]},' +
-      '"database":"mydb"}';
+      '"database":"mydb","query_timeout_seconds":60}';
     const state = parseDatabaseConfig(original);
     expect(buildDatabaseConfig(state, { password: "OLD" }, state.encryptedProxyPassword)).toBe(expected);
   });

--- a/frontend/src/components/asset/__tests__/DatabaseConfigSection.test.tsx
+++ b/frontend/src/components/asset/__tests__/DatabaseConfigSection.test.tsx
@@ -97,7 +97,8 @@ describe("DatabaseConfigSection ref 契约", () => {
 
     const built = await ref.current!.buildConfig(ctx);
     expect(built).toEqual({
-      configJSON: '{"driver":"sqlite","sqlite_source":"remote_ssh_vfs","ssh_asset_id":8,"path":"/tmp/x.db"}',
+      configJSON:
+        '{"driver":"sqlite","sqlite_source":"remote_ssh_vfs","ssh_asset_id":8,"path":"/tmp/x.db","query_timeout_seconds":30}',
       sshTunnelId: 8,
     });
   });
@@ -118,7 +119,7 @@ describe("DatabaseConfigSection ref 契约", () => {
         '{"driver":"postgresql","host":"pg.example.com","port":5432,"username":"postgres","password":"OLD",' +
         '"ssh_asset_id":5,"ssl_mode":"require",' +
         '"proxy_chain":{"layers":[{"id":"legacy-ssh-5","name":"SSH Tunnel","enabled":true,"type":"ssh","order":1,"ssh_asset_id":5}]},' +
-        '"database":"mydb"}',
+        '"database":"mydb","query_timeout_seconds":30}',
       sshTunnelId: 5,
     });
     const tc = await ref.current!.buildTestConfig!(ctx);
@@ -134,7 +135,7 @@ describe("DatabaseConfigSection ref 契约", () => {
     render(<DatabaseConfigSection ref={ref} editAsset={editAsset} ctx={ctx} onValidityChange={() => {}} />);
     const built = await ref.current!.buildConfig(ctx);
     expect(built).toEqual({
-      configJSON: '{"driver":"sqlite","path":"/tmp/x.db","database":"main","read_only":true}',
+      configJSON: '{"driver":"sqlite","path":"/tmp/x.db","database":"main","read_only":true,"query_timeout_seconds":30}',
       sshTunnelId: 0,
     });
   });

--- a/frontend/src/components/asset/configFields.tsx
+++ b/frontend/src/components/asset/configFields.tsx
@@ -34,6 +34,7 @@ export type FieldDesc<S> = WithVisibility<S> &
         label: string;
         placeholder?: string;
         min?: number;
+        max?: number;
         blankWhenZero?: boolean;
         width?: string;
         testid?: string;
@@ -125,11 +126,13 @@ function FieldNode<S>({
             className="[&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
             type="number"
             min={field.min}
+            max={field.max}
             value={display}
             placeholder={field.placeholder ? t(field.placeholder, { defaultValue: field.placeholder }) : undefined}
             onChange={(e) => {
               const n = Number(e.target.value);
-              const next = field.min !== undefined ? Math.max(field.min, n || 0) : n;
+              let next = field.min !== undefined ? Math.max(field.min, n || 0) : n;
+              if (field.max !== undefined) next = Math.min(field.max, next);
               patch({ [field.key]: next } as Partial<S>);
             }}
           />

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -373,6 +373,7 @@
     "sshTunnelNone": "Direct (no tunnel)",
     "params": "Extra Parameters",
     "paramsPlaceholder": "Connection params (optional)",
+    "queryTimeout": "Query Timeout (s)",
     "redisDatabase": "Database Index",
     "redisCommandTimeout": "Command Timeout (s)",
     "redisScanPageSize": "SCAN Page Size",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -373,6 +373,7 @@
     "sshTunnelNone": "直连（无隧道）",
     "params": "额外参数",
     "paramsPlaceholder": "连接参数（可选）",
+    "queryTimeout": "查询超时（秒）",
     "redisDatabase": "数据库索引",
     "redisCommandTimeout": "命令超时（秒）",
     "redisScanPageSize": "SCAN 分页大小",

--- a/internal/app/query/objects.go
+++ b/internal/app/query/objects.go
@@ -26,9 +26,21 @@ func (o objectConn) driverType() asset_entity.DatabaseDriver {
 	return asset_entity.DatabaseDriver(o.driver)
 }
 
+// defaultQueryTimeout 数据库元数据浏览 / SQL 查询在资产未配置 QueryTimeoutSeconds 时的默认超时。
+const defaultQueryTimeout = 30 * time.Second
+
+// queryTimeout 归一化资产的查询超时：配置了正值即用之，否则回退默认值。
+func queryTimeout(cfg *asset_entity.DatabaseConfig) time.Duration {
+	if cfg.QueryTimeoutSeconds > 0 {
+		return time.Duration(cfg.QueryTimeoutSeconds) * time.Second
+	}
+	return defaultQueryTimeout
+}
+
 // withDatabaseConn resolves a database asset, dials (or reuses) a panel
 // connection and runs fn on a fresh *sql.Conn, handling cleanup ordering.
-func (q *Query) withObjectConn(assetID int64, database string, timeout time.Duration, fn func(ctx context.Context, conn objectConn) error) error {
+// 超时取自资产的 QueryTimeoutSeconds（未配置回退 defaultQueryTimeout）。
+func (q *Query) withObjectConn(assetID int64, database string, fn func(ctx context.Context, conn objectConn) error) error {
 	ctx0 := i18n.Ctx(q.ctx, q.lang.Lang())
 	asset, err := asset_svc.Asset().Get(ctx0, assetID)
 	if err != nil {
@@ -49,7 +61,7 @@ func (q *Query) withObjectConn(assetID int64, database string, timeout time.Dura
 		return fmt.Errorf("解析凭据失败: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx0, timeout)
+	ctx, cancel := context.WithTimeout(ctx0, queryTimeout(cfg))
 	defer cancel()
 
 	db, cleanup, err := q.getOrDialPanelDB(ctx, asset, cfg, password)
@@ -70,7 +82,7 @@ func (q *Query) withObjectConn(assetID int64, database string, timeout time.Dura
 // GetTableMetadata returns columns / indexes / foreign keys for a table.
 func (q *Query) GetTableMetadata(assetID int64, database, table string) (*query_svc.TableMetadata, error) {
 	var result *query_svc.TableMetadata
-	err := q.withObjectConn(assetID, database, 15*time.Second, func(ctx context.Context, oc objectConn) error {
+	err := q.withObjectConn(assetID, database, func(ctx context.Context, oc objectConn) error {
 		meta, err := query_svc.GetTableMetadata(ctx, oc.conn, oc.driverType(), oc.database, table)
 		if err != nil {
 			return err
@@ -84,7 +96,7 @@ func (q *Query) GetTableMetadata(assetID int64, database, table string) (*query_
 // ListDatabaseObjects returns views / procedures / functions / triggers.
 func (q *Query) ListDatabaseObjects(assetID int64, database string) (*query_svc.DatabaseObjects, error) {
 	var result *query_svc.DatabaseObjects
-	err := q.withObjectConn(assetID, database, 15*time.Second, func(ctx context.Context, oc objectConn) error {
+	err := q.withObjectConn(assetID, database, func(ctx context.Context, oc objectConn) error {
 		objs, err := query_svc.ListDatabaseObjects(ctx, oc.conn, oc.driverType(), oc.database)
 		if err != nil {
 			return err
@@ -99,7 +111,7 @@ func (q *Query) ListDatabaseObjects(assetID int64, database string) (*query_svc.
 // table is only used for PostgreSQL triggers (see query_svc.ObjectMeta.Table).
 func (q *Query) GetObjectSource(assetID int64, database, objType, name, table string) (string, error) {
 	var result string
-	err := q.withObjectConn(assetID, database, 15*time.Second, func(ctx context.Context, oc objectConn) error {
+	err := q.withObjectConn(assetID, database, func(ctx context.Context, oc objectConn) error {
 		src, err := query_svc.GetObjectSource(ctx, oc.conn, oc.driverType(), oc.database, objType, name, table)
 		if err != nil {
 			return err

--- a/internal/app/query/query_ops.go
+++ b/internal/app/query/query_ops.go
@@ -179,7 +179,7 @@ func (q *Query) ExecuteSQL(assetID int64, sqlText string, database string) (stri
 		return "", fmt.Errorf("解析凭据失败: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(i18n.Ctx(q.ctx, q.lang.Lang()), 30*time.Second)
+	ctx, cancel := context.WithTimeout(i18n.Ctx(q.ctx, q.lang.Lang()), queryTimeout(cfg))
 	defer cancel()
 
 	db, cleanup, err := q.getOrDialPanelDB(ctx, asset, cfg, password)
@@ -265,7 +265,7 @@ func (q *Query) OpenTable(assetID int64, database, table string, pageSize int) (
 		return "", fmt.Errorf("解析凭据失败: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(i18n.Ctx(q.ctx, q.lang.Lang()), 30*time.Second)
+	ctx, cancel := context.WithTimeout(i18n.Ctx(q.ctx, q.lang.Lang()), queryTimeout(cfg))
 	defer cancel()
 
 	db, cleanup, err := q.getOrDialPanelDB(ctx, asset, cfg, password)
@@ -307,7 +307,7 @@ func (q *Query) ExecuteSQLPaged(assetID int64, sqlText string, database string, 
 		return "", fmt.Errorf("解析凭据失败: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(i18n.Ctx(q.ctx, q.lang.Lang()), 30*time.Second)
+	ctx, cancel := context.WithTimeout(i18n.Ctx(q.ctx, q.lang.Lang()), queryTimeout(cfg))
 	defer cancel()
 
 	db, cleanup, err := q.getOrDialPanelDB(ctx, asset, cfg, password)

--- a/internal/app/query/query_ops_test.go
+++ b/internal/app/query/query_ops_test.go
@@ -3,9 +3,25 @@ package query
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/opskat/opskat/internal/model/entity/asset_entity"
 )
+
+func TestQueryTimeout(t *testing.T) {
+	t.Run("configured value wins", func(t *testing.T) {
+		cfg := &asset_entity.DatabaseConfig{QueryTimeoutSeconds: 120}
+		if got := queryTimeout(cfg); got != 120*time.Second {
+			t.Fatalf("queryTimeout() = %v, want %v", got, 120*time.Second)
+		}
+	})
+	t.Run("zero falls back to default", func(t *testing.T) {
+		cfg := &asset_entity.DatabaseConfig{QueryTimeoutSeconds: 0}
+		if got := queryTimeout(cfg); got != defaultQueryTimeout {
+			t.Fatalf("queryTimeout() = %v, want %v", got, defaultQueryTimeout)
+		}
+	})
+}
 
 func TestPanelDBCacheKey(t *testing.T) {
 	t.Run("SQLite reuses one panel connection across schema names", func(t *testing.T) {

--- a/internal/assettype/database.go
+++ b/internal/assettype/database.go
@@ -27,20 +27,22 @@ func (h *databaseHandler) SafeView(a *asset_entity.Asset) map[string]any {
 	}
 	if cfg.Driver == asset_entity.DriverSQLite {
 		return map[string]any{
-			"driver":        string(cfg.Driver),
-			"sqlite_source": cfg.SQLiteSource,
-			"path":          cfg.Path,
-			"database":      cfg.Database,
-			"read_only":     cfg.ReadOnly,
+			"driver":                string(cfg.Driver),
+			"sqlite_source":         cfg.SQLiteSource,
+			"path":                  cfg.Path,
+			"database":              cfg.Database,
+			"read_only":             cfg.ReadOnly,
+			"query_timeout_seconds": cfg.QueryTimeoutSeconds,
 		}
 	}
 	return map[string]any{
-		"host":      cfg.Host,
-		"port":      cfg.Port,
-		"username":  cfg.Username,
-		"driver":    string(cfg.Driver),
-		"database":  cfg.Database,
-		"read_only": cfg.ReadOnly,
+		"host":                  cfg.Host,
+		"port":                  cfg.Port,
+		"username":              cfg.Username,
+		"driver":                string(cfg.Driver),
+		"database":              cfg.Database,
+		"read_only":             cfg.ReadOnly,
+		"query_timeout_seconds": cfg.QueryTimeoutSeconds,
 	}
 }
 
@@ -65,9 +67,10 @@ func (h *databaseHandler) ApplyCreateArgs(_ context.Context, a *asset_entity.Ass
 		return fmt.Errorf("database type requires driver parameter (mysql, postgresql, mssql, sqlite)")
 	}
 	cfg := &asset_entity.DatabaseConfig{
-		Driver:   asset_entity.DatabaseDriver(driver),
-		Database: ArgString(args, "database"),
-		ReadOnly: ArgString(args, "read_only") == "true",
+		Driver:              asset_entity.DatabaseDriver(driver),
+		Database:            ArgString(args, "database"),
+		ReadOnly:            ArgString(args, "read_only") == "true",
+		QueryTimeoutSeconds: ArgInt(args, "query_timeout_seconds"),
 	}
 	if cfg.Driver == asset_entity.DriverSQLite {
 		cfg.Path = ArgString(args, "path")
@@ -104,6 +107,9 @@ func (h *databaseHandler) ApplyUpdateArgs(_ context.Context, a *asset_entity.Ass
 	}
 	if v := ArgString(args, "read_only"); v != "" {
 		cfg.ReadOnly = v == "true"
+	}
+	if v := ArgInt(args, "query_timeout_seconds"); v > 0 {
+		cfg.QueryTimeoutSeconds = v
 	}
 
 	if cfg.Driver == asset_entity.DriverSQLite {

--- a/internal/model/entity/asset_entity/asset.go
+++ b/internal/model/entity/asset_entity/asset.go
@@ -178,22 +178,24 @@ type ProxyChainLayer struct {
 
 // DatabaseConfig 数据库类型的特定配置
 type DatabaseConfig struct {
-	Driver       DatabaseDriver    `json:"driver"`
-	Host         string            `json:"host"`
-	Port         int               `json:"port"`
-	Username     string            `json:"username"`
-	Password     string            `json:"password,omitempty"`      // credential_svc 加密（内联，向后兼容）
-	CredentialID int64             `json:"credential_id,omitempty"` // 统一凭证 ID（密码）
-	Database     string            `json:"database,omitempty"`      // 默认数据库
-	SSLMode      string            `json:"ssl_mode,omitempty"`      // postgresql: disable/require/verify-full
-	TLS          bool              `json:"tls,omitempty"`           // mysql: 启用 TLS 加密连接
-	Params       string            `json:"params,omitempty"`        // 额外连接参数
-	ReadOnly     bool              `json:"read_only,omitempty"`     // 连接级只读
-	SSHAssetID   int64             `json:"ssh_asset_id,omitempty"`  // Deprecated: use Asset.SSHTunnelID
-	SQLiteSource SQLiteSource      `json:"sqlite_source,omitempty"` // SQLite 文件来源: local(默认) / remote_ssh_vfs
-	Path         string            `json:"path,omitempty"`          // SQLite 文件路径;local 为本地绝对路径,remote_ssh_vfs 为远端绝对路径
-	Proxy        *ProxyConfig      `json:"proxy,omitempty"`         // SOCKS5 代理（与 SSH 隧道互斥，隧道优先）
-	ProxyChain   *ProxyChainConfig `json:"proxy_chain,omitempty"`
+	Driver       DatabaseDriver `json:"driver"`
+	Host         string         `json:"host"`
+	Port         int            `json:"port"`
+	Username     string         `json:"username"`
+	Password     string         `json:"password,omitempty"`      // credential_svc 加密（内联，向后兼容）
+	CredentialID int64          `json:"credential_id,omitempty"` // 统一凭证 ID（密码）
+	Database     string         `json:"database,omitempty"`      // 默认数据库
+	SSLMode      string         `json:"ssl_mode,omitempty"`      // postgresql: disable/require/verify-full
+	TLS          bool           `json:"tls,omitempty"`           // mysql: 启用 TLS 加密连接
+	Params       string         `json:"params,omitempty"`        // 额外连接参数
+	ReadOnly     bool           `json:"read_only,omitempty"`     // 连接级只读
+	// QueryTimeoutSeconds 查询超时（秒），0 使用默认值 30s；元数据浏览与 SQL 查询共用。
+	QueryTimeoutSeconds int               `json:"query_timeout_seconds,omitempty"`
+	SSHAssetID          int64             `json:"ssh_asset_id,omitempty"`  // Deprecated: use Asset.SSHTunnelID
+	SQLiteSource        SQLiteSource      `json:"sqlite_source,omitempty"` // SQLite 文件来源: local(默认) / remote_ssh_vfs
+	Path                string            `json:"path,omitempty"`          // SQLite 文件路径;local 为本地绝对路径,remote_ssh_vfs 为远端绝对路径
+	Proxy               *ProxyConfig      `json:"proxy,omitempty"`         // SOCKS5 代理（与 SSH 隧道互斥，隧道优先）
+	ProxyChain          *ProxyChainConfig `json:"proxy_chain,omitempty"`
 }
 
 // RedisConfig Redis类型的特定配置
@@ -925,6 +927,10 @@ func (a *Asset) validateDatabase() error {
 		}
 	default:
 		return fmt.Errorf("不支持的数据库驱动: %s", cfg.Driver)
+	}
+	// 0 表示使用默认值（30s）；显式配置时限定 5~600s。
+	if cfg.QueryTimeoutSeconds != 0 && (cfg.QueryTimeoutSeconds < 5 || cfg.QueryTimeoutSeconds > 600) {
+		return errors.New("数据库查询超时时间无效")
 	}
 	return ValidateProxyChain(EffectiveProxyChain(cfg.ProxyChain, firstNonZero(a.SSHTunnelID, cfg.SSHAssetID), cfg.Proxy))
 }

--- a/internal/model/entity/asset_entity/asset_test.go
+++ b/internal/model/entity/asset_entity/asset_test.go
@@ -480,6 +480,33 @@ func TestValidateDatabaseMSSQL(t *testing.T) {
 	})
 }
 
+func TestValidateDatabaseQueryTimeout(t *testing.T) {
+	newDB := func(timeout int) *Asset {
+		a := &Asset{Type: AssetTypeDatabase, Name: "x", GroupID: 1}
+		cfg := &DatabaseConfig{
+			Driver: DriverMySQL, Host: "localhost", Port: 3306, Username: "root",
+			QueryTimeoutSeconds: timeout,
+		}
+		_ = a.SetDatabaseConfig(cfg)
+		return a
+	}
+	convey.Convey("查询超时校验", t, func() {
+		convey.Convey("0 表示默认值,通过", func() {
+			convey.So(newDB(0).Validate(), convey.ShouldBeNil)
+		})
+		convey.Convey("边界 5 与 600 通过", func() {
+			convey.So(newDB(5).Validate(), convey.ShouldBeNil)
+			convey.So(newDB(600).Validate(), convey.ShouldBeNil)
+		})
+		convey.Convey("低于 5 报错", func() {
+			convey.So(newDB(4).Validate().Error(), convey.ShouldContainSubstring, "查询超时")
+		})
+		convey.Convey("高于 600 报错", func() {
+			convey.So(newDB(601).Validate().Error(), convey.ShouldContainSubstring, "查询超时")
+		})
+	})
+}
+
 func TestValidateDatabaseSQLite(t *testing.T) {
 	convey.Convey("SQLite driver validation", t, func() {
 		convey.Convey("缺 path 应报错", func() {


### PR DESCRIPTION
Closes #257

## 背景

数据库对象浏览（`GetTableMetadata` / `ListDatabaseObjects` / `GetObjectSource`）在 `internal/app/query/objects.go` 硬编码 **15s** 超时；相关 SQL 读路径硬编码 **30s**。大表企业库 / 慢链路下会中途 `context deadline exceeded`，让 OpsKat 对大规模库不可用。

本 PR 为每个数据库资产新增可配置 **Query Timeout（默认 30s，范围 5~600）**，同时管辖元数据浏览与实际 SQL 读。整体复用现有 Redis `commandTimeoutSeconds` / etcd / Kafka 的既有模式——类型结构体加字段、走保存/AI 工具两条写路径、查询时读取；**无迁移**（序列化进现有 `Config` JSON 列，`omitempty` 向后兼容）。

## 改动

**后端**
- `asset.go`：`DatabaseConfig` 新增 `QueryTimeoutSeconds`；`validateDatabase()` 加范围校验（0=默认；否则 5~600，镜像 Kafka）。`Asset.Validate()` 在 create/update 均会跑，前端/AI/opsctl 三条路径统一生效。
- `objects.go`：新增 `queryTimeout(cfg)`（`defaultQueryTimeout = 30s`）；`withObjectConn` 从资产配置推导超时，替换 3 处硬编码 15s。
- `query_ops.go`：`ExecuteSQL` / `ExecuteSQLPaged` / `OpenTable` 也改用 `queryTimeout(cfg)`（原 30s）。批量导入（30min）与 Redis/Mongo（各自独立配置）不动。
- `assettype/database.go`：create/update 参数解析 + `SafeView`（AI 工具 / opsctl 一致）。

**前端**
- `DatabaseConfigSection.config.ts` / `.tsx`：表单态、默认 30、build/parse 往返，高级页新增数字输入（min 5 / max 600，testid `database-query-timeout-input`）。
- `configFields.tsx`：为共享 `kind:"number"` 描述符新增可选 `max` + 钳制（additive，惠及所有数字字段）。
- i18n：en + zh-CN 文案。

## 测试与验证

- 后端：`go build ./...` 通过，`golangci-lint` 0 issues，相关包 `go test` 全绿（含 `TestQueryTimeout`、`TestValidateDatabaseQueryTimeout`）。
- 前端：全量 **2040** 用例通过，ESLint 全绿，`tsc --noEmit` 通过。
- **GUI e2e**（Playwright × 真实 `wails dev`，`e2e/scratch/`）：新建 MySQL 资产 → 高级页默认 30 → 输入钳制 700→600 / 2→5 → 保存后只读 oracle 断言 `config.query_timeout_seconds == 45` → 编辑回填 45。✅ 1 passed。

## 备注

因表单默认 30 且 `>0` 时写入（镜像 Redis），**重新保存**已有数据库资产会显式落盘 `query_timeout_seconds:30`——与旧默认行为等价，仅表现为旧配置在下次编辑时补上该键。