### PR TITLE
🐛 修复旧版 WebView2 下界面失色（弹窗透明、只剩线条）#273

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "eslint-plugin-react-x": "^5.13.2",
     "happy-dom": "^20.8.8",
+    "lightningcss": "^1.32.0",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.0.0",
     "terser": "^5.46.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       happy-dom:
         specifier: ^20.8.8
         version: 20.8.8
+      lightningcss:
+        specifier: ^1.32.0
+        version: 1.32.0
       prettier:
         specifier: ^3.8.1
         version: 3.8.1

--- a/frontend/src/__tests__/cssBaseline.test.ts
+++ b/frontend/src/__tests__/cssBaseline.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { build } from "vite";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import config from "../../vite.config";
+
+/**
+ * WebView2 Runtime 不是所有 Windows 机器都跟得上 Evergreen 更新（#273 报告的是 110）。
+ * Tailwind v4 的基线是 Chrome 111，主题 token 写成 `--background: oklch(...)`：
+ * 自定义属性解析期不校验，但 `background-color: var(--background)` 替换后计算值非法，
+ * 属性退回 unset —— 弹窗背景变透明、边框只剩 currentColor 的线条。
+ *
+ * 这里用生产配置真实构建一小段 CSS，断言旧引擎能拿到可用颜色。
+ */
+
+/** 旧引擎会整条丢弃的颜色函数；只有包在 @supports 里才允许出现。 */
+const MODERN_COLOR_FN = /(?:oklch|oklab|lch|color-mix)\(/g;
+
+/** 去掉每个 @supports 块（含前置条件与花括号内容），只留下无条件生效的声明。 */
+function stripSupportsBlocks(css: string): string {
+  let out = "";
+  let i = 0;
+  for (;;) {
+    const start = css.indexOf("@supports", i);
+    if (start === -1) return out + css.slice(i);
+    out += css.slice(i, start);
+    let j = css.indexOf("{", start);
+    if (j === -1) return out;
+    let depth = 1;
+    for (j += 1; j < css.length && depth > 0; j += 1) {
+      if (css[j] === "{") depth += 1;
+      else if (css[j] === "}") depth -= 1;
+    }
+    i = j;
+  }
+}
+
+async function buildCss(source: string): Promise<string> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opskat-cssbaseline-"));
+  const entry = path.join(dir, "entry.css");
+  fs.writeFileSync(entry, source);
+  try {
+    const result = await build({
+      configFile: false,
+      logLevel: "silent",
+      css: config.css,
+      build: {
+        cssMinify: config.build?.cssMinify,
+        write: false,
+        rollupOptions: { input: entry },
+      },
+    });
+    const { output } = (Array.isArray(result) ? result[0] : result) as {
+      output: Array<{ type: string; fileName: string; source?: string | Uint8Array }>;
+    };
+    const css = output.find((o) => o.type === "asset" && o.fileName.endsWith(".css"))?.source;
+    if (typeof css !== "string") throw new Error("构建产物中没有 CSS asset");
+    return css;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("CSS 旧引擎基线", () => {
+  it("把主题 token 里的 oklch 降级成无条件生效的颜色", async () => {
+    const css = await buildCss(
+      `:root { --background: oklch(0.96 0.01 250); }\n.panel { background-color: var(--background); }`
+    );
+
+    // 广色域值仍可保留，但必须让位给一个旧引擎认得的兜底值。
+    expect(stripSupportsBlocks(css)).toMatch(/--background:\s*#[0-9a-f]{3,8}/i);
+  }, 60_000);
+
+  it("不留下任何无 @supports 兜底的现代颜色函数", async () => {
+    const css = await buildCss(
+      [
+        `:root { --accent: oklch(0.55 0.22 260); }`,
+        `.solid { color: oklch(0.7 0.1 200); }`,
+        `.blend { background-color: color-mix(in oklab, oklch(0.8 0.1 150) 50%, transparent); }`,
+        `.token { box-shadow: inset 0 0 0 2px var(--accent); }`,
+      ].join("\n")
+    );
+
+    expect(stripSupportsBlocks(css).match(MODERN_COLOR_FN)).toBeNull();
+  }, 60_000);
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,16 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
+// Windows 的 WebView2 Runtime 并非人人都跟得上 Evergreen 更新（#273 是 110、#226 是 100）。
+// Tailwind v4 按 Chrome 111 生成样式：主题 token 是 `--background: oklch(...)`，自定义属性
+// 解析期不校验，但 `background-color: var(--background)` 替换后计算值非法，整条属性退回
+// unset —— 弹窗背景透明、边框只剩 currentColor，界面看上去"只有线条"。
+// Chrome 99 是硬底（Tailwind v4 依赖 @layer，无法降级），取 100 作为基线。
+// 注意 esbuild 的 build.cssTarget 不解决这个问题：它只降直接写在属性上的 oklch()，
+// 自定义属性和 color-mix() 原样输出。只有 Lightning CSS 会为自定义属性生成
+// 十六进制兜底 + @supports 双写，回归测试见 src/__tests__/cssBaseline.test.ts。
+const MIN_CHROME = 100;
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -49,6 +59,13 @@ export default defineConfig({
       "zustand",
     ],
   },
+  css: {
+    // Vite 只在 css.transformer === "lightningcss" 时才自动推导 targets，
+    // 这里只借用它做压缩，必须显式给，否则等于没设。
+    lightningcss: {
+      targets: { chrome: MIN_CHROME << 16 },
+    },
+  },
   build: {
     // 改用 terser：esbuild 的死代码消除存在一个 bug——把 xterm.js 里
     // `requestMode` 中 `let r; (IIFE)(r||={});` 错误地改成 `(IIFE)(void 0||(n={}))`，
@@ -56,6 +73,7 @@ export default defineConfig({
     // vim 等通过 DECRQM 查询终端能力的程序会让 xterm.js parser 崩溃，
     // 从而屏幕渲染停滞、键盘看上去"无响应"。
     minify: "terser",
+    cssMinify: "lightningcss",
   },
   test: {
     environment: "happy-dom",


### PR DESCRIPTION
closes #273

## 根因

Tailwind v4 的基线是 Chrome 111，主题 token 全部写成 `oklch()`（`frontend/src/styles/globals.css` 里 130 处）：

```css
:root { --background: oklch(0.96 0.01 250); }
.panel { background-color: var(--background); }
```

自定义属性在解析期不做校验，`--background` 能原样存下来；但一旦被 `var()` 替换进 `background-color`，计算值非法 —— **invalid at computed-value time** —— 整条属性退回 `unset`：

- `background-color` → `transparent`（弹窗透明）
- `border-color` → `currentColor`（满屏只剩线条）
- 布局、间距、图标完全正常，因为坏掉的只有颜色

Windows 的 WebView2 Runtime 并非人人都跟得上 Evergreen 更新。#273 报告者是 **110.0.1587.56**，#226 是 **100**，而 `oklch()` 和 `color-mix()` 都要 Chromium **111**。#273 报告者还提到 Runtime 安装失败，所以"让用户升级"这条路对他并不通。

顺带澄清：Tailwind 自己生成的 353 处 `color-mix()` 已经包在 `@supports (color:color-mix(in lab,red,red))` 里、外面留了不透明的 `var(--x)` 兜底，能自行降级。真正裸奔的是我们手写的主题 token。

## 修复

`frontend/vite.config.ts` 改用 Lightning CSS 压缩产物，基线定在 Chrome 100：

```ts
css:   { lightningcss: { targets: { chrome: MIN_CHROME << 16 } } },
build: { minify: "terser", cssMinify: "lightningcss" },
```

它会为自定义属性生成十六进制兜底 + `@supports` 双写：

```css
:root{--background:#edf2f8;--primary:#0766ee;...}
@supports (color:lab(0% 0 0)){:root{--background:lab(95.35% -1.09 -3.57);...}}
```

旧引擎拿 hex，新引擎照常走广色域。

**为什么不用 `build.cssTarget`。** 那条走 esbuild，实测在 `chrome107` 下：

```
输入  :root{--bg:oklch(...)}  .a{color:oklch(...)}  .b{background:color-mix(...)}
输出  :root{--bg:oklch(...)}  .a{color:#40b1b7}     .b{background:color-mix(...)}
      ^ 原样                  ^ 只有这个降了         ^ 原样
```

它只处理直接写在属性上的 `oklch()`，而失效的 130 处全在自定义属性上。只有 Lightning CSS 覆盖这一类。

**为什么是 100。** 分别构建 `chrome100` 与 `chrome107`，产物字节完全一致（同一个 hash），两者之间没有额外可降级的东西，所以取更低的那个，顺带覆盖 #226。再往下 Chrome 99 是硬底：Tailwind v4 依赖 `@layer`，无法 polyfill。中间的 `:has()`（105，9 处）和 `@container`（105，1 处）降不了，但它们失效只是丢几条规则的观感，不会像现在这样整屏透明。JS 侧不是瓶颈 —— Vite 6 的默认 target 是 `chrome87`，本次未改动。

## 验证

- 新增 `frontend/src/__tests__/cssBaseline.test.ts`：用**生产配置**真实构建一小段 CSS，断言主题 token 有无条件生效的兜底色、且不留任何无 `@supports` 保护的现代颜色函数。先跑出 RED（`expected [ 'oklch(', 'color-mix(', 'oklch(' ] to be null`），改完转 GREEN。
- 真实产物：`:root` 变成 `--background:#edf2f8` 等十六进制；裸 `oklch(` / `color-mix(` 计数归零。
- 全量 228 文件 / 2121 用例通过，`pnpm run lint` 干净，`tsc -b` 通过。
- 体积：`index.css` gzip 21,270 → 25,600 字节（+4.3 KB），桌面端本地加载可忽略。

## 遗留

低于 Chrome 100 的 Runtime 仍然会坏，且没有任何提示 —— Wails 自己的门槛硬编码在 `94.0.992.31`（`internal/wv2installer/wv2installer.go:13`），不会拦。要不要加一个启动时的版本检查 + 升级引导对话框，我倾向另开一个 issue 单独议。
