### PR TITLE
🐛 Fix Redis key search pattern matching

### DIFF
--- a/frontend/src/__tests__/RedisKeyBrowser.test.tsx
+++ b/frontend/src/__tests__/RedisKeyBrowser.test.tsx
@@ -294,6 +294,6 @@ describe("RedisKeyBrowser", () => {
       await Promise.resolve();
     });
 
-    expect(RedisScanKeys).toHaveBeenCalledWith(expect.objectContaining({ match: "*dispatcher*" }));
+    expect(RedisScanKeys).toHaveBeenCalledWith(expect.objectContaining({ match: "dispatcher", exact: true }));
   });
 });

--- a/frontend/src/__tests__/queryStore.test.ts
+++ b/frontend/src/__tests__/queryStore.test.ts
@@ -279,7 +279,7 @@ describe("queryStore redis actions", () => {
     expect(useQueryStore.getState().redisStates["query-10"].scanCursor).toBe("0");
   });
 
-  it("uses contains matching for plain redis key search", async () => {
+  it("uses exact matching for plain redis key search", async () => {
     vi.mocked(RedisScanKeys).mockResolvedValue({ cursor: "0", keys: [], hasMore: false });
 
     useQueryStore.getState().setKeyFilter("query-10", "2fe43136-1b38-43c3-b4bf-82b19c66c7bf");
@@ -499,25 +499,6 @@ describe("queryStore redis actions", () => {
         assetId: 11,
         db: 3,
         count: 500,
-      })
-    );
-  });
-
-  it("uses exact matching for plain redis key search", async () => {
-    vi.mocked(RedisScanKeys).mockResolvedValue({
-      cursor: "0",
-      keys: [],
-      hasMore: false,
-    });
-
-    useQueryStore.getState().setKeyFilter("query-10", "2fe43136-1b38-43c3-b4bf-82b19c66c7bf");
-
-    await useQueryStore.getState().scanKeys("query-10", true);
-
-    expect(RedisScanKeys).toHaveBeenCalledWith(
-      expect.objectContaining({
-        match: "2fe43136-1b38-43c3-b4bf-82b19c66c7bf",
-        exact: true,
       })
     );
   });

--- a/frontend/src/__tests__/queryStore.test.ts
+++ b/frontend/src/__tests__/queryStore.test.ts
@@ -287,7 +287,8 @@ describe("queryStore redis actions", () => {
 
     expect(RedisScanKeys).toHaveBeenCalledWith(
       expect.objectContaining({
-        match: "*2fe43136-1b38-43c3-b4bf-82b19c66c7bf*",
+        match: "2fe43136-1b38-43c3-b4bf-82b19c66c7bf",
+        exact: true,
       })
     );
   });
@@ -498,6 +499,44 @@ describe("queryStore redis actions", () => {
         assetId: 11,
         db: 3,
         count: 500,
+      })
+    );
+  });
+
+  it("uses exact matching for plain redis key search", async () => {
+    vi.mocked(RedisScanKeys).mockResolvedValue({
+      cursor: "0",
+      keys: [],
+      hasMore: false,
+    });
+
+    useQueryStore.getState().setKeyFilter("query-10", "2fe43136-1b38-43c3-b4bf-82b19c66c7bf");
+
+    await useQueryStore.getState().scanKeys("query-10", true);
+
+    expect(RedisScanKeys).toHaveBeenCalledWith(
+      expect.objectContaining({
+        match: "2fe43136-1b38-43c3-b4bf-82b19c66c7bf",
+        exact: true,
+      })
+    );
+  });
+
+  it("uses wildcard pattern matching for redis key search", async () => {
+    vi.mocked(RedisScanKeys).mockResolvedValue({
+      cursor: "0",
+      keys: [],
+      hasMore: false,
+    });
+
+    useQueryStore.getState().setKeyFilter("query-10", "dispatcher*");
+
+    await useQueryStore.getState().scanKeys("query-10", true);
+
+    expect(RedisScanKeys).toHaveBeenCalledWith(
+      expect.objectContaining({
+        match: "dispatcher*",
+        exact: false,
       })
     );
   });

--- a/frontend/src/stores/queryStore.ts
+++ b/frontend/src/stores/queryStore.ts
@@ -213,10 +213,11 @@ function defaultMongoState(): MongoDBTabState {
 }
 
 function toRedisMatchPattern(pattern: string): string {
-  const trimmed = pattern.trim();
-  if (!trimmed) return "*";
-  if (trimmed.includes("*") || trimmed.includes("?") || trimmed.includes("[")) return trimmed;
-  return `*${trimmed}*`;
+  return pattern.trim() || "*";
+}
+
+function hasRedisMatchWildcard(pattern: string): boolean {
+  return pattern.includes("*") || pattern.includes("?") || pattern.includes("[");
 }
 
 export interface RedisStreamEntry {
@@ -813,16 +814,17 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       },
     }));
     const requestId = (state.scanRequestId || 0) + 1;
+    const pattern = toRedisMatchPattern(state.keyFilter);
 
     try {
       const result = await RedisScanKeys({
         assetId: tab.assetId,
         db: state.currentDb,
         cursor,
-        match: toRedisMatchPattern(state.keyFilter || "*"),
+        match: pattern,
         type: "",
         count: tab.redisScanPageSize || 200,
-        exact: false,
+        exact: !hasRedisMatchWildcard(pattern),
       });
 
       set((s) => ({


### PR DESCRIPTION
# 🐛 Fix Redis key search pattern matching

## 变更说明 / Summary

Update Redis key search behavior to distinguish exact key lookups from wildcard pattern searches.

* Use exact lookup when the filter does not contain Redis wildcards.
* Use `SCAN MATCH` when the filter contains `*`, `?`, or `[` patterns.
* Normalize empty key filters to `*` for scanning all keys.
* Avoid forcing exact key searches through `SCAN MATCH`.

## 关联 Issue / Related Issue

Closes #

## 截图 / Screenshots

<!-- No UI changes -->

## 自检 / Checklist

* [ ] Fixes mentioned issues / 修复已提及的问题
* [x] Code reviewed by human / 代码通过人工检查
* [x] Changes tested / 已完成测试
