### PR TITLE
✨Feature : SSH 连接后自动执行配置命令 #298

### DIFF
--- a/frontend/src/components/asset/SSHConfigSection.config.ts
+++ b/frontend/src/components/asset/SSHConfigSection.config.ts
@@ -25,6 +25,7 @@ interface SSHConfig {
   proxy_chain?: ProxyChainJSON | null;
   keepalive_interval_seconds?: number;
   restore_cwd_on_reconnect?: boolean;
+  startup_command?: string;
 }
 
 /** ssh 表单子状态(凭据中的 password 走 useAssetCredential,不入此 state)。 */
@@ -51,6 +52,8 @@ export interface SSHFormState extends ConnectionFormFields {
   keepAliveIntervalSeconds: number;
   /** 开启后断线手动重连时自动 cd 回上次目录(连接时自动启用目录同步追踪 cwd)。 */
   restoreCwdOnReconnect: boolean;
+  /** SSH 交互式 shell 建立后自动执行的命令，支持换行分隔多条命令。 */
+  startupCommand: string;
 }
 
 export const SSH_DEFAULTS: SSHFormState = {
@@ -68,6 +71,7 @@ export const SSH_DEFAULTS: SSHFormState = {
   encryptedPrivateKeyPassphrase: "",
   keepAliveIntervalSeconds: 0,
   restoreCwdOnReconnect: false,
+  startupCommand: "",
   ...CONNECTION_DEFAULTS,
 };
 
@@ -137,6 +141,10 @@ export function buildSSHConfig(state: SSHFormState, opts: SSHBuildOptions): stri
     cfg.restore_cwd_on_reconnect = true;
   }
 
+  if (state.startupCommand.trim()) {
+    cfg.startup_command = state.startupCommand;
+  }
+
   return JSON.stringify(cfg);
 }
 
@@ -162,6 +170,7 @@ export function parseSSHConfig(configJSON: string, assetTunnelId = 0): SSHFormSt
       encryptedPrivateKeyPassphrase: cfg.private_key_passphrase || "",
       keepAliveIntervalSeconds: cfg.keepalive_interval_seconds || 0,
       restoreCwdOnReconnect: cfg.restore_cwd_on_reconnect || false,
