### PR TITLE
✨ 支持为 Pi 安装 opsctl AI Skill 插件

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1095,7 +1095,7 @@
     "openAICompatibleDesc": "Works with OpenAI, DeepSeek, and other major APIs",
     "anthropicDesc": "Anthropic Claude series model API",
     "opsctlBannerTitle": "Use via opsctl Plugin",
-    "opsctlBannerDesc": "Install the opsctl CLI and enable the AI Skill plugin to manage and operate your server assets directly from Claude Code, Codex, and other AI coding tools.",
+    "opsctlBannerDesc": "Install the opsctl CLI and enable the AI Skill plugin to manage and operate your server assets directly from Claude Code, Codex, Pi, and other AI coding tools.",
     "goToSettings": "Go to Settings",
     "selectProvider": "Select AI Provider",
     "configureProvider": "Configure {{provider}}",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1095,7 +1095,7 @@
     "openAICompatibleDesc": "兼容 OpenAI、DeepSeek 等主流 API",
     "anthropicDesc": "Anthropic Claude 系列模型 API",
     "opsctlBannerTitle": "通过 opsctl 插件使用",
-    "opsctlBannerDesc": "安装 opsctl CLI 并启用 AI Skill 插件，即可在 Claude Code、Codex 等 AI 编程工具中直接管理和操作你的服务器资产。",
+    "opsctlBannerDesc": "安装 opsctl CLI 并启用 AI Skill 插件，即可在 Claude Code、Codex、Pi 等 AI 编程工具中直接管理和操作你的服务器资产。",
     "goToSettings": "前往设置",
     "selectProvider": "选择 AI 提供商",
     "configureProvider": "配置 {{provider}}",

--- a/internal/app/system/settings.go
+++ b/internal/app/system/settings.go
@@ -952,6 +952,15 @@ var skillTargetDefs = []skillTargetDef{
 		},
 	},
 	{
+		// Pi 的全局 skills 目录（https://pi.dev/docs/latest/skills），SKILL.md 格式与 Codex 一致
+		"pi", "Pi", installSkill,
+		func(home string) string { return filepath.Join(home, ".pi", "agent", "skills", "opsctl") },
+		func(path string) bool {
+			_, err := os.Stat(filepath.Join(path, "SKILL.md"))
+			return err == nil
+		},
+	},
+	{
 		"gemini-cli", "Gemini CLI", installGemini,
 		func(home string) string { return filepath.Join(home, ".gemini", "extensions", "opsctl") },
 		func(path string) bool {
@@ -1556,6 +1565,12 @@ func (s *System) writePluginReference() error {
 			filepath.Join(base, "opencode", "opsctl", "SKILL.md"):                  skillMD,
 			filepath.Join(base, "opencode", "opsctl", "references", "commands.md"): s.skillContent.CommandsMD,
 			filepath.Join(base, "opencode", "opsctl", "references", "init.md"):     s.skillContent.InitMD,
+		}},
+		// Pi
+		{files: map[string]string{
+			filepath.Join(base, "pi", "opsctl", "SKILL.md"):                  skillMD,
+			filepath.Join(base, "pi", "opsctl", "references", "commands.md"): s.skillContent.CommandsMD,
+			filepath.Join(base, "pi", "opsctl", "references", "init.md"):     s.skillContent.InitMD,
 		}},
 		// Gemini CLI
 		{files: map[string]string{


### PR DESCRIPTION
## 背景

设置 → AI 插件（AI Skill 安装）目前支持 Claude Code / Codex / OpenCode / Gemini CLI，缺少 Pi 支持。

## 依据

Pi 官方文档（https://pi.dev/docs/latest/skills）：
- 全局 skills 目录：`~/.pi/agent/skills/`（另有 `~/.agents/skills/`）
- 遵循 Agent Skills 标准，目录含 `SKILL.md` 即被发现
- 格式与 Codex / OpenCode 的 SKILL.md 完全一致，可复用现有安装逻辑

## 改动

- `internal/app/system/settings.go`：
  - `skillTargetDefs` 新增 `"pi", "Pi", installSkill` 目标，安装到 `~/.pi/agent/skills/opsctl/`（SKILL.md + references）
  - `writePluginReference` 增加 `pi/opsctl/` 参考目录结构
- `frontend/src/i18n/locales/{zh-CN,en}/common.json`：安装描述文案加入 Pi

前端设置界面无需改动，目标列表由 `DetectSkills()` 动态返回，重启后自动出现 Pi 条目。

## 验证

- `go build ./internal/app/...` ✅
- `wails build` 生产构建成功 ✅
- 本机 `~/.pi/agent/skills/opsctl/` 已存在，DetectSkills 显示 Pi 已安装 ✅

基于 fork 源最新 main（fe7f076）创建，仅包含本功能一个提交。