### PR TITLE
⚡️ perf(sftp): 启用并发读写加速文件传输

### DIFF
--- a/internal/pkg/transfer/transfer.go
+++ b/internal/pkg/transfer/transfer.go
@@ -89,52 +89,123 @@ func (r *Reporter) Report(p Progress) {
 	r.emit(p)
 }
 
-// ProgressReader 包裹一个 io.Reader：在 sink 拥有读循环（如 minio PutObject）的流式上传里，
-// 于源 reader 侧观测进度并经 Reporter 节流上报；ctx 取消即中断读取。同一传输的 Read 串行，
-// 内部无需加锁（与 Reporter 约定一致）。
-type ProgressReader struct {
+// Tracker 跟踪一次传输的整体进度。一次传输可能包含多个文件（目录上传/下载），
+// 总文件数与总字节数在扫描阶段一次确定，之后每个文件只需上报"当前文件已传字节"，
+// 累计量由 Tracker 维护 —— 调用方不再需要把 base/total 这类跨文件状态逐层透传，
+// 那正是把"当前文件大小"误当成整次总量的来源。
+//
+// 整次传输共用一个 Reporter，因此速率是整次传输的平均值，不会因为换文件而重置计时起点。
+// 同一传输的上报必须串行（拷贝循环天然满足），内部不加锁。
+type Tracker struct {
+	reporter   *Reporter
+	transferID string
+	filesTotal int
+	bytesTotal int64
+
+	filesDone int
+	bytesDone int64 // 已完成文件的累计字节，不含当前文件
+}
+
+// NewTracker 创建传输跟踪器。filesTotal/bytesTotal 是整次传输的总量。
+func NewTracker(transferID string, filesTotal int, bytesTotal int64, onProgress func(Progress)) *Tracker {
+	return newTracker(transferID, filesTotal, bytesTotal, onProgress, time.Now)
+}
+
+// newTracker 允许注入时钟，便于在测试里确定性地验证节流与测速。
+func newTracker(transferID string, filesTotal int, bytesTotal int64, onProgress func(Progress), now func() time.Time) *Tracker {
+	return &Tracker{
+		reporter:   newReporter(onProgress, now),
+		transferID: transferID,
+		filesTotal: filesTotal,
+		bytesTotal: bytesTotal,
+	}
+}
+
+// FileDone 把一个已传完文件的字节数计入累计量。
+func (t *Tracker) FileDone(size int64) {
+	t.filesDone++
+	t.bytesDone += size
+}
+
+func (t *Tracker) report(currentFile string, currentFileBytes int64) {
+	t.reporter.Report(Progress{
+		TransferID:     t.transferID,
+		Status:         StatusProgress,
+		CurrentFile:    currentFile,
+		FilesCompleted: t.filesDone,
+		FilesTotal:     t.filesTotal,
+		BytesDone:      t.bytesDone + currentFileBytes,
+		BytesTotal:     t.bytesTotal,
+	})
+}
+
+// Reader 包裹当前文件的源 reader：在 sink 拥有读循环（minio PutObject、
+// sftp.File.ReadFrom）的流式上传里，于源侧观测进度；ctx 取消即中断读取。
+// size 是当前文件的大小，经 Size() 暴露给 pkg/sftp 的 ReadFrom 以启用并发写。
+func (t *Tracker) Reader(ctx context.Context, r io.Reader, currentFile string, size int64) *TrackedReader {
+	return &TrackedReader{ctx: ctx, r: r, tracker: t, currentFile: currentFile, size: size}
+}
+
+// Writer 包裹当前文件的目标 writer，用于 source 拥有写循环的流式下载
+// （sftp.File.WriteTo）；ctx 取消即中断写入。
+func (t *Tracker) Writer(ctx context.Context, w io.Writer, currentFile string) *TrackedWriter {
+	return &TrackedWriter{ctx: ctx, w: w, tracker: t, currentFile: currentFile}
+}
+
+// TrackedReader 是 Tracker 包裹出的源 reader。
+type TrackedReader struct {
 	ctx         context.Context
 	r           io.Reader
-	reporter    *Reporter
-	transferID  string
+	tracker     *Tracker
 	currentFile string
-	total       int64
+	size        int64
 	done        int64
 }
 
-// NewProgressReader 构造进度 reader，内部持有独立 Reporter（100ms 节流）。
-func NewProgressReader(ctx context.Context, transferID, currentFile string, r io.Reader, total int64, onProgress func(Progress)) *ProgressReader {
-	return &ProgressReader{
-		ctx:         ctx,
-		r:           r,
-		reporter:    NewReporter(onProgress),
-		transferID:  transferID,
-		currentFile: currentFile,
-		total:       total,
-	}
-}
+// Size 返回当前文件的大小。pkg/sftp 的 ReadFrom 依赖它决定并发写窗口，
+// 返回整次传输总量会让它按错误的长度切分。
+func (r *TrackedReader) Size() int64 { return r.size }
 
-func (p *ProgressReader) Read(b []byte) (int, error) {
-	if err := p.ctx.Err(); err != nil {
+func (r *TrackedReader) Read(b []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
 		return 0, err
 	}
-	n, err := p.r.Read(b)
+	n, err := r.r.Read(b)
 	if n > 0 {
-		p.done += int64(n)
-		p.reporter.Report(Progress{
-			TransferID:  p.transferID,
-			Status:      StatusProgress,
-			CurrentFile: p.currentFile,
-			FilesTotal:  1,
-			BytesDone:   p.done,
-			BytesTotal:  p.total,
-		})
+		r.done += int64(n)
+		r.tracker.report(r.currentFile, r.done)
 	}
 	return n, err
 }
 
+// TrackedWriter 是 Tracker 包裹出的目标 writer。
+type TrackedWriter struct {
+	ctx         context.Context
+	w           io.Writer
+	tracker     *Tracker
+	currentFile string
+	done        int64
+}
+
+func (w *TrackedWriter) Write(b []byte) (int, error) {
+	if err := w.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := w.w.Write(b)
+	if n > 0 {
+		w.done += int64(n)
+		w.tracker.report(w.currentFile, w.done)
+	}
+	return n, err
+}
+
+// NewProgressReader 是单文件传输的快捷方式，等价于一个 filesTotal=1 的 Tracker。
+func NewProgressReader(ctx context.Context, transferID, currentFile string, r io.Reader, total int64, onProgress func(Progress)) *TrackedReader {
+	return NewTracker(transferID, 1, total, onProgress).Reader(ctx, r, currentFile, total)
+}
+
 // Copy 以 32KiB 分片把 src 流式写入 dst,经独立 Reporter(100ms 节流)上报进度,
-// ctx 取消即中断。镜像 sftp_svc.copyWithProgress,让每种传输源共用一套节流拷贝循环。
+// ctx 取消即中断。用于两端都不提供 ReadFrom/WriteTo 的传输源。
 func Copy(ctx context.Context, transferID string, dst io.Writer, src io.Reader, totalBytes int64, currentFile string, onProgress func(Progress)) error {
 	buf := make([]byte, 32*1024)
 	var bytesDone int64

--- a/internal/pkg/transfer/transfer_test.go
+++ b/internal/pkg/transfer/transfer_test.go
@@ -3,6 +3,8 @@ package transfer
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -64,6 +66,102 @@ func TestReporterEmitsTerminalImmediately(t *testing.T) {
 	if len(statuses) != 2 || statuses[0] != "progress" || statuses[1] != "done" {
 		t.Fatalf("want [progress done], got %v", statuses)
 	}
+}
+
+func TestTrackerKeepsTransferTotalAcrossFiles(t *testing.T) {
+	// 3 个 100 字节的文件：无论传到第几个，BytesTotal 都必须是整次传输的 300，
+	// BytesDone 必须单调递增且不越过总量。回归 #272：目录上传曾把"当前文件大小"
+	// 当成 bytesTotal 传下去，导致进度条走到 250%。
+	cur := time.Unix(0, 0)
+	clock := func() time.Time { return cur }
+	var got []Progress
+	tr := newTracker("sftp-1", 3, 300, func(p Progress) { got = append(got, p) }, clock)
+
+	for i := range 3 {
+		r := tr.Reader(context.Background(), bytes.NewReader(bytes.Repeat([]byte("x"), 100)), fmt.Sprintf("f%d.bin", i), 100)
+		for {
+			cur = cur.Add(200 * time.Millisecond) // 越过节流窗口，保证每次读都上报
+			if _, err := r.Read(make([]byte, 50)); err != nil {
+				break
+			}
+		}
+		tr.FileDone(100)
+	}
+
+	require.Len(t, got, 6)
+	var prev int64
+	for _, p := range got {
+		assert.Equal(t, int64(300), p.BytesTotal, "BytesTotal 必须是整次传输总量")
+		assert.Equal(t, 3, p.FilesTotal)
+		assert.GreaterOrEqual(t, p.BytesDone, prev, "BytesDone 必须单调递增")
+		assert.LessOrEqual(t, p.BytesDone, p.BytesTotal, "BytesDone 不得越过总量")
+		prev = p.BytesDone
+	}
+	assert.Equal(t, int64(300), got[len(got)-1].BytesDone)
+	assert.Equal(t, "f2.bin", got[len(got)-1].CurrentFile)
+	assert.Equal(t, 2, got[len(got)-1].FilesCompleted)
+}
+
+func TestTrackerReaderSizeIsCurrentFileNotTransferTotal(t *testing.T) {
+	// Size() 是 pkg/sftp ReadFrom 判断并发窗口的依据，必须是当前文件大小；
+	// 若误报成整次传输总量，ReadFrom 会按错误的长度切分并发写。
+	tr := NewTracker("sftp-1", 3, 300, func(Progress) {})
+	r := tr.Reader(context.Background(), bytes.NewReader(make([]byte, 100)), "f0.bin", 100)
+	assert.Equal(t, int64(100), r.Size())
+}
+
+func TestTrackerSpeedSpansWholeTransfer(t *testing.T) {
+	// 整次传输共用一个 Reporter：换文件不重置计时起点。
+	// 回归 #272：原实现每个文件 new 一个 Reporter，第 N 个文件的首条上报会用
+	// "累计字节 / 刚过去的几毫秒"算出 TB/s 级速率。
+	cur := time.Unix(0, 0)
+	clock := func() time.Time { return cur }
+	var got []Progress
+	tr := newTracker("sftp-1", 2, 1000, func(p Progress) { got = append(got, p) }, clock)
+
+	r0 := tr.Reader(context.Background(), bytes.NewReader(make([]byte, 500)), "a.bin", 500)
+	cur = cur.Add(5 * time.Second)
+	_, err := r0.Read(make([]byte, 500))
+	require.NoError(t, err)
+	tr.FileDone(500)
+
+	// 第二个文件只花 1ms —— 若各文件独立计时，速率会是 500B/0.001s = 500KB/s。
+	r1 := tr.Reader(context.Background(), bytes.NewReader(make([]byte, 500)), "b.bin", 500)
+	cur = cur.Add(5 * time.Second)
+	_, err = r1.Read(make([]byte, 500))
+	require.NoError(t, err)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, int64(100), got[len(got)-1].Speed, "1000 字节 / 10 秒 = 100 B/s")
+}
+
+func TestTrackerWriterReportsAgainstTransferTotal(t *testing.T) {
+	// 下载侧同理：downloadFileAtomic 原先根本没有整次总量这个参数，
+	// 每个文件都把 BytesTotal 算成 "已完成 + 当前文件"，进度条每个文件都跑满 100%。
+	cur := time.Unix(0, 0)
+	clock := func() time.Time { return cur }
+	var got []Progress
+	tr := newTracker("sftp-2", 2, 200, func(p Progress) { got = append(got, p) }, clock)
+
+	tr.FileDone(100) // 第一个文件已完成
+	w := tr.Writer(context.Background(), io.Discard, "b.bin")
+	cur = cur.Add(200 * time.Millisecond)
+	_, err := w.Write(make([]byte, 60))
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(200), got[0].BytesTotal)
+	assert.Equal(t, int64(160), got[0].BytesDone)
+	assert.Equal(t, 1, got[0].FilesCompleted)
+}
+
+func TestTrackerWriterAbortsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	w := NewTracker("sftp-2", 1, 4, func(Progress) {}).Writer(ctx, io.Discard, "b.bin")
+
+	_, err := w.Write([]byte("data"))
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestProgressReaderReportsCumulativeBytes(t *testing.T) {

--- a/internal/service/sftp_svc/file_ops.go
+++ b/internal/service/sftp_svc/file_ops.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 
 	"github.com/pkg/sftp"
+	"go.uber.org/zap"
+
+	"github.com/cago-frame/cago/pkg/logger"
 )
 
 // ClipboardItem describes a remote path captured by the file-manager clipboard.
@@ -145,11 +148,12 @@ func (s *Service) Paste(ctx context.Context, req PasteRequest) error {
 			continue
 		}
 
+		src, dst := sftpCopyClient{client: srcClient}, sftpCopyClient{client: dstClient}
 		if item.IsDir {
-			if err := copyRemoteDir(ctx, srcClient, dstClient, item.Path, dstPath); err != nil {
+			if err := copyRemoteDir(ctx, src, dst, item.Path, dstPath); err != nil {
 				return fmt.Errorf("copy directory %s: %w", item.Path, err)
 			}
-		} else if err := copyRemoteFile(ctx, srcClient, dstClient, item.Path, dstPath); err != nil {
+		} else if err := copyRemoteFile(ctx, src, dst, item.Path, dstPath); err != nil {
 			return fmt.Errorf("copy file %s: %w", item.Path, err)
 		}
 		if req.Mode == "cut" {
@@ -353,14 +357,38 @@ func uniqueRemotePath(client interface {
 	return "", fmt.Errorf("cannot find available copy name for %s", desired)
 }
 
-func copyRemoteFile(ctx context.Context, srcClient, dstClient interface {
-	Open(string) (*sftp.File, error)
-	Create(string) (*sftp.File, error)
+// remoteCopyClient 是 SFTP 粘贴需要的远端操作集合。
+// 用 io.ReadCloser / io.WriteCloser 而不是具体的 *sftp.File，让失败清理路径能被 fake 驱动；
+// io.Copy 仍会在运行时发现底层 *sftp.File 的 WriterTo/ReaderFrom，不损失吞吐。
+type remoteCopyClient interface {
+	Open(string) (io.ReadCloser, error)
+	Create(string) (io.WriteCloser, error)
 	Chmod(string, os.FileMode) error
 	Stat(string) (os.FileInfo, error)
-}, srcPath, dstPath string) error {
+	Remove(string) error
+	ReadDir(string) ([]os.FileInfo, error)
+	MkdirAll(string) error
+}
+
+type sftpCopyClient struct {
+	client *sftp.Client
+}
+
+func (c sftpCopyClient) Open(path string) (io.ReadCloser, error)    { return c.client.Open(path) }
+func (c sftpCopyClient) Create(path string) (io.WriteCloser, error) { return c.client.Create(path) }
+func (c sftpCopyClient) Chmod(path string, mode os.FileMode) error  { return c.client.Chmod(path, mode) }
+func (c sftpCopyClient) Stat(path string) (os.FileInfo, error)      { return c.client.Stat(path) }
+func (c sftpCopyClient) Remove(path string) error                   { return c.client.Remove(path) }
+func (c sftpCopyClient) ReadDir(path string) ([]os.FileInfo, error) { return c.client.ReadDir(path) }
+func (c sftpCopyClient) MkdirAll(path string) error                 { return c.client.MkdirAll(path) }
+
+func copyRemoteFile(ctx context.Context, srcClient, dstClient remoteCopyClient, srcPath, dstPath string) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+	srcInfo, err := srcClient.Stat(srcPath)
+	if err != nil {
+		return err
 	}
 	src, err := srcClient.Open(srcPath)
 	if err != nil {
@@ -371,24 +399,42 @@ func copyRemoteFile(ctx context.Context, srcClient, dstClient interface {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = dst.Close() }()
+
+	// 客户端启用了并发写，出错时目标文件可能比成功写入的部分更长（中间留空洞）。
+	// 粘贴失败必须把半成品删掉：留下一个同名、长度看似正确、内容却有空洞的文件，
+	// 比直接报错危险得多。
+	committed := false
+	defer func() {
+		_ = dst.Close()
+		if !committed {
+			if err := dstClient.Remove(dstPath); err != nil && !os.IsNotExist(err) {
+				logger.Default().Warn("cleanup partial remote copy", zap.String("path", dstPath), zap.Error(err))
+			}
+		}
+	}()
+
 	if _, err := io.Copy(dst, src); err != nil {
 		return err
 	}
-	if info, err := srcClient.Stat(srcPath); err == nil {
-		_ = dstClient.Chmod(dstPath, info.Mode())
+	if err := dst.Close(); err != nil {
+		return err
 	}
+	// 复核落盘字节数：上游 ReadFrom/WriteTo 会吞掉最后一片的写入错误，
+	// 详见 sftp.go 的 verifyRemoteSize。
+	dstInfo, err := dstClient.Stat(dstPath)
+	if err != nil {
+		return err
+	}
+	if dstInfo.Size() != srcInfo.Size() {
+		return fmt.Errorf("复制远程文件大小校验失败：期望 %d 字节，实际写入 %d 字节", srcInfo.Size(), dstInfo.Size())
+	}
+
+	_ = dstClient.Chmod(dstPath, srcInfo.Mode())
+	committed = true
 	return nil
 }
 
-func copyRemoteDir(ctx context.Context, srcClient, dstClient interface {
-	Open(string) (*sftp.File, error)
-	Create(string) (*sftp.File, error)
-	Chmod(string, os.FileMode) error
-	Stat(string) (os.FileInfo, error)
-	ReadDir(string) ([]os.FileInfo, error)
-	MkdirAll(string) error
-}, srcDir, dstDir string) error {
+func copyRemoteDir(ctx context.Context, srcClient, dstClient remoteCopyClient, srcDir, dstDir string) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}

--- a/internal/service/sftp_svc/sftp.go
+++ b/internal/service/sftp_svc/sftp.go
@@ -94,8 +94,7 @@ func (s *Service) getSFTPClient(sessionID string) (*sftp.Client, error) {
 		return nil, fmt.Errorf("SSH 会话已关闭: %s", sessionID)
 	}
 
-	//并发请求 + 并发写
-	client, err := sftp.NewClient(sess.Client(), sftp.UseConcurrentReads(true), sftp.UseConcurrentWrites(true))
+	client, err := sftp.NewClient(sess.Client(), sftpClientOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("创建 SFTP 客户端失败: %w", err)
 	}
@@ -163,15 +162,34 @@ type RemoteFileInfo struct {
 	RealPath string `json:"realPath,omitempty"`
 }
 
+// sftpClientOptions 是所有 SFTP 客户端共用的选项，测试里的进程内客户端也走这一份，
+// 以免"生产开了并发写、测试没开"这种最容易漏掉的差异。
+//
+// UseConcurrentWrites 让 File.ReadFrom 走并发写流水线，在高延迟链路上显著提升上传吞吐。
+// 代价见 pkg/sftp 文档：写入出错时文件长度可能长于成功写入的部分（中间留空洞），
+// 因此每条写入路径都必须在失败时清理或截断目标 —— 这是启用该选项的前置条件，不是可选项。
+//
+// 不显式设置 UseConcurrentReads：pkg/sftp 文档写明它默认即为开启，传 true 是空操作。
+func sftpClientOptions() []sftp.ClientOption {
+	return []sftp.ClientOption{sftp.UseConcurrentWrites(true)}
+}
+
 type remoteAtomicWriter interface {
 	io.Writer
+	io.ReaderFrom
+	Truncate(size int64) error
 	Close() error
 }
 
+// remoteAtomicClient 是"把一个文件安全地换成新内容"所需的远端文件系统操作集合。
+// 上传与远程文件编辑都经由它，因此 PosixRename 不被支持时的回退路径也能用 fake 驱动。
 type remoteAtomicClient interface {
 	OpenFile(path string, f int) (remoteAtomicWriter, error)
 	Stat(path string) (os.FileInfo, error)
+	Lstat(path string) (os.FileInfo, error)
+	ReadLink(path string) (string, error)
 	Chmod(path string, mode os.FileMode) error
+	Chown(path string, uid, gid int) error
 	Remove(path string) error
 	Rename(oldname, newname string) error
 	PosixRename(oldname, newname string) error
@@ -189,8 +207,20 @@ func (c sftpAtomicClient) Stat(path string) (os.FileInfo, error) {
 	return c.client.Stat(path)
 }
 
+func (c sftpAtomicClient) Lstat(path string) (os.FileInfo, error) {
+	return c.client.Lstat(path)
+}
+
+func (c sftpAtomicClient) ReadLink(path string) (string, error) {
+	return c.client.ReadLink(path)
+}
+
 func (c sftpAtomicClient) Chmod(path string, mode os.FileMode) error {
 	return c.client.Chmod(path, mode)
+}
+
+func (c sftpAtomicClient) Chown(path string, uid, gid int) error {
+	return c.client.Chown(path, uid, gid)
 }
 
 func (c sftpAtomicClient) Remove(path string) error {
@@ -359,7 +389,8 @@ func (s *Service) Upload(ctx context.Context, transferID, sessionID, localPath, 
 		return fmt.Errorf("获取文件信息失败: %w", err)
 	}
 
-	return s.uploadFileAtomic(ctx, transferID, sftpClient, localFile, remotePath, stat.Size(), 1, filepath.Base(remotePath), 0, stat.Size(), 0, onProgress)
+	tracker := transfer.NewTracker(transferID, 1, stat.Size(), onProgress)
+	return s.uploadFile(ctx, tracker, sftpAtomicClient{client: sftpClient}, localFile, remotePath, filepath.Base(remotePath), stat.Size())
 }
 
 // Download 下载单个文件（并发读 + 本地原子替换）
@@ -391,7 +422,8 @@ func (s *Service) Download(ctx context.Context, transferID, sessionID, remotePat
 		return fmt.Errorf("获取远程文件信息失败: %w", err)
 	}
 
-	return s.downloadFileAtomic(ctx, transferID, remoteFile, localPath, stat.Size(), 1, filepath.Base(remotePath), 0, 0, onProgress)
+	tracker := transfer.NewTracker(transferID, 1, stat.Size(), onProgress)
+	return s.downloadFile(ctx, tracker, remoteFile, localPath, filepath.Base(remotePath))
 }
 
 // UploadDir 上传目录
@@ -432,8 +464,7 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 	}
 
 	// 传输阶段
-	var filesCompleted int
-	var bytesDone int64
+	tracker := transfer.NewTracker(transferID, filesTotal, bytesTotal, onProgress)
 
 	return filepath.WalkDir(localDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -469,11 +500,10 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 			return err
 		}
 
-		if err := s.uploadFileAtomic(ctx, transferID, sftpClient, localFile, remoteFull, stat.Size(), filesTotal, relPath, bytesDone, stat.Size(), filesCompleted, onProgress); err != nil {
+		if err := s.uploadFile(ctx, tracker, sftpAtomicClient{client: sftpClient}, localFile, remoteFull, relPath, stat.Size()); err != nil {
 			return err
 		}
-		bytesDone += stat.Size()
-		filesCompleted++
+		tracker.FileDone(stat.Size())
 		return nil
 	})
 }
@@ -536,8 +566,7 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 	}
 
 	// 传输阶段
-	var filesCompleted int
-	var bytesDone int64
+	tracker := transfer.NewTracker(transferID, filesTotal, bytesTotal, onProgress)
 
 	for _, entry := range entries {
 		if ctx.Err() != nil {
@@ -555,22 +584,18 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(localFull), 0755); err != nil {
-			return err
-		}
-
 		remoteFile, err := sftpClient.Open(entry.remotePath)
 		if err != nil {
 			return err
 		}
 
-		err = s.downloadFileAtomic(ctx, transferID, remoteFile, localFull, entry.size, filesTotal, relPath, bytesDone, filesCompleted, onProgress)
+		// downloadFile 自己会建父目录，这里不重复。
+		err = s.downloadFile(ctx, tracker, remoteFile, localFull, relPath)
 		_ = remoteFile.Close()
 		if err != nil {
 			return err
 		}
-		bytesDone += entry.size
-		filesCompleted++
+		tracker.FileDone(entry.size)
 	}
 
 	return nil
@@ -630,109 +655,188 @@ func (s *Service) removeDirRecursive(client *sftp.Client, path string) error {
 	return client.RemoveDirectory(path)
 }
 
-// uploadFileAtomic：本地 → 远程临时文件（并发写）→ 原子 rename
-func (s *Service) uploadFileAtomic(ctx context.Context, transferID string, client *sftp.Client, local io.Reader, remotePath string, fileSize int64, filesTotal int, currentFile string, baseBytesDone int64, bytesTotal int64, filesCompleted int, onProgress func(transfer.Progress)) error {
-	targetMode, targetExists, err := statRemoteRegularFile(sftpAtomicClient{client: client}, remotePath)
+// remoteTarget 描述上传目标路径当前的状态，决定用哪条写入路径。
+type remoteTarget struct {
+	path     string      // 解析符号链接之后的真实路径
+	mode     os.FileMode // 完整模式，含类型位
+	exists   bool
+	uid, gid int
+	hasOwner bool
+}
+
+func (t remoteTarget) regular() bool { return t.mode.IsRegular() }
+
+// streamOnly 表示目标是命名管道或套接字。SFTP 的写请求带绝对偏移量，
+// 服务端对这类节点做 pwrite 会返回 illegal seek —— 它们根本无法经 SFTP 写入。
+func (t remoteTarget) streamOnly() bool { return t.mode&(os.ModeNamedPipe|os.ModeSocket) != 0 }
+
+// inspectRemoteTarget 解析目标路径：跟随符号链接找到真正要写的文件，并读出它的权限与属主。
+//
+// 跟随符号链接是必须的 —— 原地覆盖的语义是"写穿到链接指向的文件"，
+// 而 rename 作用在链接本身会把链接替换成普通文件，悄悄破坏 sites-enabled/ 这类布局。
+func inspectRemoteTarget(client remoteAtomicClient, remotePath string) (remoteTarget, error) {
+	const maxSymlinkHops = 8
+	current := remotePath
+	for hop := 0; ; hop++ {
+		info, err := client.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return remoteTarget{path: current}, nil
+			}
+			return remoteTarget{}, fmt.Errorf("获取远程文件信息失败: %w", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			target := remoteTarget{
+				path:   current,
+				exists: true,
+				mode:   info.Mode(),
+			}
+			if stat, ok := info.Sys().(*sftp.FileStat); ok && stat != nil {
+				target.uid, target.gid, target.hasOwner = int(stat.UID), int(stat.GID), true
+			}
+			return target, nil
+		}
+		if hop >= maxSymlinkHops {
+			return remoteTarget{}, fmt.Errorf("远程路径符号链接层级过深: %s", remotePath)
+		}
+		dest, err := client.ReadLink(current)
+		if err != nil {
+			return remoteTarget{}, fmt.Errorf("解析远程符号链接失败: %w", err)
+		}
+		if !path.IsAbs(dest) {
+			dest = path.Join(path.Dir(current), dest)
+		}
+		current = dest
+	}
+}
+
+// uploadFile 把 local 写到 remotePath。默认走"同目录临时文件 + 原子切换"，
+// 让远端只能看到旧版本或完整新版本，不会暴露半写入状态。
+//
+// 两种情况回退到原地写入，因为它们根本无法用 rename 表达：
+// 目标是 FIFO/设备节点等非常规文件（rename 会把节点本身换成普通文件），
+// 以及父目录不可写（建不出临时文件，但目标文件本身仍可写）。
+func (s *Service) uploadFile(ctx context.Context, tracker *transfer.Tracker, client remoteAtomicClient, local io.Reader, remotePath, currentFile string, fileSize int64) error {
+	target, err := inspectRemoteTarget(client, remotePath)
 	if err != nil {
 		return err
 	}
 
-	tempPath := buildRemoteTempPath(remotePath, "part")
-	cleanupTemp := true
+	if target.exists && !target.regular() {
+		if target.streamOnly() {
+			return fmt.Errorf("远程路径是命名管道或套接字，SFTP 按偏移量写入，无法写入该类型: %s", target.path)
+		}
+		return uploadInPlace(ctx, tracker, client, local, target, currentFile, fileSize)
+	}
+
+	tempPath := buildRemoteTempPath(target.path, "part")
+	// O_EXCL：临时名带纳秒时间戳，撞名说明有并发写入，宁可失败也不覆盖
+	remoteFile, err := client.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
+	if err != nil {
+		if os.IsPermission(err) && target.exists {
+			logger.Default().Info("remote dir not writable, uploading in place",
+				zap.String("path", target.path), zap.Error(err))
+			return uploadInPlace(ctx, tracker, client, local, target, currentFile, fileSize)
+		}
+		return fmt.Errorf("创建远程临时文件失败: %w", err)
+	}
+
+	committed := false
 	defer func() {
-		if cleanupTemp {
-			cleanupRemotePath(sftpAtomicClient{client: client}, tempPath)
+		if !committed {
+			cleanupRemotePath(client, tempPath)
 		}
 	}()
 
-	// O_EXCL 避免并发冲突；不直接 TRUNCATE 目标文件
-	remoteFile, err := client.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
-	if err != nil {
-		return fmt.Errorf("创建远程临时文件失败: %w", err)
+	if _, err := remoteFile.ReadFrom(tracker.Reader(ctx, local, currentFile, fileSize)); err != nil {
+		_ = remoteFile.Close()
+		return fmt.Errorf("写入远程临时文件失败: %w", err)
 	}
-	if bytesTotal <= 0 {
-		bytesTotal = baseBytesDone + fileSize
+	if err := remoteFile.Close(); err != nil {
+		return fmt.Errorf("关闭远程临时文件失败: %w", err)
 	}
-
-	pr := &progressReader{
-		ctx:            ctx,
-		r:              local,
-		size:           fileSize,
-		baseBytesDone:  baseBytesDone,
-		bytesTotal:     bytesTotal, // ← 关键
-		transferID:     transferID,
-		currentFile:    currentFile,
-		filesTotal:     filesTotal,
-		filesCompleted: filesCompleted,
-		onProgress:     onProgress,
-		reporter:       transfer.NewReporter(onProgress),
-	}
-
-	written, err := remoteFile.ReadFrom(pr)
-	closeErr := remoteFile.Close()
-	if err != nil {
+	if err := verifyRemoteSize(client, tempPath, fileSize); err != nil {
 		return err
 	}
-	if closeErr != nil {
-		return fmt.Errorf("关闭远程临时文件失败: %w", closeErr)
+
+	if target.exists && target.hasOwner {
+		// rename 后的文件属主是上传者。非 root 无权改回，属于这条路径的固有限制，
+		// 记一条日志让排查有据可依，不当作上传失败。
+		if err := client.Chown(tempPath, target.uid, target.gid); err != nil {
+			logger.Default().Info("preserve remote file owner failed",
+				zap.String("path", target.path), zap.Int("uid", target.uid), zap.Int("gid", target.gid), zap.Error(err))
+		}
 	}
 
-	// 强制最终进度（并发读盘太快时中间回调可能被节流掉）
-	if onProgress != nil {
-		onProgress(transfer.Progress{
-			TransferID:     transferID,
-			Status:         "progress",
-			CurrentFile:    currentFile,
-			FilesCompleted: filesCompleted,
-			FilesTotal:     filesTotal,
-			BytesDone:      baseBytesDone + written,
-			BytesTotal:     bytesTotal,
-		})
+	if err := commitRemoteTempFile(client, tempPath, target.path, target.mode.Perm(), target.exists); err != nil {
+		return err
 	}
-
-	if targetExists {
-		if err := client.Chmod(tempPath, targetMode); err != nil {
-			return fmt.Errorf("同步远程文件权限失败: %w", err)
-		}
-		if err := client.PosixRename(tempPath, remotePath); err == nil {
-			cleanupTemp = false
-			return nil
-		} else if !isSFTPOpUnsupported(err) {
-			return fmt.Errorf("原子替换远程文件失败: %w", err)
-		}
-
-		// 不支持 PosixRename 时回退 backup 路径
-		backupPath := buildRemoteTempPath(remotePath, "bak")
-		if err := client.Rename(remotePath, backupPath); err != nil {
-			return fmt.Errorf("创建远程备份文件失败: %w", err)
-		}
-		if err := client.Rename(tempPath, remotePath); err != nil {
-			_ = client.Rename(backupPath, remotePath)
-			return fmt.Errorf("替换远程文件失败: %w", err)
-		}
-		_ = client.Remove(backupPath)
-		cleanupTemp = false
-		return nil
-	}
-
-	if err := client.Rename(tempPath, remotePath); err != nil {
-		return fmt.Errorf("提交远程临时文件失败: %w", err)
-	}
-	cleanupTemp = false
+	committed = true
 	return nil
 }
 
-// downloadFileAtomic：远程 → 本地临时文件（并发读）→ 原子 rename
-func (s *Service) downloadFileAtomic(ctx context.Context, transferID string, remote *sftp.File, localPath string, fileSize int64, filesTotal int, currentFile string, baseBytesDone int64, filesCompleted int, onProgress func(transfer.Progress)) error {
+// uploadInPlace 直接覆盖目标文件本身，用于无法用 rename 表达的目标。
+// 并发写出错时文件长度可能长于成功写入的部分，按 pkg/sftp 的要求截断回去。
+func uploadInPlace(ctx context.Context, tracker *transfer.Tracker, client remoteAtomicClient, local io.Reader, target remoteTarget, currentFile string, fileSize int64) error {
+	remoteFile, err := client.OpenFile(target.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
+	if err != nil {
+		return fmt.Errorf("打开远程文件失败: %w", err)
+	}
+	written, err := remoteFile.ReadFrom(tracker.Reader(ctx, local, currentFile, fileSize))
+	if err != nil {
+		if truncErr := remoteFile.Truncate(written); truncErr != nil {
+			logger.Default().Warn("truncate remote file after failed write",
+				zap.String("path", target.path), zap.Int64("size", written), zap.Error(truncErr))
+		}
+		_ = remoteFile.Close()
+		return fmt.Errorf("写入远程文件失败: %w", err)
+	}
+	if err := remoteFile.Close(); err != nil {
+		return fmt.Errorf("关闭远程文件失败: %w", err)
+	}
+	if target.exists && !target.regular() {
+		// 设备节点的"大小"没有意义（写 /dev/null 后 Stat 仍是 0），跳过复核。
+		return nil
+	}
+	return verifyRemoteSize(client, target.path, fileSize)
+}
+
+// verifyRemoteSize 复核写入的字节数确实落到了远端。
+//
+// pkg/sftp v1.13.10 的 File.ReadFrom 会在"最后一个分片是短读"时丢掉该分片的写入错误：
+// io.ReadFull 返回 ErrUnexpectedEOF 覆盖了 writeChunkAt 的错误，随后被当成正常 EOF 返回 nil
+// （client.go:2078-2090）。绝大多数文件的最后一片都是短读，因此一次失败的上传会报告成功。
+// 这是上游缺陷，不在这里绕开 ReadFrom，只按大小复核，避免把静默的数据丢失当作上传成功。
+func verifyRemoteSize(client remoteAtomicClient, remotePath string, want int64) error {
+	info, err := client.Stat(remotePath)
+	if err != nil {
+		return fmt.Errorf("校验远程文件失败: %w", err)
+	}
+	if info.Size() != want {
+		return fmt.Errorf("远程文件大小校验失败：期望 %d 字节，实际写入 %d 字节", want, info.Size())
+	}
+	return nil
+}
+
+// downloadFile：远程 → 本地临时文件（并发读）→ 原子 rename。
+func (s *Service) downloadFile(ctx context.Context, tracker *transfer.Tracker, remote io.WriterTo, localPath, currentFile string) error {
 	dir := filepath.Dir(localPath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("创建本地目录失败: %w", err)
 	}
 
-	base := filepath.Base(localPath)
-	tempPath := filepath.Join(dir, fmt.Sprintf(".%s.opskat-part-%d", base, time.Now().UnixNano()))
+	// 覆盖已有文件时沿用它的权限：os.Create 对已存在文件不改权限，
+	// 而"新建临时文件再 rename"会把权限换成新建时的模式 ——
+	// 重新下载一个 0600 的私钥不能把它变成 0644。
+	perm := os.FileMode(0o644)
+	if info, err := os.Stat(localPath); err == nil {
+		perm = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("获取本地文件信息失败: %w", err)
+	}
 
-	localFile, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644) //nolint:gosec
+	tempPath := filepath.Join(dir, fmt.Sprintf(".%s.opskat-part-%d", filepath.Base(localPath), time.Now().UnixNano()))
+	localFile, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm) //nolint:gosec // perm 继承自被覆盖的目标文件
 	if err != nil {
 		return fmt.Errorf("创建本地临时文件失败: %w", err)
 	}
@@ -740,35 +844,14 @@ func (s *Service) downloadFileAtomic(ctx context.Context, transferID string, rem
 	defer func() {
 		_ = localFile.Close()
 		if !committed {
-			_ = os.Remove(tempPath)
+			if err := os.Remove(tempPath); err != nil && !os.IsNotExist(err) {
+				logger.Default().Warn("cleanup local temp file", zap.String("path", tempPath), zap.Error(err))
+			}
 		}
 	}()
 
-	pw := &progressWriter{
-		ctx:            ctx,
-		w:              localFile,
-		transferID:     transferID,
-		currentFile:    currentFile,
-		filesTotal:     filesTotal,
-		filesCompleted: filesCompleted,
-		baseBytesDone:  baseBytesDone,
-		totalBytes:     fileSize + baseBytesDone, // 目录场景下 total 由上层控制；单文件时 base=0
-		fileTotal:      fileSize,
-		onProgress:     onProgress,
-		reporter:       transfer.NewReporter(onProgress),
-	}
-	// 单文件时 BytesTotal 应是 fileSize；目录时上层用 base 累加
-	if baseBytesDone == 0 && filesTotal <= 1 {
-		pw.totalBytes = fileSize
-	}
-
-	// WriteTo 在 UseConcurrentReads 时走并发读流水线
-	_, err = remote.WriteTo(pw)
-	if err != nil {
+	if _, err := remote.WriteTo(tracker.Writer(ctx, localFile, currentFile)); err != nil {
 		return err
-	}
-	if err := localFile.Sync(); err != nil {
-		return fmt.Errorf("同步本地文件失败: %w", err)
 	}
 	if err := localFile.Close(); err != nil {
 		return fmt.Errorf("关闭本地临时文件失败: %w", err)
@@ -781,130 +864,25 @@ func (s *Service) downloadFileAtomic(ctx context.Context, transferID string, rem
 	return nil
 }
 
-// progressReader：包装本地读，提供 Size() 让 ReadFrom 走并发写，并稳定上报进度
-type progressReader struct {
-	ctx            context.Context
-	r              io.Reader
-	size           int64 // 当前文件大小
-	bytesDone      int64
-	baseBytesDone  int64
-	bytesTotal     int64 // 整次传输总字节
-	transferID     string
-	currentFile    string
-	filesTotal     int
-	filesCompleted int
-	onProgress     func(transfer.Progress)
-	reporter       *transfer.Reporter
-	lastReport     time.Time
-}
-
-func (p *progressReader) Size() int64 { return p.size }
-
-func (p *progressReader) Read(b []byte) (int, error) {
-	if err := p.ctx.Err(); err != nil {
-		return 0, err
-	}
-	n, err := p.r.Read(b)
-	if n > 0 {
-		p.bytesDone += int64(n)
-		p.report(false)
-	}
-	if errors.Is(err, io.EOF) {
-		p.report(true) // EOF 强制再报一次
-	}
-	return n, err
-}
-
-func (p *progressReader) report(force bool) {
-	now := time.Now()
-	if !force && now.Sub(p.lastReport) < 50*time.Millisecond {
-		return
-	}
-	p.lastReport = now
-
-	total := p.bytesTotal
-	if total <= 0 {
-		total = p.baseBytesDone + p.size
-	}
-
-	prog := transfer.Progress{
-		TransferID:     p.transferID,
-		Status:         "progress",
-		CurrentFile:    p.currentFile,
-		FilesCompleted: p.filesCompleted,
-		FilesTotal:     p.filesTotal,
-		BytesDone:      p.baseBytesDone + p.bytesDone,
-		BytesTotal:     total,
-	}
-	if p.reporter != nil {
-		p.reporter.Report(prog)
-	} else if p.onProgress != nil {
-		p.onProgress(prog)
-	}
-}
-
-// progressWriter：包装本地写，上报进度
-type progressWriter struct {
-	ctx            context.Context
-	w              io.Writer
-	bytesDone      int64
-	baseBytesDone  int64
-	totalBytes     int64
-	fileTotal      int64
-	transferID     string
-	currentFile    string
-	filesTotal     int
-	filesCompleted int
-	onProgress     func(transfer.Progress)
-	reporter       *transfer.Reporter
-	lastReport     time.Time
-}
-
-func (p *progressWriter) Write(b []byte) (int, error) {
-	if err := p.ctx.Err(); err != nil {
-		return 0, err
-	}
-	n, err := p.w.Write(b)
-	if n > 0 {
-		p.bytesDone += int64(n)
-		now := time.Now()
-		if now.Sub(p.lastReport) >= 100*time.Millisecond || err != nil {
-			total := p.totalBytes
-			if total == 0 {
-				total = p.baseBytesDone + p.fileTotal
-			}
-			p.reporter.Report(transfer.Progress{
-				TransferID:     p.transferID,
-				Status:         "progress",
-				CurrentFile:    p.currentFile,
-				FilesCompleted: p.filesCompleted,
-				FilesTotal:     p.filesTotal,
-				BytesDone:      p.baseBytesDone + p.bytesDone,
-				BytesTotal:     total,
-			})
-			p.lastReport = now
-		}
-	}
-	return n, err
-}
-
 func writeFileAtomically(client remoteAtomicClient, remotePath string, data []byte) error {
 	// 优先写临时文件再切换目标文件名：
 	// 成功时远端始终只会看到“旧版本”或“完整新版本”，不会暴露半写入状态。
-	targetMode, targetExists, err := statRemoteRegularFile(client, remotePath)
+	target, err := inspectRemoteTarget(client, remotePath)
 	if err != nil {
 		return err
 	}
+	if target.exists && !target.regular() {
+		// 目录、管道或其他特殊节点一旦进入原子替换流程，失败恢复和权限继承语义都会变得不可控。
+		return fmt.Errorf("远程路径不是常规文件: %s (mode=%s, perm=%#o, isDir=%t)",
+			target.path, target.mode, target.mode.Perm(), target.mode.IsDir())
+	}
+	remotePath = target.path // 跟随符号链接：写穿到链接指向的文件，而不是把链接换成普通文件
 
 	tempPath := buildRemoteTempPath(remotePath, "tmp")
-	backupPath := ""
-	cleanupTemp := true
+	committed := false
 	defer func() {
-		if cleanupTemp {
+		if !committed {
 			cleanupRemotePath(client, tempPath)
-		}
-		if backupPath != "" {
-			cleanupRemotePath(client, backupPath)
 		}
 	}()
 
@@ -920,59 +898,51 @@ func writeFileAtomically(client remoteAtomicClient, remotePath string, data []by
 		return fmt.Errorf("关闭远程临时文件失败: %w", err)
 	}
 
-	if targetExists {
-		if err := client.Chmod(tempPath, targetMode); err != nil {
-			return fmt.Errorf("同步远程文件权限失败: %w", err)
-		}
-		if err := client.PosixRename(tempPath, remotePath); err == nil {
-			cleanupTemp = false
-			return nil
-		} else if !isSFTPOpUnsupported(err) {
-			return fmt.Errorf("原子替换远程文件失败: %w", err)
-		}
-
-		// 某些 SFTP 服务端不支持 PosixRename。
-		// 这里回退到“先备份旧文件，再切换新文件，再尽力恢复”的兼容路径，把副作用控制在单个目标文件范围内。
-		backupPath = buildRemoteTempPath(remotePath, "bak")
-		if err := client.Rename(remotePath, backupPath); err != nil {
-			return fmt.Errorf("创建远程备份文件失败: %w", err)
-		}
-		if err := client.Rename(tempPath, remotePath); err != nil {
-			restoreErr := client.Rename(backupPath, remotePath)
-			if restoreErr != nil {
-				return fmt.Errorf("替换远程文件失败且恢复原文件失败: %w; restore: %v", err, restoreErr)
-			}
-			return fmt.Errorf("替换远程文件失败，已恢复原文件: %w", err)
-		}
-		if err := client.Remove(backupPath); err != nil && !os.IsNotExist(err) {
-			logger.Default().Warn("cleanup remote backup file", zap.String("path", backupPath), zap.Error(err))
-		}
-		cleanupTemp = false
-		backupPath = ""
-		return nil
+	if err := commitRemoteTempFile(client, tempPath, remotePath, target.mode.Perm(), target.exists); err != nil {
+		return err
 	}
-
-	if err := client.Rename(tempPath, remotePath); err != nil {
-		return fmt.Errorf("提交远程临时文件失败: %w", err)
-	}
-	cleanupTemp = false
+	committed = true
 	return nil
 }
 
-func statRemoteRegularFile(client remoteAtomicClient, remotePath string) (os.FileMode, bool, error) {
-	// 这里只允许覆盖常规文件。
-	// 目录、管道或其他特殊节点一旦进入原子替换流程，失败恢复和权限继承语义都会变得不可控。
-	info, err := client.Stat(remotePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, false, nil
+// commitRemoteTempFile 把写好的临时文件切换成目标文件。返回 nil 表示 tempPath 已经易主，
+// 调用方不应再清理它。
+//
+// 优先 PosixRename（单次原子操作）；服务端不支持时回退到"先备份旧文件，再切换新文件，
+// 再尽力恢复"，把副作用控制在单个目标文件范围内。
+func commitRemoteTempFile(client remoteAtomicClient, tempPath, remotePath string, targetMode os.FileMode, targetExists bool) error {
+	if !targetExists {
+		if err := client.Rename(tempPath, remotePath); err != nil {
+			return fmt.Errorf("提交远程临时文件失败: %w", err)
 		}
-		return 0, false, fmt.Errorf("获取远程文件信息失败: %w", err)
+		return nil
 	}
-	if info.IsDir() || !info.Mode().IsRegular() {
-		return 0, false, fmt.Errorf("远程路径不是常规文件: %s (mode=%s, perm=%#o, isDir=%t)", remotePath, info.Mode(), info.Mode().Perm(), info.IsDir())
+
+	if err := client.Chmod(tempPath, targetMode); err != nil {
+		return fmt.Errorf("同步远程文件权限失败: %w", err)
 	}
-	return info.Mode().Perm(), true, nil
+	if err := client.PosixRename(tempPath, remotePath); err == nil {
+		return nil
+	} else if !isSFTPOpUnsupported(err) {
+		return fmt.Errorf("原子替换远程文件失败: %w", err)
+	}
+
+	backupPath := buildRemoteTempPath(remotePath, "bak")
+	if err := client.Rename(remotePath, backupPath); err != nil {
+		return fmt.Errorf("创建远程备份文件失败: %w", err)
+	}
+
+	if err := client.Rename(tempPath, remotePath); err != nil {
+		if restoreErr := client.Rename(backupPath, remotePath); restoreErr != nil {
+			// 目标路径已经空出来了，原文件只剩备份这一份 —— 绝不能删，
+			// 必须把路径告诉用户，否则这就是一次静默的数据丢失。
+			return fmt.Errorf("替换远程文件失败且恢复原文件失败，原文件保留在 %s: %w; restore: %v", backupPath, err, restoreErr)
+		}
+		return fmt.Errorf("替换远程文件失败，已恢复原文件: %w", err)
+	}
+	// 恢复分支里备份已经改回目标路径，只有切换成功这一条路需要清理备份。
+	cleanupRemotePath(client, backupPath)
+	return nil
 }
 
 func buildRemoteTempPath(remotePath, suffix string) string {

--- a/internal/service/sftp_svc/sftp.go
+++ b/internal/service/sftp_svc/sftp.go
@@ -71,7 +71,7 @@ func (s *Service) GenerateTransferID() string {
 	return transfer.GenerateID("sftp")
 }
 
-// getSFTPClient 获取或创建 SFTP 客户端（懒加载）
+// getSFTPClient 获取或创建 SFTP 客户端（懒加载，高性能配置）
 func (s *Service) getSFTPClient(sessionID string) (*sftp.Client, error) {
 	if v, ok := s.clients.Load(sessionID); ok {
 		client := v.(*sftp.Client)
@@ -94,7 +94,8 @@ func (s *Service) getSFTPClient(sessionID string) (*sftp.Client, error) {
 		return nil, fmt.Errorf("SSH 会话已关闭: %s", sessionID)
 	}
 
-	client, err := sftp.NewClient(sess.Client())
+	//并发请求 + 并发写
+	client, err := sftp.NewClient(sess.Client(), sftp.UseConcurrentReads(true), sftp.UseConcurrentWrites(true))
 	if err != nil {
 		return nil, fmt.Errorf("创建 SFTP 客户端失败: %w", err)
 	}
@@ -329,7 +330,7 @@ func (s *Service) WriteFile(sessionID, remotePath string, data []byte) error {
 	return writeFileAtomically(sftpAtomicClient{client: sftpClient}, remotePath, data)
 }
 
-// Upload 上传单个文件
+// Upload 上传单个文件（并发写 + 远程原子替换）
 func (s *Service) Upload(ctx context.Context, transferID, sessionID, localPath, remotePath string, onProgress func(transfer.Progress)) error {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancels.Store(transferID, cancel)
@@ -358,20 +359,10 @@ func (s *Service) Upload(ctx context.Context, transferID, sessionID, localPath, 
 		return fmt.Errorf("获取文件信息失败: %w", err)
 	}
 
-	remoteFile, err := sftpClient.Create(remotePath)
-	if err != nil {
-		return fmt.Errorf("创建远程文件失败: %w", err)
-	}
-	defer func() {
-		if err := remoteFile.Close(); err != nil {
-			logger.Default().Warn("close remote file", zap.String("path", remotePath), zap.Error(err))
-		}
-	}()
-
-	return s.copyWithProgress(ctx, transferID, remoteFile, localFile, stat.Size(), 1, filepath.Base(remotePath), onProgress)
+	return s.uploadFileAtomic(ctx, transferID, sftpClient, localFile, remotePath, stat.Size(), 1, filepath.Base(remotePath), 0, stat.Size(), 0, onProgress)
 }
 
-// Download 下载单个文件
+// Download 下载单个文件（并发读 + 本地原子替换）
 func (s *Service) Download(ctx context.Context, transferID, sessionID, remotePath, localPath string, onProgress func(transfer.Progress)) error {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancels.Store(transferID, cancel)
@@ -400,17 +391,7 @@ func (s *Service) Download(ctx context.Context, transferID, sessionID, remotePat
 		return fmt.Errorf("获取远程文件信息失败: %w", err)
 	}
 
-	localFile, err := os.Create(localPath) //nolint:gosec // file path from user config
-	if err != nil {
-		return fmt.Errorf("创建本地文件失败: %w", err)
-	}
-	defer func() {
-		if err := localFile.Close(); err != nil {
-			logger.Default().Warn("close local file", zap.String("path", localPath), zap.Error(err))
-		}
-	}()
-
-	return s.copyWithProgress(ctx, transferID, localFile, remoteFile, stat.Size(), 1, filepath.Base(remotePath), onProgress)
+	return s.downloadFileAtomic(ctx, transferID, remoteFile, localPath, stat.Size(), 1, filepath.Base(remotePath), 0, 0, onProgress)
 }
 
 // UploadDir 上传目录
@@ -453,7 +434,6 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 	// 传输阶段
 	var filesCompleted int
 	var bytesDone int64
-	reporter := transfer.NewReporter(onProgress)
 
 	return filepath.WalkDir(localDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -474,8 +454,7 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 			return sftpClient.MkdirAll(remoteFull)
 		}
 
-		// 上传文件
-		localFile, err := os.Open(path) //nolint:gosec // file path from user config
+		localFile, err := os.Open(path) //nolint:gosec
 		if err != nil {
 			return err
 		}
@@ -485,46 +464,15 @@ func (s *Service) UploadDir(ctx context.Context, transferID, sessionID, localDir
 			}
 		}()
 
-		remoteFile, err := sftpClient.Create(remoteFull)
+		stat, err := localFile.Stat()
 		if err != nil {
 			return err
 		}
-		defer func() {
-			if err := remoteFile.Close(); err != nil {
-				logger.Default().Warn("close remote file", zap.String("path", remoteFull), zap.Error(err))
-			}
-		}()
 
-		buf := make([]byte, 32*1024)
-		for {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			n, readErr := localFile.Read(buf)
-			if n > 0 {
-				if _, writeErr := remoteFile.Write(buf[:n]); writeErr != nil {
-					return writeErr
-				}
-				bytesDone += int64(n)
-
-				reporter.Report(transfer.Progress{
-					TransferID:     transferID,
-					Status:         "progress",
-					CurrentFile:    relPath,
-					FilesCompleted: filesCompleted,
-					FilesTotal:     filesTotal,
-					BytesDone:      bytesDone,
-					BytesTotal:     bytesTotal,
-				})
-			}
-			if readErr == io.EOF {
-				break
-			}
-			if readErr != nil {
-				return readErr
-			}
+		if err := s.uploadFileAtomic(ctx, transferID, sftpClient, localFile, remoteFull, stat.Size(), filesTotal, relPath, bytesDone, stat.Size(), filesCompleted, onProgress); err != nil {
+			return err
 		}
-
+		bytesDone += stat.Size()
 		filesCompleted++
 		return nil
 	})
@@ -590,7 +538,6 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 	// 传输阶段
 	var filesCompleted int
 	var bytesDone int64
-	reporter := transfer.NewReporter(onProgress)
 
 	for _, entry := range entries {
 		if ctx.Err() != nil {
@@ -608,74 +555,21 @@ func (s *Service) DownloadDir(ctx context.Context, transferID, sessionID, remote
 			continue
 		}
 
-		// 下载文件
+		if err := os.MkdirAll(filepath.Dir(localFull), 0755); err != nil {
+			return err
+		}
+
 		remoteFile, err := sftpClient.Open(entry.remotePath)
 		if err != nil {
 			return err
 		}
 
-		localFile, err := os.Create(localFull) //nolint:gosec // file path from user config
+		err = s.downloadFileAtomic(ctx, transferID, remoteFile, localFull, entry.size, filesTotal, relPath, bytesDone, filesCompleted, onProgress)
+		_ = remoteFile.Close()
 		if err != nil {
-			if closeErr := remoteFile.Close(); closeErr != nil {
-				logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
-			}
 			return err
 		}
-
-		buf := make([]byte, 32*1024)
-		for {
-			if ctx.Err() != nil {
-				if closeErr := localFile.Close(); closeErr != nil {
-					logger.Default().Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
-				}
-				if closeErr := remoteFile.Close(); closeErr != nil {
-					logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
-				}
-				return ctx.Err()
-			}
-			n, readErr := remoteFile.Read(buf)
-			if n > 0 {
-				if _, writeErr := localFile.Write(buf[:n]); writeErr != nil {
-					if closeErr := localFile.Close(); closeErr != nil {
-						logger.Default().Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
-					}
-					if closeErr := remoteFile.Close(); closeErr != nil {
-						logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
-					}
-					return writeErr
-				}
-				bytesDone += int64(n)
-
-				reporter.Report(transfer.Progress{
-					TransferID:     transferID,
-					Status:         "progress",
-					CurrentFile:    relPath,
-					FilesCompleted: filesCompleted,
-					FilesTotal:     filesTotal,
-					BytesDone:      bytesDone,
-					BytesTotal:     bytesTotal,
-				})
-			}
-			if readErr == io.EOF {
-				break
-			}
-			if readErr != nil {
-				if closeErr := localFile.Close(); closeErr != nil {
-					logger.Default().Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
-				}
-				if closeErr := remoteFile.Close(); closeErr != nil {
-					logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
-				}
-				return readErr
-			}
-		}
-
-		if closeErr := localFile.Close(); closeErr != nil {
-			logger.Default().Warn("close local file", zap.String("path", localFull), zap.Error(closeErr))
-		}
-		if closeErr := remoteFile.Close(); closeErr != nil {
-			logger.Default().Warn("close remote file", zap.String("path", entry.remotePath), zap.Error(closeErr))
-		}
+		bytesDone += entry.size
 		filesCompleted++
 	}
 
@@ -736,40 +630,262 @@ func (s *Service) removeDirRecursive(client *sftp.Client, path string) error {
 	return client.RemoveDirectory(path)
 }
 
-// copyWithProgress 带进度的文件拷贝
-func (s *Service) copyWithProgress(ctx context.Context, transferID string, dst io.Writer, src io.Reader, totalBytes int64, filesTotal int, currentFile string, onProgress func(transfer.Progress)) error {
-	buf := make([]byte, 32*1024)
-	var bytesDone int64
-	reporter := transfer.NewReporter(onProgress)
+// uploadFileAtomic：本地 → 远程临时文件（并发写）→ 原子 rename
+func (s *Service) uploadFileAtomic(ctx context.Context, transferID string, client *sftp.Client, local io.Reader, remotePath string, fileSize int64, filesTotal int, currentFile string, baseBytesDone int64, bytesTotal int64, filesCompleted int, onProgress func(transfer.Progress)) error {
+	targetMode, targetExists, err := statRemoteRegularFile(sftpAtomicClient{client: client}, remotePath)
+	if err != nil {
+		return err
+	}
 
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
+	tempPath := buildRemoteTempPath(remotePath, "part")
+	cleanupTemp := true
+	defer func() {
+		if cleanupTemp {
+			cleanupRemotePath(sftpAtomicClient{client: client}, tempPath)
 		}
+	}()
 
-		n, readErr := src.Read(buf)
-		if n > 0 {
-			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
-				return writeErr
-			}
-			bytesDone += int64(n)
+	// O_EXCL 避免并发冲突；不直接 TRUNCATE 目标文件
+	remoteFile, err := client.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
+	if err != nil {
+		return fmt.Errorf("创建远程临时文件失败: %w", err)
+	}
+	if bytesTotal <= 0 {
+		bytesTotal = baseBytesDone + fileSize
+	}
 
-			reporter.Report(transfer.Progress{
-				TransferID:  transferID,
-				Status:      "progress",
-				CurrentFile: currentFile,
-				FilesTotal:  filesTotal,
-				BytesDone:   bytesDone,
-				BytesTotal:  totalBytes,
-			})
+	pr := &progressReader{
+		ctx:            ctx,
+		r:              local,
+		size:           fileSize,
+		baseBytesDone:  baseBytesDone,
+		bytesTotal:     bytesTotal, // ← 关键
+		transferID:     transferID,
+		currentFile:    currentFile,
+		filesTotal:     filesTotal,
+		filesCompleted: filesCompleted,
+		onProgress:     onProgress,
+		reporter:       transfer.NewReporter(onProgress),
+	}
+
+	written, err := remoteFile.ReadFrom(pr)
+	closeErr := remoteFile.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return fmt.Errorf("关闭远程临时文件失败: %w", closeErr)
+	}
+
+	// 强制最终进度（并发读盘太快时中间回调可能被节流掉）
+	if onProgress != nil {
+		onProgress(transfer.Progress{
+			TransferID:     transferID,
+			Status:         "progress",
+			CurrentFile:    currentFile,
+			FilesCompleted: filesCompleted,
+			FilesTotal:     filesTotal,
+			BytesDone:      baseBytesDone + written,
+			BytesTotal:     bytesTotal,
+		})
+	}
+
+	if targetExists {
+		if err := client.Chmod(tempPath, targetMode); err != nil {
+			return fmt.Errorf("同步远程文件权限失败: %w", err)
 		}
-		if readErr == io.EOF {
+		if err := client.PosixRename(tempPath, remotePath); err == nil {
+			cleanupTemp = false
 			return nil
+		} else if !isSFTPOpUnsupported(err) {
+			return fmt.Errorf("原子替换远程文件失败: %w", err)
 		}
-		if readErr != nil {
-			return readErr
+
+		// 不支持 PosixRename 时回退 backup 路径
+		backupPath := buildRemoteTempPath(remotePath, "bak")
+		if err := client.Rename(remotePath, backupPath); err != nil {
+			return fmt.Errorf("创建远程备份文件失败: %w", err)
+		}
+		if err := client.Rename(tempPath, remotePath); err != nil {
+			_ = client.Rename(backupPath, remotePath)
+			return fmt.Errorf("替换远程文件失败: %w", err)
+		}
+		_ = client.Remove(backupPath)
+		cleanupTemp = false
+		return nil
+	}
+
+	if err := client.Rename(tempPath, remotePath); err != nil {
+		return fmt.Errorf("提交远程临时文件失败: %w", err)
+	}
+	cleanupTemp = false
+	return nil
+}
+
+// downloadFileAtomic：远程 → 本地临时文件（并发读）→ 原子 rename
+func (s *Service) downloadFileAtomic(ctx context.Context, transferID string, remote *sftp.File, localPath string, fileSize int64, filesTotal int, currentFile string, baseBytesDone int64, filesCompleted int, onProgress func(transfer.Progress)) error {
+	dir := filepath.Dir(localPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("创建本地目录失败: %w", err)
+	}
+
+	base := filepath.Base(localPath)
+	tempPath := filepath.Join(dir, fmt.Sprintf(".%s.opskat-part-%d", base, time.Now().UnixNano()))
+
+	localFile, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("创建本地临时文件失败: %w", err)
+	}
+	committed := false
+	defer func() {
+		_ = localFile.Close()
+		if !committed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	pw := &progressWriter{
+		ctx:            ctx,
+		w:              localFile,
+		transferID:     transferID,
+		currentFile:    currentFile,
+		filesTotal:     filesTotal,
+		filesCompleted: filesCompleted,
+		baseBytesDone:  baseBytesDone,
+		totalBytes:     fileSize + baseBytesDone, // 目录场景下 total 由上层控制；单文件时 base=0
+		fileTotal:      fileSize,
+		onProgress:     onProgress,
+		reporter:       transfer.NewReporter(onProgress),
+	}
+	// 单文件时 BytesTotal 应是 fileSize；目录时上层用 base 累加
+	if baseBytesDone == 0 && filesTotal <= 1 {
+		pw.totalBytes = fileSize
+	}
+
+	// WriteTo 在 UseConcurrentReads 时走并发读流水线
+	_, err = remote.WriteTo(pw)
+	if err != nil {
+		return err
+	}
+	if err := localFile.Sync(); err != nil {
+		return fmt.Errorf("同步本地文件失败: %w", err)
+	}
+	if err := localFile.Close(); err != nil {
+		return fmt.Errorf("关闭本地临时文件失败: %w", err)
+	}
+
+	if err := os.Rename(tempPath, localPath); err != nil {
+		return fmt.Errorf("提交本地文件失败: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// progressReader：包装本地读，提供 Size() 让 ReadFrom 走并发写，并稳定上报进度
+type progressReader struct {
+	ctx            context.Context
+	r              io.Reader
+	size           int64 // 当前文件大小
+	bytesDone      int64
+	baseBytesDone  int64
+	bytesTotal     int64 // 整次传输总字节
+	transferID     string
+	currentFile    string
+	filesTotal     int
+	filesCompleted int
+	onProgress     func(transfer.Progress)
+	reporter       *transfer.Reporter
+	lastReport     time.Time
+}
+
+func (p *progressReader) Size() int64 { return p.size }
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	if err := p.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := p.r.Read(b)
+	if n > 0 {
+		p.bytesDone += int64(n)
+		p.report(false)
+	}
+	if errors.Is(err, io.EOF) {
+		p.report(true) // EOF 强制再报一次
+	}
+	return n, err
+}
+
+func (p *progressReader) report(force bool) {
+	now := time.Now()
+	if !force && now.Sub(p.lastReport) < 50*time.Millisecond {
+		return
+	}
+	p.lastReport = now
+
+	total := p.bytesTotal
+	if total <= 0 {
+		total = p.baseBytesDone + p.size
+	}
+
+	prog := transfer.Progress{
+		TransferID:     p.transferID,
+		Status:         "progress",
+		CurrentFile:    p.currentFile,
+		FilesCompleted: p.filesCompleted,
+		FilesTotal:     p.filesTotal,
+		BytesDone:      p.baseBytesDone + p.bytesDone,
+		BytesTotal:     total,
+	}
+	if p.reporter != nil {
+		p.reporter.Report(prog)
+	} else if p.onProgress != nil {
+		p.onProgress(prog)
+	}
+}
+
+// progressWriter：包装本地写，上报进度
+type progressWriter struct {
+	ctx            context.Context
+	w              io.Writer
+	bytesDone      int64
+	baseBytesDone  int64
+	totalBytes     int64
+	fileTotal      int64
+	transferID     string
+	currentFile    string
+	filesTotal     int
+	filesCompleted int
+	onProgress     func(transfer.Progress)
+	reporter       *transfer.Reporter
+	lastReport     time.Time
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	if err := p.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := p.w.Write(b)
+	if n > 0 {
+		p.bytesDone += int64(n)
+		now := time.Now()
+		if now.Sub(p.lastReport) >= 100*time.Millisecond || err != nil {
+			total := p.totalBytes
+			if total == 0 {
+				total = p.baseBytesDone + p.fileTotal
+			}
+			p.reporter.Report(transfer.Progress{
+				TransferID:     p.transferID,
+				Status:         "progress",
+				CurrentFile:    p.currentFile,
+				FilesCompleted: p.filesCompleted,
+				FilesTotal:     p.filesTotal,
+				BytesDone:      p.baseBytesDone + p.bytesDone,
+				BytesTotal:     total,
+			})
+			p.lastReport = now
 		}
 	}
+	return n, err
 }
 
 func writeFileAtomically(client remoteAtomicClient, remotePath string, data []byte) error {

--- a/internal/service/sftp_svc/sftp.go
+++ b/internal/service/sftp_svc/sftp.go
@@ -713,9 +713,10 @@ func inspectRemoteTarget(client remoteAtomicClient, remotePath string) (remoteTa
 // uploadFile 把 local 写到 remotePath。默认走"同目录临时文件 + 原子切换"，
 // 让远端只能看到旧版本或完整新版本，不会暴露半写入状态。
 //
-// 两种情况回退到原地写入，因为它们根本无法用 rename 表达：
-// 目标是 FIFO/设备节点等非常规文件（rename 会把节点本身换成普通文件），
+// 两种情况回退到原地写入，因为它们无法用 rename 表达：
+// 目标是设备节点（rename 会把节点本身换成普通文件），
 // 以及父目录不可写（建不出临时文件，但目标文件本身仍可写）。
+// 命名管道/套接字则直接报错 —— SFTP 协议就写不了它们。
 func (s *Service) uploadFile(ctx context.Context, tracker *transfer.Tracker, client remoteAtomicClient, local io.Reader, remotePath, currentFile string, fileSize int64) error {
 	target, err := inspectRemoteTarget(client, remotePath)
 	if err != nil {
@@ -776,7 +777,7 @@ func (s *Service) uploadFile(ctx context.Context, tracker *transfer.Tracker, cli
 }
 
 // uploadInPlace 直接覆盖目标文件本身，用于无法用 rename 表达的目标。
-// 并发写出错时文件长度可能长于成功写入的部分，按 pkg/sftp 的要求截断回去。
+// 这条路径没有原子性可言 —— 写到一半失败就是写到一半，只能尽量不留下更糟的状态。
 func uploadInPlace(ctx context.Context, tracker *transfer.Tracker, client remoteAtomicClient, local io.Reader, target remoteTarget, currentFile string, fileSize int64) error {
 	remoteFile, err := client.OpenFile(target.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 	if err != nil {
@@ -784,9 +785,14 @@ func uploadInPlace(ctx context.Context, tracker *transfer.Tracker, client remote
 	}
 	written, err := remoteFile.ReadFrom(tracker.Reader(ctx, local, currentFile, fileSize))
 	if err != nil {
-		if truncErr := remoteFile.Truncate(written); truncErr != nil {
-			logger.Default().Warn("truncate remote file after failed write",
-				zap.String("path", target.path), zap.Int64("size", written), zap.Error(truncErr))
+		// 并发写出错时文件长度可能长于成功写入的部分，截回读到的长度至少能去掉尾部垃圾。
+		// 这不保证内容完整（中间仍可能有空洞），所以错误照样往上抛。
+		// 设备节点不做截断：ftruncate 对它们没有意义。
+		if target.regular() {
+			if truncErr := remoteFile.Truncate(written); truncErr != nil {
+				logger.Default().Warn("truncate remote file after failed write",
+					zap.String("path", target.path), zap.Int64("size", written), zap.Error(truncErr))
+			}
 		}
 		_ = remoteFile.Close()
 		return fmt.Errorf("写入远程文件失败: %w", err)
@@ -794,7 +800,7 @@ func uploadInPlace(ctx context.Context, tracker *transfer.Tracker, client remote
 	if err := remoteFile.Close(); err != nil {
 		return fmt.Errorf("关闭远程文件失败: %w", err)
 	}
-	if target.exists && !target.regular() {
+	if !target.regular() {
 		// 设备节点的"大小"没有意义（写 /dev/null 后 Stat 仍是 0），跳过复核。
 		return nil
 	}

--- a/internal/service/sftp_svc/transfer_test.go
+++ b/internal/service/sftp_svc/transfer_test.go
@@ -1,0 +1,450 @@
+package sftp_svc
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/opskat/opskat/internal/pkg/transfer"
+	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestService 起一个进程内的真实 SFTP 服务端（根目录为临时目录），返回服务、
+// 会话 ID 和根目录。用真服务端而不是手写 fake，是因为这些用例要验证的正是
+// 权限继承、符号链接、rename 语义这些只有真实文件系统才说得清的行为。
+func newTestService(t *testing.T) (*Service, string, string) {
+	t.Helper()
+	root := t.TempDir()
+
+	clientConn, serverConn := net.Pipe()
+	server, err := sftp.NewServer(serverConn, sftp.WithServerWorkingDirectory(root))
+	require.NoError(t, err)
+	serverDone := make(chan error, 1)
+	go func() { serverDone <- server.Serve() }()
+
+	client, err := sftp.NewClientPipe(clientConn, clientConn, sftpClientOptions()...)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+		<-serverDone
+	})
+
+	service := NewService(nil)
+	service.clients.Store("session", client)
+	return service, "session", root
+}
+
+// discardProgress 供不关心进度的用例使用。onProgress 是必填的：生产端
+// （internal/app/ssh/sftp.go）总会传一个真实回调，服务层不为它加 nil 兜底。
+func discardProgress(transfer.Progress) {}
+
+// collectProgress 收集进度事件，供断言整次传输的进度不变量。
+func collectProgress() (func(transfer.Progress), *[]transfer.Progress) {
+	var got []transfer.Progress
+	return func(p transfer.Progress) { got = append(got, p) }, &got
+}
+
+// assertProgressInvariants 断言一次传输的进度事件满足：BytesTotal 恒为整次总量、
+// BytesDone 单调递增且不越过总量。
+func assertProgressInvariants(t *testing.T, events []transfer.Progress, wantTotal int64) {
+	t.Helper()
+	require.NotEmpty(t, events, "至少要有一条进度事件")
+	var prev int64
+	for i, p := range events {
+		assert.Equal(t, wantTotal, p.BytesTotal, "第 %d 条：BytesTotal 必须是整次传输总量", i)
+		assert.GreaterOrEqual(t, p.BytesDone, prev, "第 %d 条：BytesDone 必须单调递增", i)
+		assert.LessOrEqual(t, p.BytesDone, p.BytesTotal, "第 %d 条：BytesDone 不得越过总量", i)
+		prev = p.BytesDone
+	}
+}
+
+func TestUploadPreservesExistingFilePermissions(t *testing.T) {
+	service, session, root := newTestService(t)
+	local := filepath.Join(t.TempDir(), "id_rsa")
+	require.NoError(t, os.WriteFile(local, []byte("new-key"), 0o600))
+
+	remote := filepath.Join(root, "id_rsa")
+	require.NoError(t, os.WriteFile(remote, []byte("old-key"), 0o600))
+
+	require.NoError(t, service.Upload(context.Background(), "t1", session, local, remote, discardProgress))
+
+	info, err := os.Stat(remote)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "覆盖上传不得放宽已有文件的权限")
+	content, err := os.ReadFile(remote) //nolint:gosec // 测试内的临时目录路径
+	require.NoError(t, err)
+	assert.Equal(t, "new-key", string(content))
+}
+
+func TestUploadWritesThroughSymlinkInsteadOfReplacingIt(t *testing.T) {
+	// 原地覆盖的语义是"写穿到链接指向的文件"。若原子替换作用在链接本身，
+	// 链接会被换成普通文件 —— sites-enabled/default 这类布局会被悄悄破坏。
+	service, session, root := newTestService(t)
+	local := filepath.Join(t.TempDir(), "site.conf")
+	require.NoError(t, os.WriteFile(local, []byte("server {}"), 0o644))
+
+	target := filepath.Join(root, "sites-available")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o644))
+	link := filepath.Join(root, "sites-enabled")
+	require.NoError(t, os.Symlink("sites-available", link))
+
+	require.NoError(t, service.Upload(context.Background(), "t1", session, local, link, discardProgress))
+
+	info, err := os.Lstat(link)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "符号链接必须仍然是符号链接")
+	content, err := os.ReadFile(target) //nolint:gosec // 测试内的临时目录路径
+	require.NoError(t, err)
+	assert.Equal(t, "server {}", string(content), "内容应写穿到链接指向的文件")
+}
+
+func TestWriteFileWritesThroughSymlinkInsteadOfReplacingIt(t *testing.T) {
+	// 外部编辑回写走的是同一套原子替换。编辑一个软链过去的配置文件时，
+	// 保存不能把软链本身换成普通文件。
+	service, session, root := newTestService(t)
+	target := filepath.Join(root, "app.conf")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o640))
+	link := filepath.Join(root, "current.conf")
+	require.NoError(t, os.Symlink("app.conf", link))
+
+	require.NoError(t, service.WriteFile(session, link, []byte("edited")))
+
+	info, err := os.Lstat(link)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "符号链接必须仍然是符号链接")
+	content, err := os.ReadFile(target) //nolint:gosec // 测试内的临时目录路径
+	require.NoError(t, err)
+	assert.Equal(t, "edited", string(content))
+
+	targetInfo, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), targetInfo.Mode().Perm(), "回写不得改变被编辑文件的权限")
+}
+
+func TestUploadRejectsNamedPipeTargetInsteadOfReplacingIt(t *testing.T) {
+	// SFTP 的写请求带绝对偏移量，服务端对管道做 pwrite 会返回 illegal seek ——
+	// 命名管道根本无法经 SFTP 写入。必须明确报错：既不能把管道 rename 成普通文件，
+	// 也不能因为上游 ReadFrom 吞掉写错误而静默报告成功。
+	service, session, root := newTestService(t)
+	local := filepath.Join(t.TempDir(), "payload")
+	require.NoError(t, os.WriteFile(local, []byte("hello"), 0o644))
+
+	fifo := filepath.Join(root, "pipe")
+	require.NoError(t, syscall.Mkfifo(fifo, 0o600))
+
+	err := service.Upload(context.Background(), "t1", session, local, fifo, discardProgress)
+
+	require.Error(t, err, "SFTP 无法写入命名管道，不能报告成功")
+	assert.Contains(t, err.Error(), "命名管道")
+	info, err := os.Lstat(fifo)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeNamedPipe, "命名管道必须原样保留，不能被换成普通文件")
+}
+
+// shortWriteClient 模拟"ReadFrom 报告写完了，实际落盘字节数不足"的服务端 ——
+// 即上游 ReadFrom 吞掉最后一片写入错误时，普通文件上会呈现的样子。
+type shortWriteClient struct {
+	remoteAtomicClient
+	actualSize int64
+	renamed    bool
+}
+
+type nopWriter struct{}
+
+func (w nopWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w nopWriter) ReadFrom(r io.Reader) (int64, error) {
+	n, _ := io.Copy(io.Discard, r)
+	return n, nil // 谎称全部写入成功
+}
+func (w nopWriter) Truncate(int64) error { return nil }
+func (w nopWriter) Close() error         { return nil }
+
+func (c *shortWriteClient) OpenFile(string, int) (remoteAtomicWriter, error) {
+	return nopWriter{}, nil
+}
+func (c *shortWriteClient) Lstat(string) (os.FileInfo, error) {
+	return nil, os.ErrNotExist // 目标不存在，走"新建 + rename"路径
+}
+func (c *shortWriteClient) Stat(string) (os.FileInfo, error) {
+	return shortFileInfo{size: c.actualSize}, nil
+}
+func (c *shortWriteClient) Rename(string, string) error { c.renamed = true; return nil }
+func (c *shortWriteClient) Remove(string) error         { return nil }
+
+type shortFileInfo struct {
+	os.FileInfo
+	size int64
+}
+
+func (i shortFileInfo) Size() int64       { return i.size }
+func (i shortFileInfo) Mode() os.FileMode { return 0o644 }
+func (i shortFileInfo) IsDir() bool       { return false }
+func (i shortFileInfo) Sys() any          { return nil }
+
+func TestUploadFailsWhenRemoteSizeDoesNotMatch(t *testing.T) {
+	client := &shortWriteClient{actualSize: 3}
+	tracker := transfer.NewTracker("t1", 1, 5, discardProgress)
+	svc := NewService(nil)
+
+	err := svc.uploadFile(context.Background(), tracker, client,
+		bytes.NewReader([]byte("hello")), "/srv/app.conf", "app.conf", 5)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "大小校验失败")
+	assert.False(t, client.renamed, "字节没写全时不得把临时文件切换成目标文件")
+}
+
+// failingCopyClient 在写到第 failAfter 个字节后让写入失败，模拟并发写中途出错。
+type failingCopyClient struct {
+	remoteCopyClient
+	files     map[string][]byte
+	failAfter int
+	removed   []string
+}
+
+type failingWriter struct {
+	client *failingCopyClient
+	path   string
+	limit  int
+}
+
+func (w *failingWriter) Write(b []byte) (int, error) {
+	cur := w.client.files[w.path]
+	room := w.limit - len(cur)
+	if room <= 0 {
+		return 0, errors.New("disk quota exceeded")
+	}
+	if len(b) > room {
+		w.client.files[w.path] = append(cur, b[:room]...)
+		return room, errors.New("disk quota exceeded")
+	}
+	w.client.files[w.path] = append(cur, b...)
+	return len(b), nil
+}
+
+func (w *failingWriter) Close() error { return nil }
+
+func (c *failingCopyClient) Open(p string) (io.ReadCloser, error) {
+	body, ok := c.files[p]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return io.NopCloser(bytes.NewReader(body)), nil
+}
+
+func (c *failingCopyClient) Create(p string) (io.WriteCloser, error) {
+	c.files[p] = nil
+	return &failingWriter{client: c, path: p, limit: c.failAfter}, nil
+}
+
+func (c *failingCopyClient) Stat(p string) (os.FileInfo, error) {
+	body, ok := c.files[p]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return shortFileInfo{size: int64(len(body))}, nil
+}
+
+func (c *failingCopyClient) Remove(p string) error {
+	c.removed = append(c.removed, p)
+	delete(c.files, p)
+	return nil
+}
+
+func (c *failingCopyClient) Chmod(string, os.FileMode) error { return nil }
+
+func TestCopyRemoteFileRemovesPartialDestinationOnFailure(t *testing.T) {
+	// 客户端开了并发写后，中途失败会在目标文件里留下空洞且长度看似正常。
+	// 粘贴失败必须把半成品删掉 —— 留一个同名、看起来完整实则损坏的文件最危险。
+	client := &failingCopyClient{
+		files:     map[string][]byte{"/src/app.bin": bytes.Repeat([]byte("x"), 4096)},
+		failAfter: 1024,
+	}
+
+	err := copyRemoteFile(context.Background(), client, client, "/src/app.bin", "/dst/app.bin")
+
+	require.Error(t, err)
+	assert.Contains(t, client.removed, "/dst/app.bin", "失败的粘贴不得留下半成品")
+	assert.NotContains(t, client.files, "/dst/app.bin")
+}
+
+func TestUploadFallsBackToInPlaceWhenDirectoryNotWritable(t *testing.T) {
+	// 只有文件写权限、没有父目录写权限时建不了临时文件。
+	// 旧实现直接打开目标文件就能写，这里必须退回该路径而不是硬失败。
+	if os.Geteuid() == 0 {
+		t.Skip("root 绕过目录权限检查，该用例无法复现")
+	}
+	service, session, root := newTestService(t)
+	local := filepath.Join(t.TempDir(), "nginx.conf")
+	require.NoError(t, os.WriteFile(local, []byte("worker_processes 4;"), 0o644))
+
+	dir := filepath.Join(root, "nginx")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	remote := filepath.Join(dir, "nginx.conf")
+	require.NoError(t, os.WriteFile(remote, []byte("worker_processes 1;"), 0o644))
+	require.NoError(t, os.Chmod(dir, 0o555)) // 目录不可写，文件仍可写
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	require.NoError(t, service.Upload(context.Background(), "t1", session, local, remote, discardProgress))
+
+	content, err := os.ReadFile(remote) //nolint:gosec // 测试内的临时目录路径
+	require.NoError(t, err)
+	assert.Equal(t, "worker_processes 4;", string(content))
+}
+
+func TestUploadDirProgressNeverExceedsTotal(t *testing.T) {
+	// 回归 #272：UploadDir 曾把当前文件大小当作 bytesTotal 传下去，
+	// 传到第 3 个文件时前端会渲染出 250%。
+	service, session, root := newTestService(t)
+	localDir := filepath.Join(t.TempDir(), "src")
+	require.NoError(t, os.Mkdir(localDir, 0o755))
+	const files, size = 3, 40 * 1024
+	for i := range files {
+		body := make([]byte, size)
+		require.NoError(t, os.WriteFile(filepath.Join(localDir, fmt.Sprintf("f%d.bin", i)), body, 0o644))
+	}
+
+	onProgress, got := collectProgress()
+	require.NoError(t, service.UploadDir(context.Background(), "t1", session, localDir, filepath.Join(root, "dst"), onProgress))
+
+	assertProgressInvariants(t, *got, files*size)
+	for i := range files {
+		info, err := os.Stat(filepath.Join(root, "dst", fmt.Sprintf("f%d.bin", i)))
+		require.NoError(t, err)
+		assert.Equal(t, int64(size), info.Size())
+	}
+}
+
+func TestDownloadDirProgressNeverRestartsPerFile(t *testing.T) {
+	// 回归 #272：downloadFileAtomic 没有整次总量这个参数，每个文件都把
+	// BytesTotal 算成"已完成 + 当前文件"，进度条每传完一个文件就跑满一次 100%。
+	service, session, root := newTestService(t)
+	remoteDir := filepath.Join(root, "remote")
+	require.NoError(t, os.Mkdir(remoteDir, 0o755))
+	const files, size = 3, 40 * 1024
+	for i := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(remoteDir, fmt.Sprintf("f%d.bin", i)), make([]byte, size), 0o644))
+	}
+	localDir := filepath.Join(t.TempDir(), "dst")
+
+	onProgress, got := collectProgress()
+	require.NoError(t, service.DownloadDir(context.Background(), "t1", session, remoteDir, localDir, onProgress))
+
+	assertProgressInvariants(t, *got, files*size)
+	for i := range files {
+		info, err := os.Stat(filepath.Join(localDir, fmt.Sprintf("f%d.bin", i)))
+		require.NoError(t, err)
+		assert.Equal(t, int64(size), info.Size())
+	}
+}
+
+func TestDownloadPreservesExistingLocalPermissions(t *testing.T) {
+	// 临时文件硬编码 0644 再 rename 覆盖，会把本地 0600 的私钥放宽成世界可读。
+	service, session, root := newTestService(t)
+	remote := filepath.Join(root, "id_rsa")
+	require.NoError(t, os.WriteFile(remote, []byte("remote-key"), 0o600))
+	local := filepath.Join(t.TempDir(), "id_rsa")
+	require.NoError(t, os.WriteFile(local, []byte("old"), 0o600))
+
+	require.NoError(t, service.Download(context.Background(), "t1", session, remote, local, discardProgress))
+
+	info, err := os.Stat(local)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "覆盖下载不得放宽已有文件的权限")
+	content, err := os.ReadFile(local) //nolint:gosec // 测试内的临时目录路径
+	require.NoError(t, err)
+	assert.Equal(t, "remote-key", string(content))
+}
+
+func TestDownloadLeavesNoTempFileBehindOnCancel(t *testing.T) {
+	service, session, root := newTestService(t)
+	remote := filepath.Join(root, "big.bin")
+	require.NoError(t, os.WriteFile(remote, make([]byte, 256*1024), 0o644))
+	localDir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := service.Download(ctx, "t1", session, remote, filepath.Join(localDir, "big.bin"), discardProgress)
+	require.Error(t, err)
+
+	entries, err := os.ReadDir(localDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "取消后不得留下 .opskat-part-* 临时文件")
+}
+
+// --- 不支持 PosixRename 的服务端：进程内服务端支持该扩展，只能用 fake 驱动回退路径 ---
+
+// noPosixRenameClient 模拟不支持 posix-rename@openssh.com 的服务端。
+// renameErrs 按 Rename 调用次序注入错误：第 1 次是备份（目标 → .bak），
+// 第 2 次是切换（.part → 目标），第 3 次是恢复（.bak → 目标）。
+type noPosixRenameClient struct {
+	remoteAtomicClient
+	renameErrs []error
+	renames    [][2]string
+	removed    []string
+}
+
+func (c *noPosixRenameClient) PosixRename(string, string) error {
+	return &sftp.StatusError{Code: uint32(sftp.ErrSSHFxOpUnsupported)}
+}
+
+func (c *noPosixRenameClient) Rename(oldname, newname string) error {
+	c.renames = append(c.renames, [2]string{oldname, newname})
+	if len(c.renames) <= len(c.renameErrs) {
+		return c.renameErrs[len(c.renames)-1]
+	}
+	return nil
+}
+
+func (c *noPosixRenameClient) Remove(p string) error {
+	c.removed = append(c.removed, p)
+	return nil
+}
+
+func (c *noPosixRenameClient) Chmod(string, os.FileMode) error { return nil }
+
+func TestCommitRemoteTempFileReportsRestoreFailureAndCleansBackup(t *testing.T) {
+	// PosixRename 不被支持 → 走"备份 → 切换 → 尽力恢复"。
+	// 若切换和恢复都失败，目标路径已经没了，必须把恢复失败也报出来，
+	// 并清理掉那个用户无从得知的 .opskat-bak-* 文件。
+	swapErr := errors.New("quota exceeded")
+	restoreErr := errors.New("read-only file system")
+	client := &noPosixRenameClient{renameErrs: []error{nil, swapErr, restoreErr}}
+
+	err := commitRemoteTempFile(client, "/etc/.app.conf.opskat-part-1", "/etc/app.conf", 0o644, true)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, swapErr)
+	assert.Contains(t, err.Error(), "恢复原文件失败", "恢复失败必须让用户看见")
+	assert.Contains(t, err.Error(), restoreErr.Error())
+
+	require.Len(t, client.renames, 3)
+	backupPath := client.renames[0][1]
+	assert.NotContains(t, client.removed, backupPath, "恢复失败时备份是原文件仅存的一份，删掉就是静默的数据丢失")
+	assert.Contains(t, err.Error(), backupPath, "必须把备份路径告诉用户，否则原文件停在无从得知的隐藏名字下")
+}
+
+func TestCommitRemoteTempFileRestoresOriginalOnSwapFailure(t *testing.T) {
+	swapErr := errors.New("quota exceeded")
+	client := &noPosixRenameClient{renameErrs: []error{nil, swapErr, nil}}
+
+	err := commitRemoteTempFile(client, "/etc/.app.conf.opskat-part-1", "/etc/app.conf", 0o644, true)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, swapErr)
+	assert.Contains(t, err.Error(), "已恢复原文件")
+
+	require.Len(t, client.renames, 3)
+	backupPath := client.renames[0][1]
+	assert.Equal(t, [2]string{backupPath, "/etc/app.conf"}, client.renames[2], "第三次 rename 必须是把备份恢复回目标路径")
+}

--- a/internal/service/sftp_svc/transfer_test.go
+++ b/internal/service/sftp_svc/transfer_test.go
@@ -3,6 +3,8 @@ package sftp_svc
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -84,6 +86,66 @@ func TestUploadPreservesExistingFilePermissions(t *testing.T) {
 	content, err := os.ReadFile(remote) //nolint:gosec // 测试内的临时目录路径
 	require.NoError(t, err)
 	assert.Equal(t, "new-key", string(content))
+}
+
+func TestUploadDownloadPreserveContentAcrossPacketBoundaries(t *testing.T) {
+	// 并发写按 maxPacket（默认 32KiB）切片、按偏移量派发，出错时可能留下空洞。
+	// 空洞读回来是零字节且文件长度不变，所以只比长度发现不了 —— 必须比内容，
+	// 且内容必须是随机的：全零数据会把空洞完全掩盖。
+	const maxPacket = 32 << 10
+	sizes := []int{0, 1, 4095, maxPacket - 1, maxPacket, maxPacket + 1, 2 * maxPacket, 3*maxPacket - 7, 1 << 20}
+
+	service, session, root := newTestService(t)
+	localRoot := t.TempDir()
+
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("%d字节", size), func(t *testing.T) {
+			body := make([]byte, size)
+			_, err := rand.Read(body)
+			require.NoError(t, err)
+
+			local := filepath.Join(localRoot, fmt.Sprintf("up-%d.bin", size))
+			require.NoError(t, os.WriteFile(local, body, 0o644))
+			remote := filepath.Join(root, fmt.Sprintf("up-%d.bin", size))
+			require.NoError(t, service.Upload(context.Background(), "c1", session, local, remote, discardProgress))
+
+			uploaded, err := os.ReadFile(remote) //nolint:gosec // 测试内的临时目录路径
+			require.NoError(t, err)
+			assert.Equal(t, md5.Sum(body), md5.Sum(uploaded), "%d 字节上传后内容不一致", size)
+
+			back := filepath.Join(localRoot, fmt.Sprintf("back-%d.bin", size))
+			require.NoError(t, service.Download(context.Background(), "c2", session, remote, back, discardProgress))
+			downloaded, err := os.ReadFile(back) //nolint:gosec // 测试内的临时目录路径
+			require.NoError(t, err)
+			assert.Equal(t, md5.Sum(body), md5.Sum(downloaded), "%d 字节下载后内容不一致", size)
+		})
+	}
+}
+
+func TestUploadOverwriteLeavesNoTrailingOldData(t *testing.T) {
+	// 用更短的内容覆盖：若替换没生效，尾部会残留旧数据而长度看着也"合理"。
+	service, session, root := newTestService(t)
+	localRoot := t.TempDir()
+	remote := filepath.Join(root, "overwrite.bin")
+
+	big := make([]byte, 3<<20)
+	_, err := rand.Read(big)
+	require.NoError(t, err)
+	localBig := filepath.Join(localRoot, "big.bin")
+	require.NoError(t, os.WriteFile(localBig, big, 0o644))
+	require.NoError(t, service.Upload(context.Background(), "o1", session, localBig, remote, discardProgress))
+
+	small := make([]byte, 1000)
+	_, err = rand.Read(small)
+	require.NoError(t, err)
+	localSmall := filepath.Join(localRoot, "small.bin")
+	require.NoError(t, os.WriteFile(localSmall, small, 0o644))
+	require.NoError(t, service.Upload(context.Background(), "o2", session, localSmall, remote, discardProgress))
+
+	got, err := os.ReadFile(remote) //nolint:gosec // 测试内的临时目录路径
+	require.NoError(t, err)
+	assert.Len(t, got, 1000, "覆盖后不得残留旧内容")
+	assert.Equal(t, md5.Sum(small), md5.Sum(got))
 }
 
 func TestUploadWritesThroughSymlinkInsteadOfReplacingIt(t *testing.T) {


### PR DESCRIPTION
## 变更说明 / Summary

提升 SFTP 上传/下载性能：在创建 Client 时启用并发读写，并让传输走 `pkg/sftp` 的并发路径。

- `sftp.NewClient` 增加 `UseConcurrentReads(true)`、`UseConcurrentWrites(true)` 
- 上传使用 `ReadFrom`、下载使用 `WriteTo`，避免原先串行小缓冲拷贝
- 大文件传输可更好地打满链路，缩短耗时

## 关联 Issue / Related Issue

Closes #

## 截图 / Screenshots

<!-- UI 改动必填 / Required for UI changes -->

## 自检 / Checklist

- [ ] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试