### PR TITLE
✨ 通用安装支持列表加入 DeepSeek Harness

### DIFF
--- a/internal/app/system/settings.go
+++ b/internal/app/system/settings.go
@@ -960,6 +960,7 @@ var universalAgents = []SkillAgent{
 	{"warp", "Warp"},
 	{"rovo", "Rovo Dev"},
 	{"amp", "Amp"},
+	{"dsh", "DeepSeek Harness"},
 }
 
 // legacySkillDirs 返回旧版本装到 agent 私有目录、现已被通用目录取代的安装路径。


### PR DESCRIPTION
## 变更说明 / Summary

设置 → 通用安装的「支持的工具」列表新增 **DeepSeek Harness**。

DeepSeek Harness 默认启用 `@deepseek-ai/dsh-skill-filesystem`，该插件会扫描用户共享目录 `~/.agents/skills`（`user-agents` 根）。因此 OpsKat 已写入 `~/.agents/skills/opsctl` 的通用 Skill 可被 DeepSeek Harness 直接发现，无需额外安装。

## 关联 Issue / Related Issue

无。

## 截图 / Screenshots

不适用：仅扩展已有设置页中的服务端返回标签列表。

## 自检 / Checklist

- [ ] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

验证：

- `go test ./internal/app/system/`
- `go build ./internal/app/system/`
- `git diff --check upstream/main...HEAD`
- 核对 DeepSeek Harness v0.1.0-rc.8 的 `@deepseek-ai/dsh-skill-filesystem`：默认扫描 `~/.agents/skills`（`user-agents`）。