+      startupCommand: cfg.startup_command || "",
       ...parseConnectionFields(cfg.proxy, tunnelId, cfg.proxy_chain),
     };
   } catch {

--- a/frontend/src/components/asset/SSHConfigSection.tsx
+++ b/frontend/src/components/asset/SSHConfigSection.tsx
@@ -527,6 +527,15 @@ export function SSHConfigSection({ editAsset, onValidityChange, ref }: ConfigSec
       label: "asset.tabAdvanced",
       fields: [
         {
+          kind: "textarea",
+          key: "startupCommand",
+          label: "asset.sshStartupCommand",
+          rows: 4,
+          mono: true,
+          testid: "ssh-startup-command-input",
+          placeholder: "asset.sshStartupCommandPlaceholder",
+        },
+        {
           kind: "custom",
           render: (s, patchState) => {
             // 创建态默认写入全局值；清空则回落为 0＝跟随全局(config 不写)。编辑态直读已存值。

--- a/frontend/src/components/asset/SSHConfigSection.tsx
+++ b/frontend/src/components/asset/SSHConfigSection.tsx
@@ -534,6 +534,7 @@ export function SSHConfigSection({ editAsset, onValidityChange, ref }: ConfigSec
           mono: true,
           testid: "ssh-startup-command-input",
           placeholder: "asset.sshStartupCommandPlaceholder",
+          hint: "asset.sshStartupCommandHint",
         },
         {
           kind: "custom",

--- a/frontend/src/components/asset/__tests__/SSHConfigSection.config.test.ts
+++ b/frontend/src/components/asset/__tests__/SSHConfigSection.config.test.ts
@@ -207,6 +207,19 @@ describe("buildSSHConfig (锁旧 save/test 序:host→port→username→auth_typ
       );
     });
   });
+
+  describe("startupCommand 启动命令(空值不写入)", () => {
+    it("非空 → 写 startup_command", () => {
+      expect(buildSSHConfig(base({ startupCommand: "cd /data" }), NO_SECRETS)).toBe(
+        '{"host":"1.2.3.4","port":22,"username":"root","auth_type":"password","startup_command":"cd /data"}'
+      );
+    });
+    it("空值 → 省略", () => {
+      expect(buildSSHConfig(base({ startupCommand: "" }), NO_SECRETS)).toBe(
+        '{"host":"1.2.3.4","port":22,"username":"root","auth_type":"password"}'
+      );
+    });
+  });
 });
 
 describe("parseSSHConfig (镜像旧 loadSSHConfig)", () => {
@@ -285,6 +298,14 @@ describe("parseSSHConfig (镜像旧 loadSSHConfig)", () => {
     expect(parseSSHConfig('{"host":"h","port":22,"username":"u","auth_type":"password"}').restoreCwdOnReconnect).toBe(
       false
     );
+  });
+
+  it("startup_command → startupCommand;缺省为空", () => {
+    expect(
+      parseSSHConfig('{"host":"h","port":22,"username":"u","auth_type":"password","startup_command":"cd /data"}')
+        .startupCommand
+    ).toBe("cd /data");
+    expect(parseSSHConfig('{"host":"h","port":22,"username":"u","auth_type":"password"}').startupCommand).toBe("");
   });
 
   it("agent:agent_source_id/agent_key_fingerprint → agentSourceId/agentKeyFingerprint;残留互斥字段不进入 agent 态", () => {

--- a/frontend/src/components/asset/__tests__/SSHConfigSection.test.tsx
+++ b/frontend/src/components/asset/__tests__/SSHConfigSection.test.tsx
@@ -257,10 +257,27 @@ describe("SSHConfigSection 托管凭据→用户名自动填充", () => {
   });
 });
 
-describe("SSHConfigSection 保活预填(新建跟随全局)", () => {
+describe("SSHConfigSection 高级设置", () => {
   // GetSSHConnectionSettings mock 返回全局默认 30;保活输入在「高级」标签,需先切换。
   const openAdvanced = async (u: ReturnType<typeof userEvent.setup>) =>
     u.click(await screen.findByTestId("config-tab-advanced"));
+
+  it("启动命令在高级页编辑并写入配置", async () => {
+    const u = userEvent.setup();
+    const ref = createRef<AssetFormHandle>();
+    render(<SSHConfigSection ref={ref} ctx={ctx} onValidityChange={() => {}} />);
+    await openAdvanced(u);
+
+    const input = await screen.findByTestId("ssh-startup-command-input");
+    await u.type(input, "cd /data");
+    await u.keyboard("{Enter}");
+    await u.type(input, "docker compose ps");
+
+    const built = await ref.current!.buildConfig(ctx);
+    expect((JSON.parse(built.configJSON) as { startup_command?: string }).startup_command).toBe(
+      "cd /data\ndocker compose ps"
+    );
+  });
 
   it("新建:保活输入预填全局默认(30),未改动 → buildConfig 写 keepalive_interval_seconds:30", async () => {
     const u = userEvent.setup();

--- a/frontend/src/components/asset/configFields.tsx
+++ b/frontend/src/components/asset/configFields.tsx
@@ -58,6 +58,7 @@ export type FieldDesc<S> = WithVisibility<S> &
         placeholder?: string;
         required?: boolean;
         mono?: boolean;
+        testid?: string;
       }
     | { kind: "row"; fields: FieldDesc<S>[] }
     | {
@@ -187,6 +188,7 @@ function FieldNode<S>({
       return (
         <Field label={t(field.label)} required={field.required}>
           <Textarea
+            data-testid={field.testid}
             value={String(state[field.key] ?? "")}
             rows={field.rows}
             placeholder={field.placeholder ? t(field.placeholder, { defaultValue: field.placeholder }) : undefined}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -787,6 +787,8 @@
     "sshKeepAliveInterval": "Idle keep-alive interval",
     "sshKeepAliveIntervalPlaceholder": "Follow global default ({{seconds}}s)",
     "sshRestoreCwdOnReconnect": "Restore last directory on reconnect",
+    "sshStartupCommand": "Run command after connecting",
+    "sshStartupCommandPlaceholder": "cd /",
     "tabSchemaRegistry": "Schema Registry",
     "tabConnect": "Connect",
     "addDescription": "Add description"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -789,6 +789,7 @@
     "sshRestoreCwdOnReconnect": "Restore last directory on reconnect",
     "sshStartupCommand": "Run command after connecting",
     "sshStartupCommandPlaceholder": "cd /",
+    "sshStartupCommandHint": "Runs on every connect and reconnect, and in every split pane. With “Restore last directory on reconnect” enabled it runs after the directory is restored.",
     "tabSchemaRegistry": "Schema Registry",
     "tabConnect": "Connect",
     "addDescription": "Add description"

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -787,6 +787,8 @@
     "sshKeepAliveInterval": "空闲保活间隔",
     "sshKeepAliveIntervalPlaceholder": "跟随全局默认（{{seconds}} 秒）",
     "sshRestoreCwdOnReconnect": "重连恢复上次目录",
+    "sshStartupCommand": "连接后执行命令",
+    "sshStartupCommandPlaceholder": "cd /",
     "tabSchemaRegistry": "Schema Registry",
     "tabConnect": "Connect",
     "addDescription": "添加备注"

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -789,6 +789,7 @@
     "sshRestoreCwdOnReconnect": "重连恢复上次目录",
     "sshStartupCommand": "连接后执行命令",
     "sshStartupCommandPlaceholder": "cd /",
+    "sshStartupCommandHint": "每次连接（含重连）与每个分屏窗格都会执行；同时开启「重连恢复上次目录」时，在恢复目录之后执行。",
     "tabSchemaRegistry": "Schema Registry",
     "tabConnect": "Connect",
     "addDescription": "添加备注"

--- a/internal/app/ssh/ssh_ops.go
+++ b/internal/app/ssh/ssh_ops.go
@@ -79,6 +79,7 @@ func (s *SSH) ConnectSSH(req SSHConnectRequest) (string, error) {
 		KeepAliveIntervalSeconds: sshCfg.KeepAliveIntervalSeconds,
 		RestoreCwdOnReconnect:    sshCfg.RestoreCwdOnReconnect,
 		InitialWorkdir:           req.InitialWorkdir,
+		StartupCommand:           sshCfg.StartupCommand,
 		OnData: func(sid string, data []byte) {
 			wailsRuntime.EventsEmit(s.ctx, "ssh:data:"+sid, base64.StdEncoding.EncodeToString(data))
 		},
@@ -231,6 +232,7 @@ func (s *SSH) ConnectSSHAsync(req SSHConnectRequest) (string, error) {
 			KeepAliveIntervalSeconds: sshCfg.KeepAliveIntervalSeconds,
 			RestoreCwdOnReconnect:    sshCfg.RestoreCwdOnReconnect,
 			InitialWorkdir:           req.InitialWorkdir,
+			StartupCommand:           sshCfg.StartupCommand,
 			OnData: func(sid string, data []byte) {
 				wailsRuntime.EventsEmit(s.ctx, "ssh:data:"+sid, base64.StdEncoding.EncodeToString(data))
 			},

--- a/internal/model/entity/asset_entity/asset.go
+++ b/internal/model/entity/asset_entity/asset.go
@@ -124,6 +124,8 @@ type SSHConfig struct {
 	// RestoreCwdOnReconnect 开启后，该资产 SSH 终端断线手动重连时自动 cd 回上次目录，
 	// 并在连接时自动启用目录同步以持续追踪 cwd（仅 bash/zsh/ksh/mksh）。
 	RestoreCwdOnReconnect bool `json:"restore_cwd_on_reconnect,omitempty"`
+	// StartupCommand 在 SSH 交互式 shell 建立后自动执行。支持以换行分隔的多条命令。
+	StartupCommand string `json:"startup_command,omitempty"`
 	// AgentSourceID 是 Agent 模式（AuthType=agent）选用的 SSH Agent 来源 ID，
 	// 必须是正数且对应现存来源（引用完整性由服务/写入边界兜底）。
 	AgentSourceID int64 `json:"agent_source_id,omitempty"`

--- a/internal/model/entity/asset_entity/asset_test.go
+++ b/internal/model/entity/asset_entity/asset_test.go
@@ -72,6 +72,7 @@ func TestAsset_SSHConfig(t *testing.T) {
 				Username:              "admin",
 				AuthType:              AuthTypeKey,
 				RestoreCwdOnReconnect: true,
+				StartupCommand:        "cd /data\ndocker compose ps",
 			}
 			err := a.SetSSHConfig(cfg)
 			assert.NoError(t, err)
@@ -83,6 +84,7 @@ func TestAsset_SSHConfig(t *testing.T) {
 			assert.Equal(t, cfg.Username, got.Username)
 			assert.Equal(t, cfg.AuthType, got.AuthType)
 			assert.Equal(t, cfg.RestoreCwdOnReconnect, got.RestoreCwdOnReconnect)
+			assert.Equal(t, cfg.StartupCommand, got.StartupCommand)
 		})
 
 		convey.Convey("非SSH类型调用GetSSHConfig应返回错误", func() {

--- a/internal/service/external_edit_svc/service_rebind_test.go
+++ b/internal/service/external_edit_svc/service_rebind_test.go
@@ -1511,10 +1511,16 @@ func TestExternalEditAutoSaveStillEntersConflictAfterRemoteCompare(t *testing.T)
 	h.remote.SetFile("ssh-b", "/srv/app/demo.txt", []byte("remote changed\n"), "/srv/app/demo.txt")
 	h.svc.reconcileLocalCopy(session.ID)
 
-	require.Eventually(t, func() bool {
-		current := h.refreshSession(t, session.ID)
-		return current.State == sessionStateConflict
-	}, 2*time.Second, 20*time.Millisecond)
+	// 冲突事件是会话状态落库、审计写完之后才发出的，只等 State 会在事件到达前就放行。
+	hasConflictEvent := func() bool {
+		for _, event := range h.snapshotEvents() {
+			if event.Type == eventSessionConflict && event.Session != nil && event.Session.ID == session.ID && event.SaveResult != nil {
+				return true
+			}
+		}
+		return false
+	}
+	require.Eventually(t, hasConflictEvent, 2*time.Second, 20*time.Millisecond)
 
 	current := h.refreshSession(t, session.ID)
 	require.Equal(t, sessionStateConflict, current.State)

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -281,7 +281,8 @@ type ConnectConfig struct {
 	// InitialWorkdir 仅在重连路径由前端携带上次已知 cwd；首次连接为空。
 	// 实际是否恢复由 RestoreCwdOnReconnect 权威闸门决定。
 	InitialWorkdir string
-	// StartupCommand 在交互式 shell 建立后自动执行；空值不执行。
+	// StartupCommand 在交互式 shell 稳定后自动执行；空值不执行。
+	// 每次连接（含重连）与每个分屏窗格都会执行一次。
 	StartupCommand string
 }
 
@@ -356,33 +357,29 @@ func (m *Manager) Connect(cfg ConnectConfig) (string, error) {
 
 	emitProgress(&cfg, "shell", "正在启动终端...")
 
-	sessionID, err := m.createSession(shared, cfg.AssetID, cfg.Cols, cfg.Rows, cfg.OnData, cfg.OnClosed, cfg.OnSync, cfg.StartupCommand)
+	sess, err := m.createSession(shared, cfg.AssetID, cfg.Cols, cfg.Rows, cfg.OnData, cfg.OnClosed, cfg.OnSync, cfg.StartupCommand)
 	if err != nil {
 		shared.release()
 		return "", err
 	}
 
 	if cfg.RestoreCwdOnReconnect {
-		if sess, ok := m.GetSession(sessionID); ok {
-			// 恢复：重连时 cd 回上次目录（首次连接 InitialWorkdir 为空 → no-op）。
-			if err := sess.RestoreWorkingDirectory(cfg.InitialWorkdir); err != nil {
-				logger.Default().Warn("restore cwd on reconnect failed",
-					zap.String("sessionID", sessionID), zap.String("cwd", cfg.InitialWorkdir), zap.Error(err))
-			}
+		// 恢复：重连时 cd 回上次目录（首次连接 InitialWorkdir 为空 → no-op）。
+		if err := sess.RestoreWorkingDirectory(cfg.InitialWorkdir); err != nil {
+			logger.Default().Warn("restore cwd on reconnect failed",
+				zap.String("sessionID", sess.ID), zap.String("cwd", cfg.InitialWorkdir), zap.Error(err))
 		}
 	}
-	if err := m.runStartupCommand(sessionID); err != nil {
-		m.Disconnect(sessionID)
-		return "", err
-	}
-	if cfg.RestoreCwdOnReconnect {
-		if sess, ok := m.GetSession(sessionID); ok {
+	// 两个自动注入串在同一 goroutine 里：启动命令先落地，同步 hook 才不会插到它前面。
+	go func() {
+		m.dispatchStartupCommand(sess)
+		if cfg.RestoreCwdOnReconnect {
 			// 捕获：延迟后自动启用目录同步，持续追踪 cwd 供下次重连。
-			go m.autoEnableDirectorySync(sess)
+			m.autoEnableDirectorySync(sess)
 		}
-	}
+	}()
 
-	return sessionID, nil
+	return sess.ID, nil
 }
 
 // ConnectClient 建立仅用于 SFTP/端口转发等非终端用途的 SSH 会话 ID。
@@ -408,14 +405,15 @@ func (m *Manager) ConnectClient(cfg ConnectConfig) (string, error) {
 	return sessionID, nil
 }
 
-// autoSyncSettleDelay 是自动启用目录同步前的等待，让 sshd 的 motd/首个 prompt 先落地，
-// 避免注入的 hook 脚本与其交错。设为变量便于测试缩短。
-var autoSyncSettleDelay = 1 * time.Second
+// shellSettleDelay 是连接建立后各类自动注入（目录同步 hook、启动命令）前的等待，
+// 让 sshd 的 motd 与 shell 首个 prompt 先落地。抢在 shell 接管 pty 之前写入时，
+// 行规程会先原样回显一遍内容、shell 拿到后再回显一遍。设为变量便于测试缩短。
+var shellSettleDelay = 1 * time.Second
 
 // autoEnableDirectorySync 在会话稳定后自动启用目录同步（用于「重连恢复上次目录」的 cwd 捕获）。
 // best-effort：不支持的 shell / 超时只记 Warn，不影响会话本身。
 func (m *Manager) autoEnableDirectorySync(sess *Session) {
-	time.Sleep(autoSyncSettleDelay)
+	time.Sleep(shellSettleDelay)
 	if sess.IsClosed() {
 		return
 	}
@@ -426,34 +424,38 @@ func (m *Manager) autoEnableDirectorySync(sess *Session) {
 	}
 }
 
-func (m *Manager) runStartupCommand(sessionID string) error {
-	sess, ok := m.GetSession(sessionID)
-	if !ok {
-		return fmt.Errorf("会话不存在: %s", sessionID)
-	}
+// dispatchStartupCommand 在 shell 稳定后派发资产配置的启动命令。
+// best-effort：与「重连恢复上次目录」的 cd 一致，写入失败只记 Warn，
+// 不牵连一条已经建立好的终端连接。
+func (m *Manager) dispatchStartupCommand(sess *Session) {
 	if strings.TrimSpace(sess.startupCommand) == "" {
-		return nil
+		return
 	}
-
 	logger.Default().Info("ssh startup command dispatch started",
-		zap.String("sessionID", sessionID), zap.Int64("assetID", sess.AssetID))
+		zap.String("sessionID", sess.ID), zap.Int64("assetID", sess.AssetID))
+
+	time.Sleep(shellSettleDelay)
+	if sess.IsClosed() {
+		logger.Default().Warn("ssh startup command dispatch skipped: session closed",
+			zap.String("sessionID", sess.ID), zap.Int64("assetID", sess.AssetID))
+		return
+	}
 	if err := sess.submitStartupCommand(sess.startupCommand); err != nil {
-		logger.Default().Error("ssh startup command dispatch failed",
-			zap.String("sessionID", sessionID), zap.Int64("assetID", sess.AssetID), zap.Error(err))
-		return fmt.Errorf("执行 SSH 启动命令失败: %w", err)
+		logger.Default().Warn("ssh startup command dispatch failed",
+			zap.String("sessionID", sess.ID), zap.Int64("assetID", sess.AssetID), zap.Error(err))
+		return
 	}
 	logger.Default().Info("ssh startup command dispatch completed",
-		zap.String("sessionID", sessionID), zap.Int64("assetID", sess.AssetID))
-	return nil
+		zap.String("sessionID", sess.ID), zap.Int64("assetID", sess.AssetID))
 }
 
 // createSession 在 sharedClient 上创建新的 SSH 会话（PTY + shell）
 func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows int,
-	onData func(string, []byte), onClosed func(string), onSync func(string, DirectorySyncState), startupCommand string) (string, error) {
+	onData func(string, []byte), onClosed func(string), onSync func(string, DirectorySyncState), startupCommand string) (*Session, error) {
 
 	session, err := shared.client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("创建会话失败: %w", err)
+		return nil, fmt.Errorf("创建会话失败: %w", err)
 	}
 
 	if cols <= 0 {
@@ -470,7 +472,7 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 		if closeErr := session.Close(); closeErr != nil {
 			logger.Default().Warn("close session after PTY request failure", zap.Error(closeErr))
 		}
-		return "", fmt.Errorf("请求PTY失败: %w", err)
+		return nil, fmt.Errorf("请求PTY失败: %w", err)
 	}
 
 	stdin, err := session.StdinPipe()
@@ -478,7 +480,7 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 		if closeErr := session.Close(); closeErr != nil {
 			logger.Default().Warn("close session after stdin pipe failure", zap.Error(closeErr))
 		}
-		return "", fmt.Errorf("获取stdin失败: %w", err)
+		return nil, fmt.Errorf("获取stdin失败: %w", err)
 	}
 
 	stdout, err := session.StdoutPipe()
@@ -486,7 +488,7 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 		if closeErr := session.Close(); closeErr != nil {
 			logger.Default().Warn("close session after stdout pipe failure", zap.Error(closeErr))
 		}
-		return "", fmt.Errorf("获取stdout失败: %w", err)
+		return nil, fmt.Errorf("获取stdout失败: %w", err)
 	}
 
 	sessionID := m.nextSessionID()
@@ -518,13 +520,13 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 		if closeErr := session.Close(); closeErr != nil {
 			logger.Default().Warn("close session after shell start failure", zap.Error(closeErr))
 		}
-		return "", fmt.Errorf("启动shell失败: %w", err)
+		return nil, fmt.Errorf("启动shell失败: %w", err)
 	}
 
 	m.sessions.Store(sessionID, sess)
 	go m.readOutput(sess)
 
-	return sessionID, nil
+	return sess, nil
 }
 
 // NewSessionFrom 在已有会话的连接上创建新会话（用于分割窗格）
@@ -541,17 +543,14 @@ func (m *Manager) NewSessionFrom(existingSessionID string, cols, rows int,
 
 	existing.shared.acquire()
 
-	sessionID, err := m.createSession(existing.shared, existing.AssetID, cols, rows, onData, onClosed, onSync, existing.startupCommand)
+	sess, err := m.createSession(existing.shared, existing.AssetID, cols, rows, onData, onClosed, onSync, existing.startupCommand)
 	if err != nil {
 		existing.shared.release()
 		return "", err
 	}
-	if err := m.runStartupCommand(sessionID); err != nil {
-		m.Disconnect(sessionID)
-		return "", err
-	}
+	go m.dispatchStartupCommand(sess)
 
-	return sessionID, nil
+	return sess.ID, nil
 }
 
 // dial 建立到目标的网络连接，支持代理和跳板机链

--- a/internal/service/ssh_svc/ssh.go
+++ b/internal/service/ssh_svc/ssh.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -75,19 +76,20 @@ func (sc *sharedClient) release() {
 
 // Session 表示一个活跃的 SSH 终端会话
 type Session struct {
-	ID          string
-	AssetID     int64
-	shared      *sharedClient
-	session     *ssh.Session
-	stdin       io.WriteCloser
-	stdout      io.Reader
-	mu          sync.Mutex
-	closed      bool
-	onData      func(data []byte)      // 终端输出回调
-	onClosed    func(sessionID string) // 会话关闭回调
-	onSync      func(sessionID string, state DirectorySyncState)
-	interactive bool
-	startedAt   time.Time
+	ID             string
+	AssetID        int64
+	shared         *sharedClient
+	session        *ssh.Session
+	stdin          io.WriteCloser
+	stdout         io.Reader
+	mu             sync.Mutex
+	closed         bool
+	onData         func(data []byte)      // 终端输出回调
+	onClosed       func(sessionID string) // 会话关闭回调
+	onSync         func(sessionID string, state DirectorySyncState)
+	interactive    bool
+	startedAt      time.Time
+	startupCommand string
 
 	// shellPath / shellType are detected lazily by EnableSync. Empty means no
 	// sync attempt has needed shell detection yet; "unsupported" means the
@@ -132,6 +134,21 @@ func (s *Session) Write(data []byte) error {
 		s.ensureSyncProbe()
 	}
 	return err
+}
+
+// submitStartupCommand submits the configured command to the interactive shell.
+// The value is intentionally sent verbatim (apart from terminal line-ending
+// normalization) because it is a user-authored shell command, not a path.
+func (s *Session) submitStartupCommand(command string) error {
+	command = strings.TrimRight(command, "\r\n")
+	if strings.TrimSpace(command) == "" {
+		return nil
+	}
+	command = strings.ReplaceAll(command, "\r\n", "\n")
+	command = strings.ReplaceAll(command, "\r", "\n")
+	command = strings.ReplaceAll(command, "\n", "\r")
+	data := append([]byte(command), '\r')
+	return s.Write(data)
 }
 
 // Resize 调整终端尺寸
@@ -264,6 +281,8 @@ type ConnectConfig struct {
 	// InitialWorkdir 仅在重连路径由前端携带上次已知 cwd；首次连接为空。
 	// 实际是否恢复由 RestoreCwdOnReconnect 权威闸门决定。
 	InitialWorkdir string
+	// StartupCommand 在交互式 shell 建立后自动执行；空值不执行。
+	StartupCommand string
 }
 
 // JumpHostEntry 跳板机连接信息
@@ -337,7 +356,7 @@ func (m *Manager) Connect(cfg ConnectConfig) (string, error) {
 
 	emitProgress(&cfg, "shell", "正在启动终端...")
 
-	sessionID, err := m.createSession(shared, cfg.AssetID, cfg.Cols, cfg.Rows, cfg.OnData, cfg.OnClosed, cfg.OnSync)
+	sessionID, err := m.createSession(shared, cfg.AssetID, cfg.Cols, cfg.Rows, cfg.OnData, cfg.OnClosed, cfg.OnSync, cfg.StartupCommand)
 	if err != nil {
 		shared.release()
 		return "", err
@@ -350,6 +369,14 @@ func (m *Manager) Connect(cfg ConnectConfig) (string, error) {
 				logger.Default().Warn("restore cwd on reconnect failed",
 					zap.String("sessionID", sessionID), zap.String("cwd", cfg.InitialWorkdir), zap.Error(err))
 			}
+		}
+	}
+	if err := m.runStartupCommand(sessionID); err != nil {
+		m.Disconnect(sessionID)
+		return "", err
+	}
+	if cfg.RestoreCwdOnReconnect {
+		if sess, ok := m.GetSession(sessionID); ok {
 			// 捕获：延迟后自动启用目录同步，持续追踪 cwd 供下次重连。
 			go m.autoEnableDirectorySync(sess)
 		}
@@ -399,9 +426,30 @@ func (m *Manager) autoEnableDirectorySync(sess *Session) {
 	}
 }
 
+func (m *Manager) runStartupCommand(sessionID string) error {
+	sess, ok := m.GetSession(sessionID)
+	if !ok {
+		return fmt.Errorf("会话不存在: %s", sessionID)
+	}
+	if strings.TrimSpace(sess.startupCommand) == "" {
+		return nil
+	}
+
+	logger.Default().Info("ssh startup command dispatch started",
+		zap.String("sessionID", sessionID), zap.Int64("assetID", sess.AssetID))
+	if err := sess.submitStartupCommand(sess.startupCommand); err != nil {
+		logger.Default().Error("ssh startup command dispatch failed",
+			zap.String("sessionID", sessionID), zap.Int64("assetID", sess.AssetID), zap.Error(err))
+		return fmt.Errorf("执行 SSH 启动命令失败: %w", err)
+	}
+	logger.Default().Info("ssh startup command dispatch completed",
+		zap.String("sessionID", sessionID), zap.Int64("assetID", sess.AssetID))
+	return nil
+}
+
 // createSession 在 sharedClient 上创建新的 SSH 会话（PTY + shell）
 func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows int,
-	onData func(string, []byte), onClosed func(string), onSync func(string, DirectorySyncState)) (string, error) {
+	onData func(string, []byte), onClosed func(string), onSync func(string, DirectorySyncState), startupCommand string) (string, error) {
 
 	session, err := shared.client.NewSession()
 	if err != nil {
@@ -444,16 +492,17 @@ func (m *Manager) createSession(shared *sharedClient, assetID int64, cols, rows 
 	sessionID := m.nextSessionID()
 
 	sess := &Session{
-		ID:          sessionID,
-		AssetID:     assetID,
-		shared:      shared,
-		session:     session,
-		stdin:       stdin,
-		stdout:      stdout,
-		onData:      func(data []byte) { onData(sessionID, data) },
-		onClosed:    onClosed,
-		interactive: true,
-		startedAt:   time.Now(),
+		ID:             sessionID,
+		AssetID:        assetID,
+		shared:         shared,
+		session:        session,
+		stdin:          stdin,
+		stdout:         stdout,
+		onData:         func(data []byte) { onData(sessionID, data) },
+		onClosed:       onClosed,
+		interactive:    true,
+		startedAt:      time.Now(),
+		startupCommand: startupCommand,
 	}
 	if onSync != nil {
 		sess.onSync = func(_ string, state DirectorySyncState) { onSync(sessionID, state) }
@@ -492,9 +541,13 @@ func (m *Manager) NewSessionFrom(existingSessionID string, cols, rows int,
 
 	existing.shared.acquire()
 
-	sessionID, err := m.createSession(existing.shared, existing.AssetID, cols, rows, onData, onClosed, onSync)
+	sessionID, err := m.createSession(existing.shared, existing.AssetID, cols, rows, onData, onClosed, onSync, existing.startupCommand)
 	if err != nil {
 		existing.shared.release()
+		return "", err
+	}
+	if err := m.runStartupCommand(sessionID); err != nil {
+		m.Disconnect(sessionID)
 		return "", err
 	}
 

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -552,6 +552,47 @@ func TestSession_SubmitStartupCommand(t *testing.T) {
 	})
 }
 
+func TestManager_DispatchStartupCommand(t *testing.T) {
+	original := shellSettleDelay
+	shellSettleDelay = 50 * time.Millisecond
+	t.Cleanup(func() { shellSettleDelay = original })
+	m := NewManager()
+
+	t.Run("submits only after the shell has settled", func(t *testing.T) {
+		stdin := &recordingWriteCloser{}
+		start := time.Now()
+		var submittedAfter time.Duration
+		stdin.onWrite = func([]byte) { submittedAfter = time.Since(start) }
+		sess := &Session{ID: "ssh-1", stdin: stdin, startupCommand: "cd /data"}
+
+		m.dispatchStartupCommand(sess)
+
+		assert.Equal(t, "cd /data\r", string(stdin.lastWrite()))
+		// 抢在 shell 接管 pty 之前写入，行规程会先原样回显一遍命令、shell 再回显一遍。
+		assert.GreaterOrEqual(t, submittedAfter, shellSettleDelay)
+	})
+
+	t.Run("session closed while settling writes nothing", func(t *testing.T) {
+		stdin := &recordingWriteCloser{}
+		sess := &Session{ID: "ssh-2", stdin: stdin, startupCommand: "cd /data", closed: true}
+
+		m.dispatchStartupCommand(sess)
+
+		assert.Equal(t, 0, stdin.writeCount())
+	})
+
+	t.Run("no startup command configured returns without settling", func(t *testing.T) {
+		stdin := &recordingWriteCloser{}
+		sess := &Session{ID: "ssh-3", stdin: stdin, startupCommand: "  "}
+		start := time.Now()
+
+		m.dispatchStartupCommand(sess)
+
+		assert.Equal(t, 0, stdin.writeCount())
+		assert.Less(t, time.Since(start), shellSettleDelay)
+	})
+}
+
 func TestSession_EnableSyncDoesNotWriteUserVisibleHookSource(t *testing.T) {
 	stdin := &recordingWriteCloser{}
 	sess := &Session{

--- a/internal/service/ssh_svc/ssh_test.go
+++ b/internal/service/ssh_svc/ssh_test.go
@@ -520,6 +520,38 @@ func TestSession_RestoreWorkingDirectory(t *testing.T) {
 	})
 }
 
+func TestSession_SubmitStartupCommand(t *testing.T) {
+	t.Run("empty command writes nothing", func(t *testing.T) {
+		stdin := &recordingWriteCloser{}
+		sess := &Session{stdin: stdin}
+
+		err := sess.submitStartupCommand("  \r\n")
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, stdin.writeCount())
+	})
+
+	t.Run("command is submitted to the interactive shell", func(t *testing.T) {
+		stdin := &recordingWriteCloser{}
+		sess := &Session{stdin: stdin}
+
+		err := sess.submitStartupCommand("cd /data")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "cd /data\r", string(stdin.lastWrite()))
+	})
+
+	t.Run("multiline command uses terminal carriage returns without adding a blank command", func(t *testing.T) {
+		stdin := &recordingWriteCloser{}
+		sess := &Session{stdin: stdin}
+
+		err := sess.submitStartupCommand("cd /data\r\ndocker compose ps\n")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "cd /data\rdocker compose ps\r", string(stdin.lastWrite()))
+	})
+}
+
 func TestSession_EnableSyncDoesNotWriteUserVisibleHookSource(t *testing.T) {
 	stdin := &recordingWriteCloser{}
 	sess := &Session{


### PR DESCRIPTION
<!-- 标题请使用 gitmoji / Use gitmoji in title: ✨ Feature / 🐛 Bugfix / ♻️ Refactor / 🎨 UI / ⚡️ Perf / 🔒 Security / 🔧 Chore / ✅ Tests / 📄 Docs -->

## 变更说明 / Summary

<!-- 简述改动内容与动机 / What changed and why -->

SSH 高级配置新增连接后执行命令，支持多行输入和中英文提示，空白配置不持久化。

交互式 shell 建立后派发启动命令；重连先恢复工作目录再执行，分屏会话继承同一配置。命令换行统一为终端回车，并记录不含命令内容的派发日志。

补充配置序列化、表单交互和终端命令派发测试。

## 关联 Issue / Related Issue

Closes #298

## 截图 / Screenshots

<!-- UI 改动必填 / Required for UI changes -->

## 自检 / Checklist

- [x]  Fixes mentioned issues / 修复已提及的问题
- [x]  Code reviewed by human / 代码通过人工检查
- [x]  Changes tested / 已完成测试
