### PR TITLE
✨ exec --type 支持数据库驱动名别名，并补 db/kubernetes 同义词

### DIFF
--- a/cmd/opsctl/command/exec.go
+++ b/cmd/opsctl/command/exec.go
@@ -230,7 +230,11 @@ Arguments:
 
 Flags:
   --type <type>   Optional assertion: fails fast if the asset is not of this
-                  type (accepts protocol aliases, e.g. "sql" for database).
+                  type. Accepts protocol aliases ("sql"/"db" for database,
+                  "exec" for ssh, "mongo", "kubernetes"/"kube" for k8s), and
+                  database driver names ("mysql", "postgres", "mssql",
+                  "sqlite"), which additionally assert the asset's driver —
+                  "--type mysql" fails on a PostgreSQL asset.
                   Does not select dispatch — that always comes from the
                   asset's real type.
 

--- a/internal/ai/permission/type_assert.go
+++ b/internal/ai/permission/type_assert.go
@@ -6,23 +6,72 @@ import (
 	"github.com/opskat/opskat/internal/model/entity/asset_entity"
 )
 
-// CanonicalTypeFor 把一个类型名或协议别名规范成资产类型。
+// driverAliases 把一个**驱动**名映射到它断言的 DatabaseDriver。
 //
-// 别名来自本包既有的 permissionTypes 注册表（type_registry.go 的 init）：
-// ssh←exec、database←sql、mongodb←mongo。opsctl batch 的 `sql:2:SELECT 1` 前缀
-// 与 batch_exec 条目的 type 字段都落在这张表上，因此"沿用旧写法"不需要任何兼容 shim。
+// 这些名字故意不注册进 permissionTypes：那张表是权限派发、审批标签（ApprovalTypeFor）
+// 与 grant 支持（SupportsGrantApproval）的唯一真相源，而 "mysql" 三者都不是——塞进去会让
+// SupportsGrantApproval("mysql") 报 true，把 grant 契约扩大到一个根本不是审批类型的词上。
 //
-// 注意 GrantToolCp（"cp"）也注册在同一张表里，它不是资产类型；调用方拿到的
+// 语义上它们也不是 database 的同义词：`sql`/`db` 说的是同一个资产类型的另一个叫法，
+// `mysql` 说的是 DatabaseConfig.Driver 的取值。若按普通别名注册（mysql→database 就完事），
+// type=mysql 会在一个 PostgreSQL 资产上静默通过——而 --type 存在的唯一理由就是把
+// "方言写错"提前变成错误，一个会撒谎的断言比没有断言更糟。所以驱动名多带一个约束，
+// 由 AssertAssetType 落实。
+//
+// 只收驱动本身与它们的常见拼法。mariadb 没有收：它复用 mysql 驱动，但"MariaDB 资产"
+// 与"driver=mysql"是两件事，等真有人要再说。
+var driverAliases = map[string]asset_entity.DatabaseDriver{
+	"mysql":      asset_entity.DriverMySQL,
+	"postgresql": asset_entity.DriverPostgreSQL,
+	"postgres":   asset_entity.DriverPostgreSQL,
+	"mssql":      asset_entity.DriverMSSQL,
+	"sqlserver":  asset_entity.DriverMSSQL,
+	"sqlite":     asset_entity.DriverSQLite,
+	"sqlite3":    asset_entity.DriverSQLite,
+}
+
+func init() {
+	// 两张表必须无交集，否则一个驱动名会被 permissionTypes 悄悄遮蔽，连带丢掉驱动约束
+	// （resolveDeclaredType 先查 permissionTypes）。撞名是启动期编程错误，与
+	// registerPermissionType 的 panic-on-duplicate 同一原则。
+	for name := range driverAliases {
+		if _, exists := permissionTypeFor(name); exists {
+			panic(fmt.Sprintf("permission: driver alias %q collides with a registered permission type", name))
+		}
+	}
+}
+
+// resolveDeclaredType 解析一个调用方声明的类型名，返回它断言的资产类型，以及——仅当
+// 声明的是驱动名时——它额外断言的驱动。driver 为空表示"只断言类型，不涉及方言"。
+func resolveDeclaredType(name string) (canonical string, driver asset_entity.DatabaseDriver, ok bool) {
+	if name == "" {
+		return "", "", false
+	}
+	if handler, found := permissionTypeFor(name); found {
+		return handler.canonical, "", true
+	}
+	if d, found := driverAliases[name]; found {
+		return asset_entity.AssetTypeDatabase, d, true
+	}
+	return "", "", false
+}
+
+// CanonicalTypeFor 把一个类型名、协议别名或驱动名规范成资产类型。
+//
+// 别名来自两处：本包既有的 permissionTypes 注册表（type_registry.go 的 init）——
+// ssh←exec、database←sql/db、mongodb←mongo、k8s←kubernetes/kube；以及 driverAliases
+// ——database←mysql/postgres/…。opsctl batch 的 `sql:2:SELECT 1` 前缀与 batch_exec 条目的
+// type 字段都落在这里，因此"沿用旧写法"不需要任何兼容 shim，而 `mysql:2:SELECT 1`
+// 也与 --type mysql 认同一套词。
+//
+// 驱动名在这里只解析到 "database"：驱动约束不在类型解析这一层，它需要资产本身才能判定，
+// 由 AssertAssetType 落实。想连驱动一起解析的调用方用 resolveDeclaredType。
+//
+// 注意 GrantToolCp（"cp"）也注册在 permissionTypes 里，它不是资产类型；调用方拿到的
 // canonical 会是 "cp"，与任何 asset.Type 都不相等，于是断言正常失败——这正确。
 func CanonicalTypeFor(name string) (string, bool) {
-	if name == "" {
-		return "", false
-	}
-	handler, ok := permissionTypeFor(name)
-	if !ok {
-		return "", false
-	}
-	return handler.canonical, true
+	canonical, _, ok := resolveDeclaredType(name)
+	return canonical, ok
 }
 
 // CanonicalExecTypeFor resolves a canonical asset type or protocol alias only
