### PR TITLE
🐛 修复 SSH Agent 每把密钥显示相同使用资产数 #278

### DIFF
--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { DatabaseSync } from "node:sqlite";
 import { join } from "node:path";
 
@@ -73,6 +74,32 @@ export function findAuditLogs(filter: { assetName?: string; toolName?: string } 
     (where.length ? ` WHERE ${where.join(" AND ")}` : "") +
     " ORDER BY id";
   return query((db) => db.prepare(sql).all(...args) as unknown as AuditRow[]);
+}
+
+/**
+ * 等审计行落库，返回满足断言的那一份快照。审计断言一律走这里。
+ *
+ * 审计行不是工具调用的同步产物：runner.auditMiddleware 在工具返回**之后**用一个独立
+ * goroutine 写（internal/ai/runner/hooks.go）。所以"资产已经软删除了""对话已经出结果了"
+ * 都不代表审计行已经在表里——先等别的副作用、再同步读审计表，是等错了信号。
+ * 这里等的信号和读的数据是同一个，也不会在等到之后重查一次（重查可能多出刚落库的行）。
+ */
+export async function waitForAuditLogs(
+  filter: { assetName?: string; toolName?: string },
+  count: number,
+  opts: { timeout?: number } = {}
+): Promise<AuditRow[]> {
+  let rows: AuditRow[] = [];
+  await expect
+    .poll(
+      () => {
+        rows = findAuditLogs(filter);
+        return rows.length;
+      },
+      { timeout: opts.timeout ?? 60_000 }
+    )
+    .toBe(count);
+  return rows;
 }
 
 export interface GrantItemRow {

--- a/e2e/tests/ai-exec-crud.spec.ts
+++ b/e2e/tests/ai-exec-crud.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { ensureAIProvider, openApp, openNewChat, scriptModel, sendChat, seedSSHAsset } from "../fixtures/ai";
-import { findAssetByName, findAuditLogs } from "../fixtures/db";
+import { findAssetByName, findAuditLogs, waitForAuditLogs } from "../fixtures/db";
 
 // Plan C collapsed the old per-verb add_asset/update_asset/delete_asset tools into
 // put_asset (create-or-update, branching on whether `asset` is passed) and delete_asset
@@ -8,7 +8,7 @@ import { findAssetByName, findAuditLogs } from "../fixtures/db";
 // invariants, through the real app: a scripted model calls the tool, and the DB /
 // approval UI are read back independently of the app's own claims.
 
-const putAssetRows = () => findAuditLogs({ toolName: "put_asset" });
+const putAssetFilter = { toolName: "put_asset" };
 
 test.beforeEach(async ({ page }) => {
   await openApp(page);
@@ -19,7 +19,7 @@ test("put_asset creates, then updates the same row through the same tool", async
   const name = `e2e-ai-put-${Date.now()}`;
   const renamed = `${name}-renamed`;
   const auditSecret = `e2e-audit-secret-${Date.now()}`;
-  const before = putAssetRows().length;
+  const before = findAuditLogs(putAssetFilter).length;
 
   await scriptModel([
     {
@@ -53,8 +53,7 @@ test("put_asset creates, then updates the same row through the same tool", async
   expect(findAssetByName(name)).toBeUndefined();
 
   // Both the create and the update went through the one put_asset tool.
-  await expect.poll(() => putAssetRows().length, { timeout: 10_000 }).toBe(before + 2);
-  const rows = putAssetRows();
+  const rows = await waitForAuditLogs(putAssetFilter, before + 2);
   const createdAudit = rows[before];
   expect(createdAudit.asset_id).toBe(row.id);
   expect(createdAudit.asset_name).toBe(name);
@@ -87,8 +86,7 @@ test("delete_asset always prompts, and the panel offers no allow-all — approvi
   // Soft-deleted (StatusDeleted=2), not gone from the table.
   await expect.poll(() => findAssetByName(asset)?.status, { timeout: 60_000 }).toBe(2);
 
-  const rows = findAuditLogs({ assetName: asset, toolName: "delete_asset" });
-  expect(rows.length).toBe(1);
-  expect(rows[0].decision).toBe("allow");
-  expect(rows[0].decision_source).toBe("user_allow");
+  const [deleteAudit] = await waitForAuditLogs({ assetName: asset, toolName: "delete_asset" }, 1);
+  expect(deleteAudit.decision).toBe("allow");
+  expect(deleteAudit.decision_source).toBe("user_allow");
 });

--- a/e2e/tests/ai-exec-policy.spec.ts
+++ b/e2e/tests/ai-exec-policy.spec.ts
@@ -10,7 +10,7 @@ import {
   sendChat,
   seedSSHAsset,
 } from "../fixtures/ai";
-import { findApprovedGrantItems, findAuditLogs } from "../fixtures/db";
+import { findApprovedGrantItems, findAuditLogs, waitForAuditLogs } from "../fixtures/db";
 
 // The two decision paths that must NOT prompt (policy allow / policy deny), and
 // the authorization-persistence rule: "remember + allow" persists a grant that
@@ -117,8 +117,7 @@ test("allow-this-once persists nothing and the next command prompts again", asyn
   await expect(pendingApproval(page, answered)).toBeVisible({ timeout: 60_000 });
   await page.getByTestId("ai-approval-allow").click();
 
-  await expect.poll(() => execRows(asset).length, { timeout: 60_000 }).toBe(2);
-  const rows = execRows(asset);
+  const rows = await waitForAuditLogs({ assetName: asset, toolName: "exec" }, 2);
   expect(rows.map((r) => r.decision_source)).toEqual(["user_allow", "user_allow"]);
   expect(findApprovedGrantItems(asset)).toEqual([]);
 });

--- a/e2e/tests/ai-exec.spec.ts
+++ b/e2e/tests/ai-exec.spec.ts
@@ -10,7 +10,7 @@ import {
   seedSSHAsset,
   toolResultsSeenByModel,
 } from "../fixtures/ai";
-import { findAuditLogs } from "../fixtures/db";
+import { waitForAuditLogs } from "../fixtures/db";
 
 // The unified `exec` AI tool, end-to-end through the real app: a scripted model
 // (fixtures/openai-mock.mjs, reached via a real ai_providers row) calls exec, the
@@ -26,7 +26,8 @@ import { findAuditLogs } from "../fixtures/db";
 //      `mock-exec-ran: <command>` — i.e. the far end of the wire, not another of
 //      the app's own copies of the string.
 
-const execRows = (asset: string) => findAuditLogs({ assetName: asset, toolName: "exec" });
+// 每个用例都恰好产生一条 exec 审计行；等它落库并取回。
+const waitExecRow = async (asset: string) => (await waitForAuditLogs({ assetName: asset, toolName: "exec" }, 1))[0];
 
 test.beforeEach(async ({ page }) => {
   await openApp(page);
@@ -53,8 +54,7 @@ test("approved exec runs exactly the command the dialog showed, and audits that 
 
   await page.getByTestId("ai-approval-allow").click();
 
-  await expect.poll(() => execRows(asset).length, { timeout: 60_000 }).toBe(1);
-  const row = execRows(asset)[0];
+  const row = await waitExecRow(asset);
   expect(row.command).toBe(shown); // audited == approved
   expect(row.result).toBe(`mock-exec-ran: ${shown}\n`); // executed == approved
   expect(row.decision).toBe("allow");
@@ -77,8 +77,7 @@ test("denied exec never reaches the server and the model is told it was denied",
   await expect(page.getByTestId("ai-approval-block")).toBeVisible({ timeout: 60_000 });
   await page.getByTestId("ai-approval-deny").click();
 
-  await expect.poll(() => execRows(asset).length, { timeout: 60_000 }).toBe(1);
-  const row = execRows(asset)[0];
+  const row = await waitExecRow(asset);
   expect(row.decision).toBe("deny");
   expect(row.decision_source).toBe("user_deny");
   // The mock sshd echoes every command it is asked to run; nothing was echoed,
@@ -116,11 +115,11 @@ test("the dialog shows the canonicalized command, and that is the string audited
 
   await page.getByTestId("ai-approval-allow").click();
 
-  await expect.poll(() => execRows(asset).length, { timeout: 60_000 }).toBe(1);
   // The audit row records the approved (canonical) string, not the model's raw one.
   // The etcd endpoint itself is unreachable by design here, so this row's `error`
   // is a dial failure — irrelevant to the string identity being asserted.
-  expect(execRows(asset)[0].command).toBe(shown);
+  const row = await waitExecRow(asset);
+  expect(row.command).toBe(shown);
 });
 
 test("stopping the turn while an approval is pending cancels it instead of executing", async ({ page }) => {
@@ -142,8 +141,7 @@ test("stopping the turn while an approval is pending cancels it instead of execu
   await page.getByTestId("ai-stop-button").click();
   await expect(dialog).toBeHidden({ timeout: 30_000 });
 
-  await expect.poll(() => execRows(asset).length, { timeout: 60_000 }).toBe(1);
-  const row = execRows(asset)[0];
+  const row = await waitExecRow(asset);
   // An unanswered prompt resolves as a denial — never as a silent approval.
   expect(row.decision).toBe("deny");
   expect(row.decision_source).toBe("user_deny");
@@ -169,8 +167,7 @@ test("a Redis asset dispatches through the same exec tool", async ({ page }) => 
   expect((await page.getByTestId("ai-approval-command").innerText()).trim()).toBe(command);
   await page.getByTestId("ai-approval-allow").click();
 
-  await expect.poll(() => execRows(asset).length, { timeout: 60_000 }).toBe(1);
-  const row = execRows(asset)[0];
+  const row = await waitExecRow(asset);
   expect(row.command).toBe(command);
   expect(row.decision_source).toBe("user_allow");
   // The reply came from the mock Redis through the app's real Redis client.

--- a/internal/ai/tool/tool_handlers_crud_test.go
+++ b/internal/ai/tool/tool_handlers_crud_test.go
@@ -160,6 +160,9 @@ func (r *fakeAssetRepo) CountByTypes(_ context.Context, _ []string) (int64, erro
 func (r *fakeAssetRepo) CountAgentAuthBySourceID(_ context.Context, _ int64) (int64, error) {
 	return 0, nil
 }
+func (r *fakeAssetRepo) CountAgentAuthBySourceIDGroupByFingerprint(_ context.Context, _ int64) (map[string]int64, error) {
+	return nil, nil
+}
 func (r *fakeAssetRepo) ListAgentAuthBySourceID(_ context.Context, _ int64) ([]*asset_entity.Asset, error) {
 	return nil, nil
 }

--- a/internal/repository/asset_repo/asset.go
+++ b/internal/repository/asset_repo/asset.go
@@ -26,6 +26,9 @@ type AssetRepo interface {
 	// CountAgentAuthBySourceID 统计引用了指定 SSH Agent 来源的活动 SSH 资产数
 	// （config 中 auth_type=agent 且 agent_source_id 匹配）。
 	CountAgentAuthBySourceID(ctx context.Context, sourceID int64) (int64, error)
+	// CountAgentAuthBySourceIDGroupByFingerprint 把引用了指定来源的活动 SSH 资产
+	// 按所选身份指纹（agent_key_fingerprint）分组计数，用于逐把密钥展示使用数。
+	CountAgentAuthBySourceIDGroupByFingerprint(ctx context.Context, sourceID int64) (map[string]int64, error)
 	// ListAgentAuthBySourceID 列出引用了指定 SSH Agent 来源的活动 SSH 资产。
 	ListAgentAuthBySourceID(ctx context.Context, sourceID int64) ([]*asset_entity.Asset, error)
 }
@@ -166,6 +169,27 @@ func (r *assetRepo) CountAgentAuthBySourceID(ctx context.Context, sourceID int64
 	var count int64
 	err := agentSourceAssetQuery(ctx, sourceID).Model(&asset_entity.Asset{}).Count(&count).Error
 	return count, err
+}
+
+func (r *assetRepo) CountAgentAuthBySourceIDGroupByFingerprint(ctx context.Context, sourceID int64) (map[string]int64, error) {
+	// Agent 模式资产在写入时必须携带规范指纹（validateSSHAgentContract），所以这里
+	// 不存在指纹缺失的分组。
+	const fingerprintExpr = "json_extract(config, '$.agent_key_fingerprint')"
+	var rows []struct {
+		Fingerprint string
+		Total       int64
+	}
+	if err := agentSourceAssetQuery(ctx, sourceID).Model(&asset_entity.Asset{}).
+		Select(fingerprintExpr + " AS fingerprint, COUNT(*) AS total").
+		Group(fingerprintExpr).
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int64, len(rows))
+	for _, row := range rows {
+		counts[row.Fingerprint] = row.Total
+	}
+	return counts, nil
 }
 
 func (r *assetRepo) ListAgentAuthBySourceID(ctx context.Context, sourceID int64) ([]*asset_entity.Asset, error) {

--- a/internal/repository/asset_repo/mock_asset_repo/asset.go
+++ b/internal/repository/asset_repo/mock_asset_repo/asset.go
@@ -57,6 +57,21 @@ func (mr *MockAssetRepoMockRecorder) CountAgentAuthBySourceID(ctx, sourceID any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAgentAuthBySourceID", reflect.TypeOf((*MockAssetRepo)(nil).CountAgentAuthBySourceID), ctx, sourceID)
 }
 
+// CountAgentAuthBySourceIDGroupByFingerprint mocks base method.
+func (m *MockAssetRepo) CountAgentAuthBySourceIDGroupByFingerprint(ctx context.Context, sourceID int64) (map[string]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountAgentAuthBySourceIDGroupByFingerprint", ctx, sourceID)
+	ret0, _ := ret[0].(map[string]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountAgentAuthBySourceIDGroupByFingerprint indicates an expected call of CountAgentAuthBySourceIDGroupByFingerprint.
+func (mr *MockAssetRepoMockRecorder) CountAgentAuthBySourceIDGroupByFingerprint(ctx, sourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAgentAuthBySourceIDGroupByFingerprint", reflect.TypeOf((*MockAssetRepo)(nil).CountAgentAuthBySourceIDGroupByFingerprint), ctx, sourceID)
+}
+
 // CountByTypes mocks base method.
 func (m *MockAssetRepo) CountByTypes(ctx context.Context, types []string) (int64, error) {
 	m.ctrl.T.Helper()

--- a/internal/service/import_svc/windterm_test.go
+++ b/internal/service/import_svc/windterm_test.go
@@ -315,6 +315,9 @@ func (r *windTermAssetRepo) CountByTypes(context.Context, []string) (int64, erro
 func (r *windTermAssetRepo) CountAgentAuthBySourceID(context.Context, int64) (int64, error) {
 	return 0, nil
 }
+func (r *windTermAssetRepo) CountAgentAuthBySourceIDGroupByFingerprint(context.Context, int64) (map[string]int64, error) {
+	return nil, nil
+}
 func (r *windTermAssetRepo) ListAgentAuthBySourceID(context.Context, int64) ([]*asset_entity.Asset, error) {
 	return nil, nil
 }

--- a/internal/service/ssh_agent_svc/inspect.go
+++ b/internal/service/ssh_agent_svc/inspect.go
@@ -61,6 +61,12 @@ func Inspect(ctx context.Context, id int64) (*InspectResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	// 每把身份的使用数按所选指纹单独统计：来源级 usages 是所有身份的合计，
+	// 直接套用到每一行会让同来源的每把密钥都显示相同的数字（#278）。
+	perIdentity, err := asset_repo.Asset().CountAgentAuthBySourceIDGroupByFingerprint(ctx, id)
+	if err != nil {
+		return nil, err
+	}
 	result := &InspectResult{
 		SourceID:   id,
 		Usages:     usages,
@@ -71,7 +77,7 @@ func Inspect(ctx context.Context, id int64) (*InspectResult, error) {
 			Fingerprint: ident.Fingerprint,
 			Type:        ident.Type,
 			Comment:     ident.Comment,
-			Usages:      usages,
+			Usages:      perIdentity[ident.Fingerprint],
 		})
 	}
 	return result, nil

--- a/internal/service/ssh_agent_svc/inspect_test.go
+++ b/internal/service/ssh_agent_svc/inspect_test.go
@@ -96,7 +96,7 @@ func TestInspect_ReturnsBoundedIdentitySummary(t *testing.T) {
 
 	src, err := Create(ctx, SourceInput{Name: "work", EndpointType: "unix_socket", Endpoint: srv.path})
 	require.NoError(t, err)
-	assetID := createAgentAsset(t, ctx, src.ID)
+	assetID := createAgentAsset(t, ctx, "box", src.ID, fp)
 	defer func() { _ = asset_repo.Asset().Delete(ctx, assetID) }()
 
 	Convey("检查来源返回有界身份摘要", t, func() {
@@ -113,6 +113,42 @@ func TestInspect_ReturnsBoundedIdentitySummary(t *testing.T) {
 	})
 }
 
+// 回归 #278：来源下每把身份显示的使用数必须是"绑定该指纹的活动资产数"，
+// 而不是整个来源的引用总数——后者会让同一来源的每把密钥都显示相同的数字。
+func TestInspect_UsagesAreCountedPerIdentity(t *testing.T) {
+	ctx := setupInspectTest(t)
+
+	privA, _, fpA := testKey(t)
+	privB, _, fpB := testKey(t)
+	privC, _, fpC := testKey(t)
+	srv := startFakeAgent(t,
+		agent.AddedKey{PrivateKey: privA, Comment: "a"},
+		agent.AddedKey{PrivateKey: privB, Comment: "b"},
+		agent.AddedKey{PrivateKey: privC, Comment: "c"},
+	)
+
+	src, err := Create(ctx, SourceInput{Name: "work", EndpointType: "unix_socket", Endpoint: srv.path})
+	require.NoError(t, err)
+	createAgentAsset(t, ctx, "only-a", src.ID, fpA)
+	createAgentAsset(t, ctx, "b-one", src.ID, fpB)
+	createAgentAsset(t, ctx, "b-two", src.ID, fpB)
+
+	Convey("同一来源下不同身份各自统计使用数", t, func() {
+		res, err := Inspect(ctx, src.ID)
+		assert.NoError(t, err)
+		require.NotNil(t, res)
+
+		byFingerprint := map[string]int64{}
+		for _, ident := range res.Identities {
+			byFingerprint[ident.Fingerprint] = ident.Usages
+		}
+		assert.Equal(t, int64(1), byFingerprint[fpA], "只有一个资产绑定该密钥")
+		assert.Equal(t, int64(2), byFingerprint[fpB], "两个资产绑定该密钥")
+		assert.Equal(t, int64(0), byFingerprint[fpC], "没有资产绑定该密钥")
+		assert.Equal(t, int64(3), res.Usages, "来源级使用数仍是引用该来源的资产总数")
+	})
+}
+
 func TestInspect_ReachableEmptyAgent(t *testing.T) {
 	ctx := setupInspectTest(t)
 
@@ -120,7 +156,8 @@ func TestInspect_ReachableEmptyAgent(t *testing.T) {
 	srv := startFakeAgent(t)
 	src, err := Create(ctx, SourceInput{Name: "empty", EndpointType: "unix_socket", Endpoint: srv.path})
 	require.NoError(t, err)
-	assetID := createAgentAsset(t, ctx, src.ID)
+	_, _, fp := testKey(t)
+	assetID := createAgentAsset(t, ctx, "box", src.ID, fp)
 	defer func() { _ = asset_repo.Asset().Delete(ctx, assetID) }()
 
 	Convey("可达但无身份是合法观察态，不是错误（与 Probe 的 ProbeEmpty 一致）", t, func() {

--- a/internal/service/ssh_agent_svc/source_test.go
+++ b/internal/service/ssh_agent_svc/source_test.go
@@ -32,16 +32,18 @@ func setupServiceTest(t *testing.T) context.Context {
 	return context.Background()
 }
 
-// createAgentAsset inserts an active SSH asset whose config references the
-// given source (auth_type=agent + agent_source_id).
-func createAgentAsset(t *testing.T, ctx context.Context, sourceID int64) int64 {
+// createAgentAsset inserts an active SSH asset whose config references the given
+// source and identity (auth_type=agent + agent_source_id + agent_key_fingerprint,
+// the shape validateSSHAgentContract requires of every agent-mode asset).
+func createAgentAsset(t *testing.T, ctx context.Context, name string, sourceID int64, fingerprint string) int64 {
 	t.Helper()
 	asset := &asset_entity.Asset{
-		Name:       "box",
+		Name:       name,
 		Type:       asset_entity.AssetTypeSSH,
 		Status:     asset_entity.StatusActive,
 		Createtime: 1,
-		Config:     fmt.Sprintf(`{"host":"h","port":22,"username":"u","auth_type":"agent","agent_source_id":%d}`, sourceID),
+		Config: fmt.Sprintf(`{"host":"h","port":22,"username":"u","auth_type":"agent","agent_source_id":%d,"agent_key_fingerprint":%q}`,
+			sourceID, fingerprint),
 	}
 	require.NoError(t, asset_repo.Asset().Create(ctx, asset))
 	return asset.ID
@@ -112,7 +114,8 @@ func TestSource_Update_InvalidatesOnEndpointChange(t *testing.T) {
 
 	src, err := Create(ctx, SourceInput{Name: "work", EndpointType: "environment", Endpoint: "SSH_AUTH_SOCK"})
 	require.NoError(t, err)
-	assetID := createAgentAsset(t, ctx, src.ID)
+	_, _, fp := testKey(t)
+	assetID := createAgentAsset(t, ctx, "box", src.ID, fp)
 
 	Convey("修改端点类型或值触发连接失效回调", t, func() {
 		Convey("端点值变化使引用资产被失效", func() {
@@ -143,7 +146,8 @@ func TestSource_Delete_RejectsInUse(t *testing.T) {
 		Convey("被活动 Agent 资产引用的来源拒绝删除（ssh_agent_source_in_use）", func() {
 			src, err := Create(ctx, SourceInput{Name: "a", EndpointType: "environment", Endpoint: "SSH_AUTH_SOCK"})
 			require.NoError(t, err)
-			assetID := createAgentAsset(t, ctx, src.ID)
+			_, _, fp := testKey(t)
+			assetID := createAgentAsset(t, ctx, "box", src.ID, fp)
 
 			err = Delete(ctx, src.ID)
 			assert.Error(t, err)


### PR DESCRIPTION
## 变更说明 / Summary

`ssh_agent_svc.Inspect` 只算了一个**来源级**总数（`CountAgentAuthBySourceID`），再把同一个数字赋给每一条身份摘要：

```go
usages, _ := asset_repo.Asset().CountAgentAuthBySourceID(ctx, id)  // 来源总数
for _, ident := range ids {
    ... Usages: usages   // 每把密钥都是这个数
}
```

于是一个来源下挂 N 把密钥时，每把都显示来源的资产总数——连一个资产都没绑定的密钥也照样显示。

改为按 `agent_key_fingerprint` 分组统计：

- `asset_repo` 新增 `CountAgentAuthBySourceIDGroupByFingerprint`，复用既有的 `agentSourceAssetQuery` 条件，一次 GROUP BY 查询拿到全部分组，无 N+1；
- `Inspect` 逐把身份取 `perIdentity[ident.Fingerprint]`；
- 来源级 `Usages`（删除确认对话框用）语义不变。

前端无改动：`IdentitySummary` 结构未变，`usages > 0` 才显示徽标——未被使用的密钥现在正确地不显示。

### 关于历史数据

`agent_key_fingerprint` 与 SSH Agent 功能同批引入（ceca5a33），`asset_svc.Create/Update` 是资产的唯一写入方且都走 `Validate()` → `validateSSHAgentContract` 强制规范指纹。因此不存在缺指纹的历史行会被算成 0，分组查询也据此没有加 COALESCE 兜底。

## 关联 Issue / Related Issue

Closes #278

## 测试 / Testing

新增回归用例 `TestInspect_UsagesAreCountedPerIdentity`（真实 SQLite + 真实 unix socket agent 夹具）：3 把身份、3 个资产，A 绑 1 个、B 绑 2 个、C 绑 0 个。

修复前（RED），三把全报 3：

```
expected: 2  actual: 3   两个资产绑定该密钥
expected: 0  actual: 3   没有资产绑定该密钥
```

同时把 `createAgentAsset` 测试夹具补成契约要求的形状（带 `agent_key_fingerprint`），原先造的是写入边界会拒绝的数据。

- `go test ./...` 全绿
- `golangci-lint run` 0 issues
- 真实库佐证：本机 `opskat.db` 中来源 3 下两个 agent 资产分别绑不同指纹，各应为 1，修复前都显示 2

## 自检 / Checklist

- [x]  Fixes mentioned issues / 修复已提及的问题
- [ ]  Code reviewed by human / 代码通过人工检查
- [x]  Changes tested / 已完成测试