@@ -43,12 +92,17 @@ func CanonicalExecTypeFor(name string) (string, bool) {
 // 声明了就必须对得上：派发永远由资产导出，这里只把"模型/人写错方言"从协议层的
 // 服务端报错（读起来像基础设施故障）提前成一条点名双方类型的建模错误。
 //
+// 声明的若是驱动名（mysql/postgres/…，见 driverAliases），断言多走一层：类型对上之后
+// 还要求资产的 DatabaseConfig.Driver 一致。这正是允许驱动名当 --type 值的前提——
+// 只把 mysql 映射到 database 就等于让 type=mysql 在 PostgreSQL 资产上通过，
+// 恰好在它该拦住的地方失灵。
+//
 // 调用方必须把它放在权限检查之前——它无副作用，而 CheckForAsset 会弹审批对话框。
 func AssertAssetType(asset *asset_entity.Asset, declared string) error {
 	if declared == "" {
 		return nil
 	}
-	canonical, ok := CanonicalTypeFor(declared)
+	canonical, driver, ok := resolveDeclaredType(declared)
 	if !ok {
 		return fmt.Errorf("unknown type %q; asset %q is type=%s — call help(asset=%q) for its command syntax",
 			declared, asset.Name, asset.Type, asset.Name)
@@ -56,6 +110,17 @@ func AssertAssetType(asset *asset_entity.Asset, declared string) error {
 	if canonical != asset.Type {
 		return fmt.Errorf("asset %q is type=%s, but you passed type=%s — call help(asset=%q) for its command syntax",
 			asset.Name, asset.Type, declared, asset.Name)
+	}
+	if driver == "" {
+		return nil
+	}
+	cfg, err := asset.GetDatabaseConfig()
+	if err != nil {
+		return err
+	}
+	if cfg.Driver != driver {
+		return fmt.Errorf("asset %q is a database with driver=%s, but you passed type=%s — call help(asset=%q) for its command syntax",
+			asset.Name, cfg.Driver, declared, asset.Name)
 	}
 	return nil
 }

--- a/internal/ai/permission/type_assert_test.go
+++ b/internal/ai/permission/type_assert_test.go
@@ -17,8 +17,16 @@ func TestCanonicalTypeFor(t *testing.T) {
 		{"exec", asset_entity.AssetTypeSSH, true},     // 协议别名
 		{"sql", asset_entity.AssetTypeDatabase, true}, // opsctl batch 前缀沿用
 		{"database", asset_entity.AssetTypeDatabase, true},
+		{"db", asset_entity.AssetTypeDatabase, true},
 		{"mongo", asset_entity.AssetTypeMongoDB, true},
 		{"redis", asset_entity.AssetTypeRedis, true},
+		{"kubernetes", asset_entity.AssetTypeK8s, true},
+		{"kube", asset_entity.AssetTypeK8s, true},
+		// Driver names resolve to the database type too, so the opsctl batch prefix
+		// (`mysql:prod-db:SELECT 1`) validates the same set of words --type accepts.
+		// The driver constraint itself is enforced by AssertAssetType, not here.
+		{"mysql", asset_entity.AssetTypeDatabase, true},
+		{"postgres", asset_entity.AssetTypeDatabase, true},
 		{"nonsense", "", false},
 		{"", "", false},
 	}
@@ -87,6 +95,81 @@ func TestAssertAssetType_EchoesDeclaredAliasNotCanonical(t *testing.T) {
 	}
 }
 
+// newDBAsset builds a database asset carrying a real DatabaseConfig, which is what the
+// driver-level assertion reads back. Constructing it through SetDatabaseConfig (rather
+// than hand-writing Config JSON) keeps the test honest about the serialization the
+// production path actually parses.
+func newDBAsset(t *testing.T, name string, driver asset_entity.DatabaseDriver) *asset_entity.Asset {
+	t.Helper()
+	a := &asset_entity.Asset{Name: name, Type: asset_entity.AssetTypeDatabase}
+	if err := a.SetDatabaseConfig(&asset_entity.DatabaseConfig{
+		Driver: driver, Host: "10.0.0.1", Port: 3306, Username: "app",
+	}); err != nil {
+		t.Fatalf("SetDatabaseConfig: %v", err)
+	}
+	return a
+}
+
+// TestAssertAssetType_DriverAlias covers the whole point of admitting driver names as
+// --type values: they must assert the *driver*, not just resolve to "database". A plain
+// alias (mysql→database) would let type=mysql pass on a PostgreSQL asset, which turns the
+// assertion into a lie exactly where it is supposed to catch a wrong dialect.
+func TestAssertAssetType_DriverAlias(t *testing.T) {
+	mysqlAsset := newDBAsset(t, "prod-db", asset_entity.DriverMySQL)
+	pgAsset := newDBAsset(t, "analytics", asset_entity.DriverPostgreSQL)
+
+	if err := AssertAssetType(mysqlAsset, "mysql"); err != nil {
+		t.Fatalf("driver alias matching the asset's driver must pass, got %v", err)
+	}
+	if err := AssertAssetType(pgAsset, "postgres"); err != nil {
+		t.Fatalf("spelling variant of the driver must pass, got %v", err)
+	}
+	// The canonical type name still skips the driver check — declaring "database" says
+	// nothing about the dialect, so every database asset satisfies it.
+	if err := AssertAssetType(pgAsset, "database"); err != nil {
+		t.Fatalf("canonical type must not imply a driver, got %v", err)
+	}
+
+	err := AssertAssetType(pgAsset, "mysql")
+	if err == nil {
+		t.Fatal("driver alias must fail on an asset with a different driver")
+	}
+	// Same shape as the type-mismatch error: name both sides, echo what the caller
+	// actually passed, point at help.
+	for _, want := range []string{`"analytics"`, "driver=postgresql", "type=mysql", "help"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q must contain %q", err.Error(), want)
+		}
+	}
+
+	// A driver name on a non-database asset fails at the type layer, and must still echo
+	// the declared word rather than its canonical resolution.
+	redis := &asset_entity.Asset{Name: "cache-1", Type: asset_entity.AssetTypeRedis}
+	err = AssertAssetType(redis, "mysql")
+	if err == nil {
+		t.Fatal("driver alias must fail on a non-database asset")
+	}
+	if !strings.Contains(err.Error(), "type=mysql") {
+		t.Errorf("error %q must echo the declared value %q", err.Error(), "mysql")
+	}
+}
+
+// TestDriverAliasStaysOutOfPermissionRegistry locks the seam between the two tables.
+// permissionTypes is the source of truth for permission dispatch, approval labels and
+// grant support; driver names are none of those things. Registering them there would make
+// SupportsGrantApproval("mysql") report true, widening the grant contract to a name that
+// is not an approval type.
+func TestDriverAliasStaysOutOfPermissionRegistry(t *testing.T) {
+	for _, name := range []string{"mysql", "postgres", "postgresql", "sqlite", "mssql"} {
+		if SupportsGrantApproval(name) {
+			t.Errorf("driver alias %q must not register as an approval type", name)
+		}
+		if got := ApprovalTypeFor(name); got != name {
+			t.Errorf("ApprovalTypeFor(%q) = %q, want passthrough %q", name, got, name)
+		}
+	}
+}
+
 func TestCanonicalExecTypeFor(t *testing.T) {
 	tests := []struct {
 		name string
@@ -102,6 +185,8 @@ func TestCanonicalExecTypeFor(t *testing.T) {
 		{name: "etcd", want: asset_entity.AssetTypeEtcd, ok: true},
 		{name: "kafka", want: asset_entity.AssetTypeKafka, ok: true},
 		{name: "k8s", want: asset_entity.AssetTypeK8s, ok: true},
+		{name: "kubernetes", want: asset_entity.AssetTypeK8s, ok: true},
+		{name: "mysql", want: asset_entity.AssetTypeDatabase, ok: true},
 		{name: "serial", want: asset_entity.AssetTypeSerial, ok: true},
 		{name: "cp", ok: false},
 		{name: "rdp", ok: false},

--- a/internal/ai/permission/type_registry.go
+++ b/internal/ai/permission/type_registry.go
@@ -75,12 +75,12 @@ func SupportsGrantApproval(approvalType string) bool {
 func init() {
 	registerPermissionType(asset_entity.AssetTypeSSH, "exec", shellGrantPatterns, checkCommandPolicyPermission, "exec")
 	registerPermissionType(asset_entity.AssetTypeSerial, "serial", nil, checkCommandPolicyPermission)
-	registerPermissionType(asset_entity.AssetTypeDatabase, "sql", nil, checkDatabasePermission, "sql")
+	registerPermissionType(asset_entity.AssetTypeDatabase, "sql", nil, checkDatabasePermission, "sql", "db")
 	registerPermissionType(asset_entity.AssetTypeRedis, "redis", nil, checkRedisPermission)
 	registerPermissionType(asset_entity.AssetTypeEtcd, "etcd", nil, checkEtcdPermission)
 	registerPermissionType(asset_entity.AssetTypeMongoDB, "mongo", nil, checkMongoDBPermission, "mongo")
 	registerPermissionType(asset_entity.AssetTypeKafka, "kafka", nil, checkKafkaPermission)
-	registerPermissionType(asset_entity.AssetTypeK8s, "k8s", shellGrantPatterns, checkK8sPermission)
+	registerPermissionType(asset_entity.AssetTypeK8s, "k8s", shellGrantPatterns, checkK8sPermission, "kubernetes", "kube")
 	registerPermissionType(asset_entity.AssetTypeOSS, "oss", ossGrantPatterns, checkOSSPermission)
 	// cp 不是资产类型而是操作面：任何能开 SFTP 的资产上的文件传输都归它，主体是远端路径
 	// 而非命令，所以不按 shell 子命令拆；cpGrantPatterns 做的是另一件事——把系统给出的

--- a/plugin/opsctl/skills/opsctl/references/commands.md
+++ b/plugin/opsctl/skills/opsctl/references/commands.md
@@ -92,14 +92,21 @@ real type, never from a flag or verb name.
 
 **Flags**:
 - `--type <type>` — Optional assertion: fails fast (before any approval
-  prompt) if the asset is not of this type. Accepts protocol aliases (e.g.
-  `sql` for `database`). Does not select dispatch — that always comes from
-  the asset's real type.
+  prompt) if the asset is not of this type. Does not select dispatch — that
+  always comes from the asset's real type. Accepts three kinds of value:
+  - canonical asset types: `ssh`, `serial`, `database`, `redis`, `mongodb`,
+    `etcd`, `kafka`, `k8s`, `oss`;
+  - protocol aliases: `exec` (ssh), `sql` / `db` (database), `mongo`
+    (mongodb), `kubernetes` / `kube` (k8s);
+  - database driver names: `mysql`, `postgresql` / `postgres`, `mssql` /
+    `sqlserver`, `sqlite` / `sqlite3`. These assert the driver **as well as**
+    the type — `--type mysql` fails on a PostgreSQL asset, which is the whole
+    reason driver names are accepted rather than folded into `database`.
 
-When the type is known, always pass this assertion. Prefer canonical asset
-types (`ssh`, `database`, `redis`, `mongodb`, `etcd`, `kafka`, `k8s`,
-`serial`, `oss`) over the accepted compatibility aliases (`exec`, `sql`, `mongo`).
-Omit it only when the type is genuinely unknown.
+When the type is known, always pass this assertion. Prefer the canonical
+asset type; reach for a driver name only when the dialect actually matters to
+the command you are about to run. Omit it only when the type is genuinely
+unknown.
 
 **Approval flow**:
 1. Command policy check (allow-list/deny-list per asset)


### PR DESCRIPTION
## 背景

`opsctl exec --type` / exec 工具的 `type` 参数 / batch 前缀是**可选断言**：不参与派发（协议永远来自 `asset.Type`），只把「方言写错」提前变成一条点名双方类型的错误。

别名机制本来就有（`registerPermissionType` 的可变参），已注册 `ssh←exec`、`database←sql`、`mongodb←mongo`。缺的是 `mysql`、`postgres` 这类**驱动名** —— 写了会直接报 `unknown type`。

## 为什么驱动名不能当普通别名

把 `mysql → database` 一映射了事，会让 `--type mysql` 在一个 PostgreSQL 资产上**静默通过** —— 恰好在这个断言该拦住方言写错的地方失灵。一个会撒谎的断言比没有断言更糟。

所以驱动名多带一个约束，由 `AssertAssetType` 比对 `DatabaseConfig.Driver` 落实：

```console
$ opsctl exec analytics --type mysql -- "SELECT 1"
Error: asset "analytics" is a database with driver=postgresql, but you passed type=mysql — call help(asset="analytics") for its command syntax
```

## 改动

- `type_assert.go`：新增 `driverAliases` 表 + `resolveDeclaredType`；`AssertAssetType` 在类型对上之后再校验驱动。收 `mysql`、`postgresql`/`postgres`、`mssql`/`sqlserver`、`sqlite`/`sqlite3`。**mariadb 没收** —— 它复用 mysql 驱动，但「MariaDB 资产」与「driver=mysql」是两件事。
- 驱动名**故意不进** `permissionTypes`：那张表同时是权限派发、审批标签（`ApprovalTypeFor`）与 grant 支持（`SupportsGrantApproval`）的真相源，塞进去会让 `SupportsGrantApproval("mysql")` 返回 true，把 grant 契约扩大到一个根本不是审批类型的词上。两表撞名在 `init` 里 panic。
- `type_registry.go`：补两个纯类型同义词 `database←db`、`k8s←kubernetes/kube`。
- 别名对 `--type`、exec 工具的 `type` 参数、batch 的 `mysql:prod-db:...` 前缀三处同时生效 —— 它们共用 `CanonicalTypeFor`/`AssertAssetType`。
- AI 工具描述**没**改成宣传别名：别名是对输入的容错，让模型主动写驱动名只会增加失败面。

## 文档

- 本仓：`opsctl exec --help` 的 `--type` 说明、`plugin/opsctl/skills/opsctl/references/commands.md` 的可填值清单。
- 文档站（`opskat.github.io`）的对应改动在分支 `docs/exec-type-driver-aliases`（commit e645123），因依赖该仓另一条尚未合并的 CLI 文档整合分支，暂未开 PR；待其合入 main 且本 PR 发版后再提。

## 验证

- TDD：先写失败测试（`unknown type "mysql"`，失败在缺行为而非编译），再实现。
- `go test ./...` → **EXIT=0，98 包 ok，无 FAIL**
- `golangci-lint run internal/ai/permission/... cmd/opsctl/command/...` → **0 issues**
