### PR TITLE
⚡️ 数据库表格与文件列表的性能优化：大字段渲染、选中重渲、无谓重算

### DIFF
--- a/frontend/src/__tests__/FileManagerPanel.test.tsx
+++ b/frontend/src/__tests__/FileManagerPanel.test.tsx
@@ -1217,6 +1217,61 @@ describe("FileManagerPanel", () => {
     expect(screen.queryByText("externalEdit.recovery.title")).not.toBeInTheDocument();
   });
 
+  it("selects one row on click, toggles with ctrl-click, and takes a range on shift-click", async () => {
+    vi.mocked(SFTPListDir).mockResolvedValue([
+      { name: "a.log", isDir: false, size: 1, modTime: 0 },
+      { name: "b.log", isDir: false, size: 2, modTime: 0 },
+      { name: "c.log", isDir: false, size: 3, modTime: 0 },
+      { name: "d.log", isDir: false, size: 4, modTime: 0 },
+    ]);
+
+    render(<FileManagerPanel tabId="tab1" sessionId="s1" isOpen width={280} onWidthChange={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("a.log")).toBeInTheDocument());
+
+    const row = (name: string) => screen.getByText(name).closest("[data-sftp-entry-row]") as HTMLElement;
+    const selectedNames = () =>
+      Array.from(document.querySelectorAll("[data-sftp-entry-row]"))
+        .filter((el) => el.className.includes("bg-primary/15"))
+        .map((el) => el.textContent?.match(/^[a-d]\.log/)?.[0])
+        .filter(Boolean);
+
+    fireEvent.click(row("b.log"));
+    expect(selectedNames()).toEqual(["b.log"]);
+
+    // ctrl-click adds, then removes the same row
+    fireEvent.click(row("d.log"), { ctrlKey: true });
+    expect(selectedNames()).toEqual(["b.log", "d.log"]);
+    fireEvent.click(row("d.log"), { ctrlKey: true });
+    expect(selectedNames()).toEqual(["b.log"]);
+
+    // plain click collapses back to a single row
+    fireEvent.click(row("a.log"));
+    expect(selectedNames()).toEqual(["a.log"]);
+
+    // shift-click takes the whole range from the last clicked row
+    fireEvent.click(row("c.log"), { shiftKey: true });
+    expect(selectedNames()).toEqual(["a.log", "b.log", "c.log"]);
+  });
+
+  it("clears the selection when clicking empty space below the rows", async () => {
+    vi.mocked(SFTPListDir).mockResolvedValue([{ name: "a.log", isDir: false, size: 1, modTime: 0 }]);
+
+    const { container } = render(
+      <FileManagerPanel tabId="tab1" sessionId="s1" isOpen width={280} onWidthChange={vi.fn()} />
+    );
+    await waitFor(() => expect(screen.getByText("a.log")).toBeInTheDocument());
+
+    const row = screen.getByText("a.log").closest("[data-sftp-entry-row]") as HTMLElement;
+    fireEvent.click(row);
+    expect(row.className).toContain("bg-primary/15");
+
+    const scroller = container.querySelector("[data-sftp-entry-row]")!.closest("div.text-xs")!.parentElement!;
+    fireEvent.click(scroller);
+    expect((screen.getByText("a.log").closest("[data-sftp-entry-row]") as HTMLElement).className).not.toContain(
+      "bg-primary/15"
+    );
+  });
+
   it("moves a dragged file into a dropped folder", async () => {
     vi.mocked(SFTPListDir).mockResolvedValue([
       { name: "logs", isDir: true, size: 0, modTime: 0 },

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -834,3 +834,50 @@ describe("QueryResultTable — very large cell values", () => {
     expect(input.value).toBe(big);
   });
 });
+
+describe("QueryResultTable — selection re-render scope", () => {
+  const columns = ["id", "name", "email", "city", "note"];
+  const rows = Array.from({ length: 12 }, (_, i) => ({
+    id: i,
+    name: `name-${i}`,
+    email: `u${i}@example.com`,
+    city: `city-${i}`,
+    note: `note-${i}`,
+  }));
+
+  function renderTable() {
+    const renderCell = vi.fn((value: unknown) => <span>{String(value)}</span>);
+    render(<QueryResultTable columns={columns} rows={rows} renderCell={renderCell} />);
+    return renderCell;
+  }
+
+  const cell = (rowIdx: number, col: string) =>
+    document.querySelector(`[data-cell-key="${rowIdx}:${col}"]`) as HTMLElement;
+
+  it("moving the selected cell re-renders only the cells whose state changed", () => {
+    const renderCell = renderTable();
+    const total = document.querySelectorAll("td[data-cell-key]").length;
+    expect(total).toBeGreaterThan(20); // 保证这个断言有意义
+
+    fireEvent.click(cell(0, "name"));
+    renderCell.mockClear();
+    fireEvent.click(cell(3, "city"));
+
+    // 只有"失去选中"和"获得选中"这两个格子需要重渲染。
+    expect(renderCell.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  it("selecting a whole column re-renders that column, not the whole table", () => {
+    const renderCell = renderTable();
+    const total = document.querySelectorAll("td[data-cell-key]").length;
+
+    fireEvent.click(screen.getByText("name"));
+    renderCell.mockClear();
+    fireEvent.click(screen.getByText("email"));
+
+    // 两列的格子换了外观,其余不动。
+    const rowsRendered = document.querySelectorAll("tr[data-index]").length;
+    expect(renderCell.mock.calls.length).toBeLessThanOrEqual(rowsRendered * 2 + 2);
+    expect(renderCell.mock.calls.length).toBeLessThan(total);
+  });
+});

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, it, expect, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryResultTable } from "@/components/query/QueryResultTable";
-import { cellValueToText } from "@/lib/cellValue";
+import { CELL_DISPLAY_MAX_CHARS, cellValueToDisplayText, cellValueToText } from "@/lib/cellValue";
 
 const { toastError, toastSuccess } = vi.hoisted(() => ({
   toastError: vi.fn(),
@@ -754,5 +754,83 @@ describe("QueryResultTable — cell context actions", () => {
 
     rerender(<QueryResultTable columns={columns} rows={rows} rowDensity="comfortable" />);
     expect(document.querySelector('[data-cell-key="0:name"]')).toHaveClass("py-2");
+  });
+});
+
+describe("cellValueToDisplayText", () => {
+  it("passes short values through unchanged", () => {
+    expect(cellValueToDisplayText("hello")).toBe("hello");
+    expect(cellValueToDisplayText(42)).toBe("42");
+    expect(cellValueToDisplayText(null)).toBe("");
+    expect(cellValueToDisplayText({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it("caps a value at the display limit and marks the cut", () => {
+    const out = cellValueToDisplayText("x".repeat(200_000));
+    expect(out).toHaveLength(CELL_DISPLAY_MAX_CHARS + 1);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("caps stringified objects as well", () => {
+    const out = cellValueToDisplayText({ blob: "x".repeat(200_000) });
+    expect(out).toHaveLength(CELL_DISPLAY_MAX_CHARS + 1);
+  });
+
+  it("keeps a value exactly at the limit intact", () => {
+    const exact = "x".repeat(CELL_DISPLAY_MAX_CHARS);
+    expect(cellValueToDisplayText(exact)).toBe(exact);
+  });
+});
+
+describe("QueryResultTable — very large cell values", () => {
+  const big = "x".repeat(200_000);
+  const columns = ["id", "payload"];
+  const rows = [
+    { id: 1, payload: big },
+    { id: 2, payload: "small" },
+  ];
+
+  it("puts only a bounded slice of the value into the cell DOM", () => {
+    render(<QueryResultTable columns={columns} rows={rows} />);
+    const cell = document.querySelector('[data-cell-key="0:payload"]') as HTMLElement;
+    expect(cell.textContent!.length).toBeLessThanOrEqual(CELL_DISPLAY_MAX_CHARS + 1);
+  });
+
+  it("bounds the cell tooltip too", () => {
+    render(<QueryResultTable columns={columns} rows={rows} />);
+    const cell = document.querySelector('[data-cell-key="0:payload"]') as HTMLElement;
+    expect(cell.getAttribute("title")!.length).toBeLessThanOrEqual(CELL_DISPLAY_MAX_CHARS + 1);
+  });
+
+  it("still copies the untruncated value", () => {
+    render(<QueryResultTable columns={columns} rows={rows} editable />);
+    fireEvent.contextMenu(document.querySelector('[data-cell-key="0:payload"]') as HTMLElement, {
+      clientX: 40,
+      clientY: 50,
+    });
+    fireEvent.click(screen.getByText("query.copyValue"));
+
+    expect(writeText).toHaveBeenCalledWith(big);
+  });
+
+  it("keeps the filter popover labels bounded", async () => {
+    const user = userEvent.setup();
+    render(<QueryResultTable columns={columns} rows={rows} enableColumnFilter />);
+    await user.click(screen.getAllByTitle("query.filterColumn")[1]);
+
+    const popover = await screen.findByRole("dialog");
+    for (const label of popover.querySelectorAll("label")) {
+      expect(label.textContent!.length).toBeLessThanOrEqual(CELL_DISPLAY_MAX_CHARS + 20);
+    }
+  });
+
+  it("still edits against the untruncated value", async () => {
+    const onSetCellValue = vi.fn();
+    render(<QueryResultTable columns={columns} rows={rows} editable onSetCellValue={onSetCellValue} />);
+    const cell = document.querySelector('[data-cell-key="0:payload"]') as HTMLElement;
+    fireEvent.doubleClick(cell);
+
+    const input = cell.querySelector("input") as HTMLInputElement;
+    expect(input.value).toBe(big);
   });
 });

--- a/frontend/src/__tests__/RedisKeyDetail.test.tsx
+++ b/frontend/src/__tests__/RedisKeyDetail.test.tsx
@@ -108,6 +108,42 @@ describe("RedisKeyDetail", () => {
     expect(within(valueBox).getByText("true")).toHaveClass("text-syntax-boolean");
   });
 
+  it("renders the same value as raw / hex / base64 when switching view modes", () => {
+    useQueryStore.setState((s) => ({
+      redisStates: {
+        ...s.redisStates,
+        "query-10": {
+          ...s.redisStates["query-10"],
+          selectedKey: "bin:1",
+          keyInfo: {
+            type: "string",
+            ttl: -1,
+            size: 5,
+            total: -1,
+            value: "hi 中",
+            valueCursor: "",
+            valueOffset: 0,
+            hasMoreValues: false,
+            loadingMore: false,
+          },
+        },
+      },
+    }));
+
+    render(<RedisKeyDetail tabId="query-10" />);
+
+    expect(screen.getByTestId("redis-string-value").textContent).toBe("hi 中");
+
+    fireEvent.click(screen.getByText("Hex"));
+    expect(screen.getByTestId("redis-string-value").textContent).toBe("686920e4b8ad");
+
+    fireEvent.click(screen.getByText("Base64"));
+    expect(screen.getByTestId("redis-string-value").textContent).toBe("aGkg5Lit");
+
+    fireEvent.click(screen.getByText("query.rawText"));
+    expect(screen.getByTestId("redis-string-value").textContent).toBe("hi 中");
+  });
+
   it("executes command input with quoted arguments preserved", async () => {
     vi.mocked(ExecuteRedisArgs).mockResolvedValue(JSON.stringify({ type: "string", value: "OK" }));
 

--- a/frontend/src/__tests__/TableFilterBuilder.test.tsx
+++ b/frontend/src/__tests__/TableFilterBuilder.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TableFilterBuilder } from "@/components/query/TableFilterBuilder";
 import { createFilterCondition, type TableFilterItem, type TableSortItem } from "@/lib/tableFilter";
+import { CELL_DISPLAY_MAX_CHARS, cellValueToDisplayText } from "@/lib/cellValue";
 
 describe("TableFilterBuilder", () => {
   it("shows distinct suggested values and writes the selected value into the condition", async () => {
@@ -340,5 +341,41 @@ describe("TableFilterBuilder", () => {
     await user.click(screen.getByTitle("query.toggleSortDirection:id"));
 
     expect(onSortsChange).toHaveBeenLastCalledWith([expect.objectContaining({ column: "id", dir: "desc" })]);
+  });
+});
+
+describe("TableFilterBuilder — very large values", () => {
+  const big = "x".repeat(200_000);
+
+  it("bounds the suggestion labels and still selects the untruncated value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <TableFilterBuilder
+        columns={["id", "body"]}
+        rows={[
+          { id: 1, body: big },
+          { id: 2, body: "small" },
+        ]}
+        filters={[createFilterCondition("f-body", "body")]}
+        sorts={[]}
+        driver="mysql"
+        onChange={onChange}
+        onSortsChange={vi.fn()}
+        onApply={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByTitle("query.chooseFilterValue"));
+    const panel = await screen.findByRole("dialog");
+    expect(panel.textContent!.length).toBeLessThan(CELL_DISPLAY_MAX_CHARS * 3);
+
+    const option = within(panel).getByText(cellValueToDisplayText(big));
+    await user.click(option);
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ kind: "condition", column: "body", value: big }),
+    ]);
   });
 });

--- a/frontend/src/components/query/MongoDBResultView.tsx
+++ b/frontend/src/components/query/MongoDBResultView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ChevronLeft, ChevronRight, ChevronsLeft, RefreshCw, Loader2 } from "lucide-react";
 import { Button, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@opskat/ui";
 import { QueryResultTable } from "./QueryResultTable";
+import { cellValueToDisplayText } from "@/lib/cellValue";
 import { CodeEditor } from "@/components/CodeEditor";
 
 interface MongoDBResultViewProps {
@@ -221,8 +222,9 @@ export function MongoDBResultView({
 }
 
 // Primitives render as strings; objects/arrays get a truncated single-line JSON
-// preview. Full value is available via hover title and right-click → copy
-// (handled by QueryResultTable).
+// preview. Both are length-capped — a multi-MB text node inside a `truncate`
+// line box costs seconds of layout in Chromium. Full value is available via
+// right-click → copy (handled by QueryResultTable).
 function renderMongoCell(value: unknown): React.ReactNode {
   if (value === null || value === undefined) {
     return <span className="text-muted-foreground italic">null</span>;
@@ -232,7 +234,7 @@ function renderMongoCell(value: unknown): React.ReactNode {
     const truncated = json.length > 80 ? json.slice(0, 80) + "…" : json;
     return <span className="text-muted-foreground truncate block">{truncated}</span>;
   }
-  return <span className="truncate block">{String(value)}</span>;
+  return <span className="truncate block">{cellValueToDisplayText(value)}</span>;
 }
 
 function safeStringify(v: unknown): string {

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -26,7 +26,7 @@ import { Popover, PopoverContent, PopoverTrigger, computeContextMenuPosition } f
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { toast } from "sonner";
 import { notifyCopied } from "@/lib/notify";
-import { cellValueToText } from "@/lib/cellValue";
+import { cellValueToDisplayText, cellValueToText } from "@/lib/cellValue";
 import type { CellValueFilterOperator } from "@/lib/tableSql";
 import { TABLE_FILTER_OPERATOR_LABEL_KEYS, TABLE_FILTER_OPERATOR_OPTIONS } from "@/lib/tableFilterOperators";
 
@@ -1418,7 +1418,7 @@ function QueryResultTableImpl({
                           maxWidth: `${width}px`,
                           ...(isFrozen ? { left: `${frozenLeft}px` } : {}),
                         }}
-                        title={displayValue == null ? "NULL" : cellValueToText(displayValue)}
+                        title={displayValue == null ? "NULL" : cellValueToDisplayText(displayValue)}
                         onClick={() => handleCellClick(origIdx, col)}
                         onDoubleClick={() => {
                           if (!editable) return;
@@ -1452,7 +1452,7 @@ function QueryResultTableImpl({
                               ) : displayValue == null ? (
                                 <span className="text-muted-foreground italic">NULL</span>
                               ) : (
-                                <span className="truncate block">{cellValueToText(displayValue)}</span>
+                                <span className="truncate block">{cellValueToDisplayText(displayValue)}</span>
                               )}
                             </div>
                             {showDateAction && (
@@ -2037,14 +2037,23 @@ function ColumnValuePanel({ col, entries, selected, onChange }: ColumnValuePanel
   const allKeys = useMemo(() => entries.map((e) => e.key), [entries]);
   const allChecked = allKeys.length > 0 && selectedSet.size === allKeys.length;
 
+  // 每个候选值的展示文本 + 小写检索键只算一次。以前是在 filter 回调里对原值
+  // cellValueToText().toLowerCase(),大字段(TEXT / JSON / BLOB)下每敲一个字符
+  // 就要把整列的字节重新分配一遍。检索范围与展示文本一致 —— 看不到的部分不参与匹配。
+  const decorated = useMemo(
+    () =>
+      entries.map((e) => {
+        const text = cellValueToDisplayText(e.value);
+        return { ...e, text, searchKey: text.toLowerCase() };
+      }),
+    [entries]
+  );
+
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    if (!q) return entries;
-    return entries.filter((e) => {
-      if (e.value == null) return "null".includes(q);
-      return cellValueToText(e.value).toLowerCase().includes(q);
-    });
-  }, [entries, search]);
+    if (!q) return decorated;
+    return decorated.filter((e) => (e.value == null ? "null".includes(q) : e.searchKey.includes(q)));
+  }, [decorated, search]);
 
   const showSearch = entries.length > 5;
 
@@ -2118,7 +2127,7 @@ function ColumnValuePanel({ col, entries, selected, onChange }: ColumnValuePanel
         ) : (
           filtered.map((entry) => {
             const checked = selectedSet.has(entry.key);
-            const text = cellValueToText(entry.value);
+            const text = entry.text;
             const label =
               entry.value == null ? (
                 <span className="text-muted-foreground italic">NULL</span>

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -111,6 +111,10 @@ interface QueryResultTableProps {
 const NULL_KEY = "__opskat_null_sentinel__";
 const DEFAULT_COLUMN_WIDTH = 160;
 
+// 复用同一个空集合,避免"清空选中"每次都产生新引用。
+// 安全的前提:本文件对选中集合一律整体替换,从不原地 add/delete。
+const EMPTY_ROW_SELECTION = new Set<number>();
+
 const CONTEXT_MENU_ITEM_CLASS =
   "relative flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground";
 
@@ -942,10 +946,13 @@ function QueryResultTableImpl({
     setCtxMenu(null);
   }, [ctxMenu, onDeleteRow]);
 
+  // 清空时复用同一个空 Set:普通的"点另一个单元格"不该让行选中状态换标识。
+  // 一旦换了,依赖它的 handleCellContextMenu 也换标识,memo 化的单元格全部失效,
+  // 每点一下就重渲染整屏 —— 正是要消掉的那笔开销。
   const selectCell = useCallback(
     (origIdx: number, col: string) => {
       setSelectedCell({ origIdx, col });
-      setSelectedRowIdxs(new Set());
+      setSelectedRowIdxs((prev) => (prev.size === 0 ? prev : EMPTY_ROW_SELECTION));
       onSelectedCellChange?.({ rowIdx: origIdx, col });
       onSelectedRowsChange?.([]);
       containerRef.current?.focus();
@@ -994,17 +1001,31 @@ function QueryResultTableImpl({
     [displayColumns, onSelectedCellChange, onSelectedRowsChange, selectedColumns]
   );
 
+  // handleCellContextMenu 会传给 memo 化的 ResultCell,必须是稳定引用。它只是"读一下
+  // 当前选中集合来决定分支",所以走 ref 镜像而不是进依赖数组 —— 否则每次改选中都会
+  // 换标识,把整屏单元格的 memo 全部打掉。右键只可能发生在 effect 冲洗之后,不会读到旧值。
+  const selectedRowIdxsRef = useRef(selectedRowIdxs);
+  const selectedColumnsRef = useRef(selectedColumns);
+  useEffect(() => {
+    selectedRowIdxsRef.current = selectedRowIdxs;
+  }, [selectedRowIdxs]);
+  useEffect(() => {
+    selectedColumnsRef.current = selectedColumns;
+  }, [selectedColumns]);
+
   const handleCellContextMenu = useCallback(
     (e: React.MouseEvent, origIdx: number, col: string, value: unknown) => {
       e.preventDefault();
       e.stopPropagation();
-      if (selectedRowIdxs.has(origIdx) || selectedColumns.has(col)) {
+      const selectedRowIdxsNow = selectedRowIdxsRef.current;
+      const selectedColumnsNow = selectedColumnsRef.current;
+      if (selectedRowIdxsNow.has(origIdx) || selectedColumnsNow.has(col)) {
         setSelectedCell({ origIdx, col });
-        if (!selectedRowIdxs.has(origIdx)) {
-          setSelectedRowIdxs(new Set());
+        if (!selectedRowIdxsNow.has(origIdx)) {
+          setSelectedRowIdxs(EMPTY_ROW_SELECTION);
           onSelectedRowsChange?.([]);
         }
-        if (!selectedColumns.has(col)) {
+        if (!selectedColumnsNow.has(col)) {
           setSelectedColumns(new Set());
           columnSelectionAnchorRef.current = null;
         }
@@ -1016,7 +1037,7 @@ function QueryResultTableImpl({
       setCtxMenuPosition(null);
       setCtxMenu({ kind: "cell", x: e.clientX, y: e.clientY, rowIdx: origIdx, col, value });
     },
-    [onSelectedCellChange, onSelectedRowsChange, selectCell, selectedRowIdxs, selectedColumns]
+    [onSelectedCellChange, onSelectedRowsChange, selectCell]
   );
 
   const handleColumnContextMenu = useCallback(
@@ -1056,6 +1077,11 @@ function QueryResultTableImpl({
     },
     [selectCell]
   );
+
+  // ResultCell 是 memo 化的,传给它的回调必须是稳定引用,否则 memo 每次都失效。
+  const handleStartEdit = useCallback((ck: string) => setEditingCell(ck), []);
+  const handleCancelEdit = useCallback(() => setEditingCell(null), []);
+  const openDateEditorLabel = t("query.openDateTimePicker");
 
   // Arrow key navigation + Enter/F2 to edit + Escape to deselect/cancel
   const handleKeyDown = useCallback(
@@ -1376,101 +1402,35 @@ function QueryResultTableImpl({
                 >
                   {displayColumns.map((col) => {
                     const ck = cellKey(origIdx, col);
-                    const isEdited = edits?.has(ck);
-                    const displayValue = isEdited ? edits!.get(ck) : row[col];
-                    const isEditing = editingCell === ck;
-                    const isSelected = selectedCell?.origIdx === origIdx && selectedCell?.col === col;
-                    const width = colWidths[col] ?? DEFAULT_COLUMN_WIDTH;
-                    const frozenLeft = frozenColumnOffsets[col];
-                    const isFrozen = frozenLeft != null;
-                    const dateModeForCell = getDateEditMode(col, columnTypes?.[col], displayValue);
-                    const showDateAction =
-                      editable && isSelected && !isEditing && !!dateModeForCell && !!setCellValueHandler;
-
-                    const focusPositionClass = isFrozen ? "z-20" : "relative z-10";
-                    const editedBgClass = isFrozen ? "query-table-frozen-cell-edited" : "bg-warning/15";
-                    const selectedBgClass = isFrozen ? "query-table-frozen-cell-selected" : "bg-primary/15";
-                    const editingBgClass = isFrozen ? "query-table-frozen-cell-focus" : "bg-primary/5";
-                    const focusClass = isEditing
-                      ? `ring-2 ring-inset ring-primary ${editingBgClass} ${focusPositionClass}`
-                      : isSelected
-                        ? `ring-2 ring-inset ring-primary/60 ${focusPositionClass}`
-                        : "";
-
+                    const isEdited = !!edits?.has(ck);
                     return (
-                      <td
+                      <ResultCell
                         key={col}
-                        data-cell-key={ck}
-                        data-row-selected={isRowSelected ? "true" : undefined}
-                        data-column-selected={selectedColumns.has(col) ? col : undefined}
-                        className={`border border-border px-2 ${cellPaddingClass} whitespace-nowrap cursor-default ${
-                          isEdited
-                            ? editedBgClass
-                            : isRowSelected || selectedColumns.has(col)
-                              ? selectedBgClass
-                              : isFrozen
-                                ? "bg-background"
-                                : ""
-                        } ${isFrozen ? "sticky z-10" : ""} ${focusClass}`}
-                        style={{
-                          width: `${width}px`,
-                          minWidth: `${width}px`,
-                          maxWidth: `${width}px`,
-                          ...(isFrozen ? { left: `${frozenLeft}px` } : {}),
-                        }}
-                        title={displayValue == null ? "NULL" : cellValueToDisplayText(displayValue)}
-                        onClick={() => handleCellClick(origIdx, col)}
-                        onDoubleClick={() => {
-                          if (!editable) return;
-                          setEditingCell(ck);
-                        }}
-                        onContextMenu={(e) => handleCellContextMenu(e, origIdx, col, displayValue)}
-                      >
-                        {isEditing ? (
-                          <input
-                            ref={inputRef}
-                            className="w-full bg-transparent outline-none border-none p-0 m-0 text-xs font-mono"
-                            defaultValue={cellValueToText(displayValue)}
-                            onBlur={(e) => commitEdit(origIdx, col, e.target.value)}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter") {
-                                // IME 合成中：让 Enter 作为候选词确认，不提交编辑
-
-                                if (e.nativeEvent.isComposing || e.keyCode === 229) return;
-                                commitEdit(origIdx, col, (e.target as HTMLInputElement).value);
-                              }
-                              if (e.key === "Escape") {
-                                setEditingCell(null);
-                              }
-                            }}
-                          />
-                        ) : (
-                          <div className="flex min-w-0 items-center gap-1">
-                            <div className="min-w-0 flex-1">
-                              {renderCell ? (
-                                renderCell(displayValue, { rowIdx: origIdx, col })
-                              ) : displayValue == null ? (
-                                <span className="text-muted-foreground italic">NULL</span>
-                              ) : (
-                                <span className="truncate block">{cellValueToDisplayText(displayValue)}</span>
-                              )}
-                            </div>
-                            {showDateAction && (
-                              <button
-                                type="button"
-                                className="flex h-6 w-7 shrink-0 items-center justify-center rounded bg-primary text-primary-foreground hover:bg-primary/90"
-                                title={t("query.openDateTimePicker")}
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  handleOpenDateEditorForCell(origIdx, col, displayValue, event);
-                                }}
-                              >
-                                <MoreHorizontal className="h-4 w-4" />
-                              </button>
-                            )}
-                          </div>
-                        )}
-                      </td>
+                        cellKeyStr={ck}
+                        origIdx={origIdx}
+                        col={col}
+                        value={isEdited ? edits!.get(ck) : row[col]}
+                        columnType={columnTypes?.[col]}
+                        isEdited={isEdited}
+                        isEditing={editingCell === ck}
+                        isSelected={selectedCell?.origIdx === origIdx && selectedCell?.col === col}
+                        isRowSelected={isRowSelected}
+                        isColumnSelected={selectedColumns.has(col)}
+                        width={colWidths[col] ?? DEFAULT_COLUMN_WIDTH}
+                        frozenLeft={frozenColumnOffsets[col]}
+                        paddingClass={cellPaddingClass}
+                        editable={!!editable}
+                        canSetCellValue={canSetCellValue}
+                        renderCell={renderCell}
+                        inputRef={inputRef}
+                        openDateEditorLabel={openDateEditorLabel}
+                        onSelect={handleCellClick}
+                        onStartEdit={handleStartEdit}
+                        onContextMenu={handleCellContextMenu}
+                        onCommitEdit={commitEdit}
+                        onCancelEdit={handleCancelEdit}
+                        onOpenDateEditor={handleOpenDateEditorForCell}
+                      />
                     );
                   })}
                 </tr>
@@ -2012,6 +1972,146 @@ interface ColumnValuePanelProps {
   selected: Set<string> | null;
   onChange: (next: Set<string> | null) => void;
 }
+
+interface ResultCellProps {
+  cellKeyStr: string;
+  origIdx: number;
+  col: string;
+  value: unknown;
+  columnType?: string;
+  isEdited: boolean;
+  isEditing: boolean;
+  isSelected: boolean;
+  isRowSelected: boolean;
+  isColumnSelected: boolean;
+  width: number;
+  frozenLeft?: number;
+  paddingClass: string;
+  editable: boolean;
+  canSetCellValue: boolean;
+  renderCell?: (value: unknown, ctx: RenderCellContext) => React.ReactNode;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  openDateEditorLabel: string;
+  onSelect: (origIdx: number, col: string) => void;
+  onStartEdit: (cellKeyStr: string) => void;
+  onContextMenu: (e: React.MouseEvent, origIdx: number, col: string, value: unknown) => void;
+  onCommitEdit: (origIdx: number, col: string, value: string) => void;
+  onCancelEdit: () => void;
+  onOpenDateEditor: (origIdx: number, col: string, value: unknown, event: React.MouseEvent) => void;
+}
+
+// 单元格独立 memo:选中态是表级 state,改一次会让整个 <tbody> 重跑。以前 40 行 × 25 列
+// 就是一次点击重建 1000 个 <td>(实测点击到反馈 p50 144ms);memo 之后只有"失去选中"和
+// "获得选中"这两个格子真正重渲染。className 拼接、getDateEditMode、cellValueToDisplayText
+// 也一并搬进来,让它们只在该格子真的变了时才算。
+const ResultCell = memo(function ResultCell({
+  cellKeyStr,
+  origIdx,
+  col,
+  value,
+  columnType,
+  isEdited,
+  isEditing,
+  isSelected,
+  isRowSelected,
+  isColumnSelected,
+  width,
+  frozenLeft,
+  paddingClass,
+  editable,
+  canSetCellValue,
+  renderCell,
+  inputRef,
+  openDateEditorLabel,
+  onSelect,
+  onStartEdit,
+  onContextMenu,
+  onCommitEdit,
+  onCancelEdit,
+  onOpenDateEditor,
+}: ResultCellProps) {
+  const isFrozen = frozenLeft != null;
+  const dateMode = getDateEditMode(col, columnType, value);
+  const showDateAction = editable && isSelected && !isEditing && !!dateMode && canSetCellValue;
+
+  const focusPositionClass = isFrozen ? "z-20" : "relative z-10";
+  const editedBgClass = isFrozen ? "query-table-frozen-cell-edited" : "bg-warning/15";
+  const selectedBgClass = isFrozen ? "query-table-frozen-cell-selected" : "bg-primary/15";
+  const editingBgClass = isFrozen ? "query-table-frozen-cell-focus" : "bg-primary/5";
+  const focusClass = isEditing
+    ? `ring-2 ring-inset ring-primary ${editingBgClass} ${focusPositionClass}`
+    : isSelected
+      ? `ring-2 ring-inset ring-primary/60 ${focusPositionClass}`
+      : "";
+
+  return (
+    <td
+      data-cell-key={cellKeyStr}
+      data-row-selected={isRowSelected ? "true" : undefined}
+      data-column-selected={isColumnSelected ? col : undefined}
+      className={`border border-border px-2 ${paddingClass} whitespace-nowrap cursor-default ${
+        isEdited ? editedBgClass : isRowSelected || isColumnSelected ? selectedBgClass : isFrozen ? "bg-background" : ""
+      } ${isFrozen ? "sticky z-10" : ""} ${focusClass}`}
+      style={{
+        width: `${width}px`,
+        minWidth: `${width}px`,
+        maxWidth: `${width}px`,
+        ...(isFrozen ? { left: `${frozenLeft}px` } : {}),
+      }}
+      title={value == null ? "NULL" : cellValueToDisplayText(value)}
+      onClick={() => onSelect(origIdx, col)}
+      onDoubleClick={() => {
+        if (!editable) return;
+        onStartEdit(cellKeyStr);
+      }}
+      onContextMenu={(e) => onContextMenu(e, origIdx, col, value)}
+    >
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          className="w-full bg-transparent outline-none border-none p-0 m-0 text-xs font-mono"
+          defaultValue={cellValueToText(value)}
+          onBlur={(e) => onCommitEdit(origIdx, col, e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              // IME 合成中:让 Enter 作为候选词确认,不提交编辑
+              if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+              onCommitEdit(origIdx, col, (e.target as HTMLInputElement).value);
+            }
+            if (e.key === "Escape") {
+              onCancelEdit();
+            }
+          }}
+        />
+      ) : (
+        <div className="flex min-w-0 items-center gap-1">
+          <div className="min-w-0 flex-1">
+            {renderCell ? (
+              renderCell(value, { rowIdx: origIdx, col })
+            ) : value == null ? (
+              <span className="text-muted-foreground italic">NULL</span>
+            ) : (
+              <span className="truncate block">{cellValueToDisplayText(value)}</span>
+            )}
+          </div>
+          {showDateAction && (
+            <button
+              type="button"
+              className="flex h-6 w-7 shrink-0 items-center justify-center rounded bg-primary text-primary-foreground hover:bg-primary/90"
+              title={openDateEditorLabel}
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenDateEditor(origIdx, col, value, event);
+              }}
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      )}
+    </td>
+  );
+});
 
 function ColumnValuePanel({ col, entries, selected, onChange }: ColumnValuePanelProps) {
   const { t } = useTranslation();

--- a/frontend/src/components/query/RedisStringEditor.tsx
+++ b/frontend/src/components/query/RedisStringEditor.tsx
@@ -73,18 +73,10 @@ export function RedisStringEditor({ tabId, t }: { tabId: string; t: (key: string
     }
   }, [originalVal]);
 
-  const hexValue = useMemo(
-    () => Array.from(new TextEncoder().encode(originalVal), (b) => b.toString(16).padStart(2, "0")).join(""),
-    [originalVal]
-  );
-
-  const base64Value = useMemo(() => {
-    const bytes = new TextEncoder().encode(originalVal);
-    let binary = "";
-    for (const b of bytes) binary += String.fromCharCode(b);
-    return btoa(binary);
-  }, [originalVal]);
-
+  // hex / base64 只在切到对应视图时才算。以前两个 useMemo 都无条件执行:hex 给每个
+  // 字节建一个 2 字符的字符串再 join,base64 在循环里逐字节拼接 —— 点一个 key 就要
+  // 全跑一遍,哪怕用户一直停在 raw 视图。实测(纯 JS,不含渲染):
+  //   256KB → hex 77ms + base64 41ms;1MB → 303ms + 156ms;5MB → 1276ms + 656ms。
   const displayValue = useMemo(() => {
     if (viewMode === "json" && isJson) {
       try {
@@ -93,10 +85,17 @@ export function RedisStringEditor({ tabId, t }: { tabId: string; t: (key: string
         return originalVal;
       }
     }
-    if (viewMode === "hex") return hexValue;
-    if (viewMode === "base64") return base64Value;
+    if (viewMode === "hex") {
+      return Array.from(new TextEncoder().encode(originalVal), (b) => b.toString(16).padStart(2, "0")).join("");
+    }
+    if (viewMode === "base64") {
+      const bytes = new TextEncoder().encode(originalVal);
+      let binary = "";
+      for (const b of bytes) binary += String.fromCharCode(b);
+      return btoa(binary);
+    }
     return originalVal;
-  }, [base64Value, hexValue, isJson, originalVal, viewMode]);
+  }, [isJson, originalVal, viewMode]);
 
   const jsonTokens = useMemo(() => {
     if (!isJson || (viewMode !== "raw" && viewMode !== "json")) return null;

--- a/frontend/src/components/query/TableDataTab.tsx
+++ b/frontend/src/components/query/TableDataTab.tsx
@@ -53,7 +53,7 @@ import {
   type TableSortItem,
 } from "@/lib/tableFilter";
 import { filterOperatorNeedsRange } from "@/lib/tableFilterOperators";
-import { cellValueToText } from "@/lib/cellValue";
+import { cellValueToDisplayText } from "@/lib/cellValue";
 
 interface TableDataTabProps {
   tabId: string;
@@ -985,7 +985,7 @@ function TableDataTabContent({ tabId, innerTabId, database, table }: TableDataTa
         return <span className="text-muted-foreground/70 italic">(Default)</span>;
       }
       if (value == null) return <span className="text-muted-foreground italic">NULL</span>;
-      return <span className="truncate block">{cellValueToText(value)}</span>;
+      return <span className="truncate block">{cellValueToDisplayText(value)}</span>;
     },
     [rowsLength]
   );

--- a/frontend/src/components/query/TableFilterBuilder.tsx
+++ b/frontend/src/components/query/TableFilterBuilder.tsx
@@ -28,7 +28,7 @@ import {
   SelectValue,
   computeContextMenuPosition,
 } from "@opskat/ui";
-import { cellValueToText } from "@/lib/cellValue";
+import { cellValueToDisplayText, cellValueToText } from "@/lib/cellValue";
 import {
   addFilterCondition,
   addFilterGroup,
@@ -108,7 +108,7 @@ function distinctValues(rows: Record<string, unknown>[], column: string): Distin
       map.set(key, {
         key,
         value: value == null ? null : value,
-        label: value == null ? "NULL" : cellValueToText(value),
+        label: value == null ? "NULL" : cellValueToDisplayText(value),
         count: 1,
       });
     }
@@ -912,7 +912,7 @@ function FilterValuePicker({ value, rows, column, onChange }: FilterValuePickerP
   const [open, setOpen] = useState(false);
   const [customValue, setCustomValue] = useState("");
   const [search, setSearch] = useState("");
-  const label = value === undefined ? "?" : value == null ? "NULL" : cellValueToText(value);
+  const label = value === undefined ? "?" : value == null ? "NULL" : cellValueToDisplayText(value);
   // distinctValues 是 O(rows) 全表扫描;只在 popover 打开后才计算,关闭后丢弃。
   // 否则父组件每次 re-render 都会因 rows 引用变化触发整列重算,大表上 ~几十~几百 ms。
   const suggestions = useMemo<DistinctValue[]>(() => (open ? distinctValues(rows, column) : []), [open, rows, column]);

--- a/frontend/src/components/terminal/file-manager/FileList.tsx
+++ b/frontend/src/components/terminal/file-manager/FileList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { File, Folder, Loader2 } from "lucide-react";
 import { Button, cn, Input, ScrollArea } from "@opskat/ui";
@@ -92,6 +92,69 @@ export function FileList({
     () => sortedEntries.map((entry) => getEntryPath(currentPath, entry)),
     [currentPath, sortedEntries]
   );
+  // 父组件 FileManagerPanel 把 onNavigate / onOpenContextMenu / onRenameCancel 等
+  // 写成内联箭头函数,而 selected 也住在父组件 —— 选中一变父组件就重渲,这些 prop
+  // 全部换标识。若把它们直接传给行,行的 memo 一次都不会命中(实测反而更慢,因为白
+  // 付了一遍 props 比较)。这里镜像进 ref,对外只暴露标识恒定的包装。
+  const cbRef = useRef({
+    canExternalEdit,
+    onExternalOpen,
+    onNavigate,
+    onOpenContextMenu,
+    onMoveEntriesToDirectory,
+    onRenameCancel,
+    onRenameCommit,
+    renamePath,
+  });
+  useEffect(() => {
+    cbRef.current = {
+      canExternalEdit,
+      onExternalOpen,
+      onNavigate,
+      onOpenContextMenu,
+      onMoveEntriesToDirectory,
+      onRenameCancel,
+      onRenameCommit,
+      renamePath,
+    };
+  }, [
+    canExternalEdit,
+    onExternalOpen,
+    onNavigate,
+    onOpenContextMenu,
+    onMoveEntriesToDirectory,
+    onRenameCancel,
+    onRenameCommit,
+    renamePath,
+  ]);
+
+  const stableCanExternalEdit = useCallback(
+    (entry: sftp_svc.FileEntry) => cbRef.current.canExternalEdit?.(entry) ?? false,
+    []
+  );
+  const stableExternalOpen = useCallback((path: string) => cbRef.current.onExternalOpen?.(path), []);
+  const stableNavigate = useCallback((path: string) => cbRef.current.onNavigate(path), []);
+  const stableOpenContextMenu = useCallback(
+    (x: number, y: number, entry: sftp_svc.FileEntry | null) => cbRef.current.onOpenContextMenu(x, y, entry),
+    []
+  );
+  const stableMoveEntries = useCallback(
+    (sourcePaths: string[], targetDirPath: string) =>
+      cbRef.current.onMoveEntriesToDirectory(sourcePaths, targetDirPath),
+    []
+  );
+  const stableRenameCancel = useCallback(() => cbRef.current.onRenameCancel(), []);
+
+  // 命中判断用 Set:以前每行都跑一次 selected.includes(),n 行 × O(选中数) 在
+  // 全选(shift 选完整个目录)时退化成 O(n²)。
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+  // 事件回调需要"当前选中集合",但不能把它放进依赖 —— 否则每次改选中回调就换标识,
+  // 把所有行的 memo 全部打掉(和 QueryResultTable 里 handleCellContextMenu 同一个坑)。
+  const selectedRef = useRef(selected);
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
+
   const lastClickedRef = useRef<number | null>(null);
   const draggedPathsRef = useRef<string[]>([]);
   const pointerDragRef = useRef<{
@@ -106,61 +169,74 @@ export function FileList({
   const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
   const slowClickRef = useRef<{ path: string; time: number; timer: number | null }>({ path: "", time: 0, timer: null });
 
-  const selectEntry = (path: string, index: number, event: React.MouseEvent) => {
-    if (event.shiftKey && lastClickedRef.current !== null) {
-      const start = Math.min(lastClickedRef.current, index);
-      const end = Math.max(lastClickedRef.current, index);
-      setSelected(entryPaths.slice(start, end + 1));
-      return;
-    }
-    if (event.ctrlKey || event.metaKey) {
-      setSelected((prev) => (prev.includes(path) ? prev.filter((item) => item !== path) : [...prev, path]));
+  const entryPathsRef = useRef(entryPaths);
+  useEffect(() => {
+    entryPathsRef.current = entryPaths;
+  }, [entryPaths]);
+
+  const selectEntry = useCallback(
+    (path: string, index: number, event: React.MouseEvent) => {
+      if (event.shiftKey && lastClickedRef.current !== null) {
+        const start = Math.min(lastClickedRef.current, index);
+        const end = Math.max(lastClickedRef.current, index);
+        setSelected(entryPathsRef.current.slice(start, end + 1));
+        return;
+      }
+      if (event.ctrlKey || event.metaKey) {
+        setSelected((prev) => (prev.includes(path) ? prev.filter((item) => item !== path) : [...prev, path]));
+        lastClickedRef.current = index;
+        return;
+      }
+      setSelected([path]);
       lastClickedRef.current = index;
-      return;
-    }
-    setSelected([path]);
-    lastClickedRef.current = index;
-  };
+    },
+    [setSelected]
+  );
 
-  const maybeStartSlowRename = (path: string, index: number, eventTime: number) => {
-    const now = eventTime;
-    const prev = slowClickRef.current;
-    if (prev.timer) window.clearTimeout(prev.timer);
-    if (
-      prev.path === path &&
-      now - prev.time > 450 &&
-      now - prev.time < 1400 &&
-      selected.length === 1 &&
-      selected[0] === path
-    ) {
-      prev.path = "";
-      prev.time = 0;
-      onOpenContextMenu(-1, -1, null); // closes any pending menu in parent no-op path
-      window.dispatchEvent(new CustomEvent("sftp:rename-request", { detail: { path } }));
-      return;
-    }
-    slowClickRef.current = { path, time: now, timer: null };
-    slowClickRef.current.timer = window.setTimeout(() => {
-      if (slowClickRef.current.path === path) slowClickRef.current.path = "";
-    }, 1500);
-    lastClickedRef.current = index;
-  };
+  const maybeStartSlowRename = useCallback(
+    (path: string, index: number, eventTime: number) => {
+      const now = eventTime;
+      const prev = slowClickRef.current;
+      const sel = selectedRef.current;
+      if (prev.timer) window.clearTimeout(prev.timer);
+      if (
+        prev.path === path &&
+        now - prev.time > 450 &&
+        now - prev.time < 1400 &&
+        sel.length === 1 &&
+        sel[0] === path
+      ) {
+        prev.path = "";
+        prev.time = 0;
+        stableOpenContextMenu(-1, -1, null); // closes any pending menu in parent no-op path
+        window.dispatchEvent(new CustomEvent("sftp:rename-request", { detail: { path } }));
+        return;
+      }
+      slowClickRef.current = { path, time: now, timer: null };
+      slowClickRef.current.timer = window.setTimeout(() => {
+        if (slowClickRef.current.path === path) slowClickRef.current.path = "";
+      }, 1500);
+      lastClickedRef.current = index;
+    },
+    [stableOpenContextMenu]
+  );
 
-  const commitRename = (nextName: string) => {
-    if (!renamePath) return;
+  const commitRename = useCallback((nextName: string) => {
+    const { renamePath: path, onRenameCancel: cancel, onRenameCommit: commit } = cbRef.current;
+    if (!path) return;
     const trimmed = nextName.trim();
     if (!trimmed) {
-      onRenameCancel();
+      cancel();
       return;
     }
-    onRenameCommit(renamePath, trimmed);
-  };
+    commit(path, trimmed);
+  }, []);
 
   const isEntryTarget = (target: EventTarget | null) => {
     return target instanceof Element && !!target.closest("[data-sftp-entry-row]");
   };
 
-  const getDragPaths = (event: React.DragEvent) => {
+  const getDragPaths = useCallback((event: React.DragEvent) => {
     if (draggedPathsRef.current.length) return draggedPathsRef.current;
     const raw = event.dataTransfer.getData("application/x-opskat-sftp-paths");
     if (!raw) return [];
@@ -170,29 +246,32 @@ export function FileList({
     } catch {
       return [];
     }
-  };
+  }, []);
 
-  const getMovableDragPaths = (event: React.DragEvent, targetDirPath: string) => {
-    return getDragPaths(event).filter((path) => canMovePathToDirectory(path, targetDirPath));
-  };
+  const getMovableDragPaths = useCallback(
+    (event: React.DragEvent, targetDirPath: string) =>
+      getDragPaths(event).filter((path) => canMovePathToDirectory(path, targetDirPath)),
+    [getDragPaths]
+  );
 
-  const getPointerDropTargetPath = (clientX: number, clientY: number, sourcePaths: string[]) => {
+  const getPointerDropTargetPath = useCallback((clientX: number, clientY: number, sourcePaths: string[]) => {
     const target = document.elementFromPoint(clientX, clientY);
     const row = target?.closest<HTMLElement>("[data-sftp-entry-row][data-sftp-entry-dir='true']");
     const targetPath = row?.dataset.sftpEntryPath;
     if (!targetPath) return null;
     return sourcePaths.some((path) => canMovePathToDirectory(path, targetPath)) ? targetPath : null;
-  };
+  }, []);
 
-  const clearDragState = () => {
+  const clearDragState = useCallback(() => {
     draggedPathsRef.current = [];
     pointerDragRef.current = null;
     setDropTargetPath(null);
-  };
+  }, []);
 
-  const beginPointerDrag = (path: string, event: React.PointerEvent<HTMLElement>) => {
+  const beginPointerDrag = useCallback((path: string, event: React.PointerEvent<HTMLElement>) => {
     if (event.button !== 0 || event.shiftKey || event.ctrlKey || event.metaKey) return;
-    const sourcePaths = selected.includes(path) ? selected : [path];
+    const sel = selectedRef.current;
+    const sourcePaths = sel.includes(path) ? sel : [path];
     pointerDragRef.current = {
       dragging: false,
       pointerId: event.pointerId,
@@ -206,40 +285,92 @@ export function FileList({
     } catch {
       // Pointer capture is unavailable in jsdom and may fail if the pointer is already released.
     }
-  };
+  }, []);
 
-  const updatePointerDrag = (event: React.PointerEvent<HTMLElement>) => {
-    const drag = pointerDragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
-    const distance = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
-    if (!drag.dragging && distance < 6) return;
-    if (!drag.dragging) {
-      drag.dragging = true;
-      suppressNextClickRef.current = true;
-      setSelected(drag.sourcePaths);
-    }
-    event.preventDefault();
-    setDropTargetPath(getPointerDropTargetPath(event.clientX, event.clientY, drag.sourcePaths));
-  };
+  const updatePointerDrag = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const drag = pointerDragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const distance = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
+      if (!drag.dragging && distance < 6) return;
+      if (!drag.dragging) {
+        drag.dragging = true;
+        suppressNextClickRef.current = true;
+        setSelected(drag.sourcePaths);
+      }
+      event.preventDefault();
+      setDropTargetPath(getPointerDropTargetPath(event.clientX, event.clientY, drag.sourcePaths));
+    },
+    [getPointerDropTargetPath, setSelected]
+  );
 
-  const endPointerDrag = (event: React.PointerEvent<HTMLElement>) => {
-    const drag = pointerDragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
-    const targetPath = drag.dragging ? getPointerDropTargetPath(event.clientX, event.clientY, drag.sourcePaths) : null;
-    clearDragState();
-    try {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    } catch {
-      // Pointer capture is best-effort across browser/test environments.
-    }
-    if (!drag.dragging) return;
-    event.preventDefault();
-    event.stopPropagation();
-    if (targetPath) onMoveEntriesToDirectory(drag.sourcePaths, targetPath);
-    window.setTimeout(() => {
-      suppressNextClickRef.current = false;
-    }, 0);
-  };
+  const endPointerDrag = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const drag = pointerDragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const targetPath = drag.dragging
+        ? getPointerDropTargetPath(event.clientX, event.clientY, drag.sourcePaths)
+        : null;
+      clearDragState();
+      try {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      } catch {
+        // Pointer capture is best-effort across browser/test environments.
+      }
+      if (!drag.dragging) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (targetPath) stableMoveEntries(drag.sourcePaths, targetPath);
+      window.setTimeout(() => {
+        suppressNextClickRef.current = false;
+      }, 0);
+    },
+    [clearDragState, getPointerDropTargetPath, stableMoveEntries]
+  );
+
+  // 所有行共用同一个 handlers 对象:每行 26 个 prop 时,5000 行全部改选中(shift 全选)
+  // 要多付一遍 26×5000 的浅比较和 props 分配,反而比不 memo 更慢。收成一个恒定标识的
+  // 对象后,行的 prop 面只剩 entry + 4 个布尔 + h。
+  const rowHandlers = useMemo(
+    () => ({
+      canExternalEdit: stableCanExternalEdit,
+      onExternalOpen: stableExternalOpen,
+      onNavigate: stableNavigate,
+      onOpenContextMenu: stableOpenContextMenu,
+      onMoveEntriesToDirectory: stableMoveEntries,
+      onRenameCancel: stableRenameCancel,
+      commitRename,
+      selectEntry,
+      maybeStartSlowRename,
+      selectedRef,
+      setSelected,
+      draggedPathsRef,
+      suppressNextClickRef,
+      getMovableDragPaths,
+      setDropTargetPath,
+      clearDragState,
+      beginPointerDrag,
+      updatePointerDrag,
+      endPointerDrag,
+    }),
+    [
+      beginPointerDrag,
+      clearDragState,
+      commitRename,
+      endPointerDrag,
+      getMovableDragPaths,
+      maybeStartSlowRename,
+      selectEntry,
+      setSelected,
+      stableCanExternalEdit,
+      stableExternalOpen,
+      stableMoveEntries,
+      stableNavigate,
+      stableOpenContextMenu,
+      stableRenameCancel,
+      updatePointerDrag,
+    ]
+  );
 
   return (
     <ScrollArea
@@ -292,109 +423,18 @@ export function FileList({
             )}
             {sortedEntries.map((entry, index) => {
               const fullPath = getEntryPath(currentPath, entry);
-              const isSelected = selected.includes(fullPath);
-              const isCut = clipboardCutPaths.has(fullPath);
-              const isRenaming = renamePath === fullPath;
-              const isDropTarget = dropTargetPath === fullPath;
               return (
-                <div
+                <FileRow
                   key={entry.name}
-                  data-sftp-entry-row="true"
-                  data-sftp-entry-dir={entry.isDir ? "true" : "false"}
-                  data-sftp-entry-path={fullPath}
-                  draggable={false}
-                  className={cn(
-                    "flex items-center gap-1.5 px-2 py-1 cursor-pointer transition-colors rounded-sm",
-                    isSelected ? "bg-primary/15 text-primary" : "hover:bg-muted/50",
-                    isCut && "opacity-45",
-                    isDropTarget && "bg-primary/10 ring-1 ring-primary/30"
-                  )}
-                  style={{ contentVisibility: "auto", containIntrinsicSize: "auto 28px" }}
-                  onDragStart={(e) => {
-                    if (isRenaming) {
-                      e.preventDefault();
-                      return;
-                    }
-                    const paths = selected.includes(fullPath) ? selected : [fullPath];
-                    draggedPathsRef.current = paths;
-                    e.dataTransfer.effectAllowed = "move";
-                    e.dataTransfer.setData("application/x-opskat-sftp-paths", JSON.stringify(paths));
-                    e.dataTransfer.setData("text/plain", fullPath);
-                    if (!selected.includes(fullPath)) setSelected([fullPath]);
-                  }}
-                  onDragEnd={clearDragState}
-                  onDragOver={(e) => {
-                    if (!entry.isDir || !getMovableDragPaths(e, fullPath).length) return;
-                    e.preventDefault();
-                    e.dataTransfer.dropEffect = "move";
-                    setDropTargetPath(fullPath);
-                  }}
-                  onDragLeave={(e) => {
-                    const nextTarget = e.relatedTarget;
-                    if (nextTarget instanceof Node && e.currentTarget.contains(nextTarget)) return;
-                    if (dropTargetPath === fullPath) setDropTargetPath(null);
-                  }}
-                  onDrop={(e) => {
-                    if (!entry.isDir) return;
-                    const sourcePaths = getMovableDragPaths(e, fullPath);
-                    if (!sourcePaths.length) return;
-                    e.preventDefault();
-                    e.stopPropagation();
-                    clearDragState();
-                    onMoveEntriesToDirectory(sourcePaths, fullPath);
-                  }}
-                  onPointerDown={(e) => {
-                    if (!isRenaming) beginPointerDrag(fullPath, e);
-                  }}
-                  onPointerMove={updatePointerDrag}
-                  onPointerUp={endPointerDrag}
-                  onPointerCancel={clearDragState}
-                  onClick={(e) => {
-                    if (suppressNextClickRef.current) {
-                      suppressNextClickRef.current = false;
-                      return;
-                    }
-                    if (isRenaming) return;
-                    selectEntry(fullPath, index, e);
-                    maybeStartSlowRename(fullPath, index, e.timeStamp);
-                  }}
-                  onDoubleClick={() => {
-                    if (isRenaming) return;
-                    if (entry.isDir) {
-                      onNavigate(fullPath);
-                      return;
-                    }
-                    if (canExternalEdit?.(entry)) {
-                      onExternalOpen?.(fullPath);
-                    }
-                  }}
-                  onContextMenu={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (!selected.includes(fullPath)) setSelected([fullPath]);
-                    onOpenContextMenu(e.clientX, e.clientY, entry);
-                  }}
-                >
-                  {entry.isDir ? (
-                    <Folder className="h-3.5 w-3.5 text-primary/70 shrink-0" />
-                  ) : (
-                    <File className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                  )}
-                  {isRenaming ? (
-                    <RenameInput
-                      key={fullPath}
-                      initialName={entry.name}
-                      onCommit={commitRename}
-                      onCancel={onRenameCancel}
-                    />
-                  ) : (
-                    <span className="flex-1 truncate">{entry.name}</span>
-                  )}
-                  {!entry.isDir && (
-                    <span className="text-muted-foreground shrink-0 text-[10px]">{formatBytes(entry.size)}</span>
-                  )}
-                  <span className="text-muted-foreground shrink-0 text-[10px]">{formatDate(entry.modTime)}</span>
-                </div>
+                  entry={entry}
+                  fullPath={fullPath}
+                  index={index}
+                  isSelected={selectedSet.has(fullPath)}
+                  isCut={clipboardCutPaths.has(fullPath)}
+                  isRenaming={renamePath === fullPath}
+                  isDropTarget={dropTargetPath === fullPath}
+                  h={rowHandlers}
+                />
               );
             })}
           </>
@@ -403,3 +443,146 @@ export function FileList({
     </ScrollArea>
   );
 }
+
+interface FileRowHandlers {
+  canExternalEdit: (entry: sftp_svc.FileEntry) => boolean;
+  onExternalOpen: (path: string) => void;
+  onNavigate: (path: string) => void;
+  onOpenContextMenu: (x: number, y: number, entry: sftp_svc.FileEntry | null) => void;
+  onMoveEntriesToDirectory: (sourcePaths: string[], targetDirPath: string) => void;
+  onRenameCancel: () => void;
+  commitRename: (nextName: string) => void;
+  selectEntry: (path: string, index: number, event: React.MouseEvent) => void;
+  maybeStartSlowRename: (path: string, index: number, eventTime: number) => void;
+  selectedRef: React.RefObject<string[]>;
+  setSelected: (next: string[] | ((prev: string[]) => string[])) => void;
+  draggedPathsRef: React.RefObject<string[]>;
+  suppressNextClickRef: React.RefObject<boolean>;
+  getMovableDragPaths: (event: React.DragEvent, targetDirPath: string) => string[];
+  setDropTargetPath: (path: string | null) => void;
+  clearDragState: () => void;
+  beginPointerDrag: (path: string, event: React.PointerEvent<HTMLElement>) => void;
+  updatePointerDrag: (event: React.PointerEvent<HTMLElement>) => void;
+  endPointerDrag: (event: React.PointerEvent<HTMLElement>) => void;
+}
+
+interface FileRowProps {
+  entry: sftp_svc.FileEntry;
+  fullPath: string;
+  index: number;
+  isSelected: boolean;
+  isCut: boolean;
+  isRenaming: boolean;
+  isDropTarget: boolean;
+  h: FileRowHandlers;
+}
+
+// 单行 memo 化:选中态是列表级 state,不 memo 的话点一行会把整个目录的行全部重渲。
+// 5000 个文件的目录实测单击一次 631ms、shift 全选 1.6s(见 PR 说明)。所有需要
+// "当前选中集合"的回调都通过 ref 读,保证 props 在选中变化时保持同一标识。
+const FileRow = memo(function FileRow({
+  entry,
+  fullPath,
+  index,
+  isSelected,
+  isCut,
+  isRenaming,
+  isDropTarget,
+  h,
+}: FileRowProps) {
+  return (
+    <div
+      data-sftp-entry-row="true"
+      data-sftp-entry-dir={entry.isDir ? "true" : "false"}
+      data-sftp-entry-path={fullPath}
+      draggable={false}
+      className={cn(
+        "flex items-center gap-1.5 px-2 py-1 cursor-pointer transition-colors rounded-sm",
+        isSelected ? "bg-primary/15 text-primary" : "hover:bg-muted/50",
+        isCut && "opacity-45",
+        isDropTarget && "bg-primary/10 ring-1 ring-primary/30"
+      )}
+      style={{ contentVisibility: "auto", containIntrinsicSize: "auto 28px" }}
+      onDragStart={(e) => {
+        if (isRenaming) {
+          e.preventDefault();
+          return;
+        }
+        const { selectedRef, draggedPathsRef } = h;
+        const sel = selectedRef.current;
+        const paths = sel.includes(fullPath) ? sel : [fullPath];
+        draggedPathsRef.current = paths;
+        e.dataTransfer.effectAllowed = "move";
+        e.dataTransfer.setData("application/x-opskat-sftp-paths", JSON.stringify(paths));
+        e.dataTransfer.setData("text/plain", fullPath);
+        if (!sel.includes(fullPath)) h.setSelected([fullPath]);
+      }}
+      onDragEnd={h.clearDragState}
+      onDragOver={(e) => {
+        if (!entry.isDir || !h.getMovableDragPaths(e, fullPath).length) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        h.setDropTargetPath(fullPath);
+      }}
+      onDragLeave={(e) => {
+        const nextTarget = e.relatedTarget;
+        if (nextTarget instanceof Node && e.currentTarget.contains(nextTarget)) return;
+        if (isDropTarget) h.setDropTargetPath(null);
+      }}
+      onDrop={(e) => {
+        if (!entry.isDir) return;
+        const sourcePaths = h.getMovableDragPaths(e, fullPath);
+        if (!sourcePaths.length) return;
+        e.preventDefault();
+        e.stopPropagation();
+        h.clearDragState();
+        h.onMoveEntriesToDirectory(sourcePaths, fullPath);
+      }}
+      onPointerDown={(e) => {
+        if (!isRenaming) h.beginPointerDrag(fullPath, e);
+      }}
+      onPointerMove={h.updatePointerDrag}
+      onPointerUp={h.endPointerDrag}
+      onPointerCancel={h.clearDragState}
+      onClick={(e) => {
+        const { suppressNextClickRef } = h;
+        if (suppressNextClickRef.current) {
+          suppressNextClickRef.current = false;
+          return;
+        }
+        if (isRenaming) return;
+        h.selectEntry(fullPath, index, e);
+        h.maybeStartSlowRename(fullPath, index, e.timeStamp);
+      }}
+      onDoubleClick={() => {
+        if (isRenaming) return;
+        if (entry.isDir) {
+          h.onNavigate(fullPath);
+          return;
+        }
+        if (h.canExternalEdit?.(entry)) {
+          h.onExternalOpen?.(fullPath);
+        }
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!h.selectedRef.current.includes(fullPath)) h.setSelected([fullPath]);
+        h.onOpenContextMenu(e.clientX, e.clientY, entry);
+      }}
+    >
+      {entry.isDir ? (
+        <Folder className="h-3.5 w-3.5 text-primary/70 shrink-0" />
+      ) : (
+        <File className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+      )}
+      {isRenaming ? (
+        <RenameInput key={fullPath} initialName={entry.name} onCommit={h.commitRename} onCancel={h.onRenameCancel} />
+      ) : (
+        <span className="flex-1 truncate">{entry.name}</span>
+      )}
+      {!entry.isDir && <span className="text-muted-foreground shrink-0 text-[10px]">{formatBytes(entry.size)}</span>}
+      <span className="text-muted-foreground shrink-0 text-[10px]">{formatDate(entry.modTime)}</span>
+    </div>
+  );
+});

--- a/frontend/src/lib/cellValue.ts
+++ b/frontend/src/lib/cellValue.ts
@@ -9,3 +9,18 @@ export function cellValueToText(v: unknown): string {
   }
   return String(v);
 }
+
+// 单元格放进 DOM 的最大字符数。表格单元格用的是 `truncate`(nowrap + ellipsis),
+// Chromium 为了排出这一行的 line box 必须把整段文本 shape 完,代价与值长度成正比 ——
+// 哪怕最终只有 ~150px 可见。实测(45 个可见单元格,Chromium):
+//   10KB/单元格 → 20ms layout,100KB → 195ms,1MB → 2.3s;之后每次重排(改列宽 /
+//   窗口缩放 / measureElement 的 ResizeObserver)1MB 仍要 163ms。截断后恒定 ~4ms。
+// 512 字符远超单列最大宽度 420px 能显示的量(12px 等宽字体约 60 字符),所以看得见的
+// 内容一个都没少。完整值仍然走复制 / 编辑 / 导出路径,不受这里影响。
+export const CELL_DISPLAY_MAX_CHARS = 512;
+
+/** 面向渲染的文本:与 cellValueToText 相同,但截断到 CELL_DISPLAY_MAX_CHARS。 */
+export function cellValueToDisplayText(v: unknown): string {
+  const text = cellValueToText(v);
+  return text.length > CELL_DISPLAY_MAX_CHARS ? `${text.slice(0, CELL_DISPLAY_MAX_CHARS)}…` : text;
+}


### PR DESCRIPTION
## 变更说明 / Summary

三类性能问题，共四处修复。全部先实测定位、改完再实测验证，不靠经验估算。

---

### 1. 大字段拖垮表格布局（`77d54976`）

**根因：** 整个单元格值被塞进 DOM 文本节点，外面套 `truncate`（`nowrap` + `ellipsis`）。Chromium 为了排这一行的 line box 必须把**整段文本 shape 完**，代价与值长度成正比 —— 哪怕最终只有 ~150px 可见。虚拟化砍掉了行数，但没管每个单元格里的字节数。

微基准（真实 Chromium，45 个可见单元格，复刻组件 markup + CSS）：

| 单元格值 | 全量渲染 | 截断到 512 字符 |
|---|---|---|
| 10 KB | 23 ms | 4.4 ms |
| 100 KB | 195 ms | 4.5 ms |
| 1 MB | 2238 ms | 4.7 ms |

拆开看 1MB 那档：建 DOM 只要 5.7ms，**首次 layout 2536ms**；`title` 属性不是成本，纯粹是文本排版。

**改法：** `lib/cellValue.ts` 新增 `cellValueToDisplayText`（上限 512 字符 + `…`），用在所有「把值写进 DOM」的地方。复制 / 编辑 / 导出走的仍是完整值。512 远超单列最大宽度 420px 能显示的量（12px 等宽约 60 字符），看得见的内容一个都没少。

覆盖：`QueryResultTable` 单元格文本 + `title`、`ColumnValuePanel`（顺带修了搜索框每敲一个字符就对整列原值 `toLowerCase()` 的热点）、`TableFilterBuilder` 候选值标签、`TableDataTab.renderCell`、`MongoDBResultView`。

**沙箱实测**（SQLite，200 行 × 200KB TEXT，同一份数据靠 HMR 切换有无截断，连滚 20 次）：

| | 前 | 后 |
|---|---|---|
| 20 次滚动 | 9106 ms | 923 ms |
| 有效帧率 | 2 fps | 22 fps |
| 主线程阻塞 | 8843 ms | 449 ms |
| 最长 long task | 571 ms | 60 ms |

---

### 2. 选中单元格重渲整屏表格（`f64c67d9`）

**根因：** 选中态是表级 state，改一次就让整个 `<tbody>` 重跑 —— 40 行 × 25 列的表点一下要重建 1000 个 `<td>`。

**改法：** `<td>` 抽成 memo 化的 `ResultCell`。配套两处让 memo 真正生效（缺任一处等于白做）：`selectCell` 清空行选中时复用同一个空 Set；`handleCellContextMenu` 改用 ref 镜像读选中集合，不再把它放进依赖数组。

**沙箱实测**（前后各 3 轮，1000 个渲染单元格，Event Timing 口径）：

| | 前 | 后 |
|---|---|---|
| 点击选中 p90 | 304 / 256 / 272 ms | 120 / 112 / 112 ms |
| 方向键 max | 264 / 280 / 304 ms | 128 / 128 / 136 ms |
| 整列选中 p90 | 256 / 304 / 272 ms | 176 / 184 / 112 ms |
| longTask max | ~250–300 ms | ~110 ms |

---

### 3. 文件列表：选中一行重渲整个目录（`624b99b2`）

同一个坑在 SFTP 文件管理器里更严重：选中态是列表级 state，5000 个文件的目录点一行要重建 **5001 个未虚拟化的行**，每行还跑一次 `selected.includes()` —— shift 全选后退化成 O(n²)。

**改法三件套，缺任一件都等于白做：**
- `selected` 建 `Set` 做命中判断，去掉 n×m 的数组扫描；
- 行抽成 memo 化的 `FileRow`；
- 父组件 `FileManagerPanel` 把 `onNavigate` / `onOpenContextMenu` / `onRenameCancel` 写成内联箭头，而 `selected` 也住在父组件 —— 选中一变父组件重渲、这些 prop 全部换标识，memo 一次都不命中。用 ref 镜像隔开，并把 19 个稳定回调收成单个对象，每行 prop 面从 26 个降到 8 个。

只加 memo 而不做后两件事时实测**反而更慢**（单击 631→907ms），和 `f64c67d9` 里 QueryResultTable 的坑完全相同。

**真机 A/B/A 实测**（192.168.8.141 SFTP，5000 个文件的目录，每档 3 轮取中位数）：

| | 原始 | 修复 | 回测原始 | |
|---|---|---|---|---|
| 单击一行 | 601 ms | **46 ms** | 608 ms | **13×** |
| shift 全选 5000 | 1572 ms | **1198 ms** | 1623 ms | 1.3× |
| 全选后再单击 | 1258 ms | 1296 ms | 1290 ms | -3%（噪声级） |

最后一档略负：此时 5000 行的 `isSelected` 全部翻转，memo 比较是纯开销。根治要靠虚拟化，见「已知未做」。

选中行为此前**没有任何测试覆盖**，补了单击 / ctrl 切换 / shift 范围 / 点空白清空。

---

### 4. Redis 大字符串空转 hex/base64（`624b99b2`）

`RedisStringEditor` 里两个 `useMemo` 不看 `viewMode` 就执行 —— hex 给每个字节建一个 2 字符的字符串再 join，base64 在循环里逐字节拼接。点一个 key 就全跑一遍，哪怕用户一直停在 raw 视图。

| Redis string 值 | hex | base64 | 合计白算 |
|---|---|---|---|
| 256 KB | 77 ms | 41 ms | 118 ms |
| 1 MB | 303 ms | 156 ms | 459 ms |
| 5 MB | 1276 ms | 656 ms | 1932 ms |

改成按 `viewMode` 惰性计算后归零。补了四种视图输出的特征测试（hex/base64 期望值独立推算，不取自实现）。

---

## 查过但实测不值得改

| 位置 | 怀疑 | 实测结论 |
|---|---|---|
| `RedisStreamViewer.tsx:111` | 选中一行重渲所有虚拟行 + 重跑 `formatFields` | 40 行 0.1–25ms，25ms 还是「每条 195KB」的极端值 |
| `RedisStreamViewer.tsx:196` | `rawText`/`formattedText` 双算 | 白花 ≤3.6ms |
| `RedisCollectionTable.tsx` | grep 出 28 处 "selected" | 误报，全是 `state.selectedKey`（当前打开哪个 key），无逐行选中态 |
| `RedisKeyBrowser.tsx:573` | 选中 key 重渲虚拟列表 | 行内容只是短字符串 + 按钮，可忽略 |

## 已知未做

- **超大文本（5MB）的瓶颈在传输层，不在渲染。** 渲染已是常数代价（5MB/格滚动仍有 27fps），但 IPC 实测 ~70 MB/s：50 行 × 5MB = 3.5s、JS 堆 894MB；合成 200 行（1GB）直接把渲染进程打挂。默认分页 1000 行遇上 5MB 字段 = 5GB，必崩。正确解法是后端截断 + 按需取完整值 —— 仓库里 Kafka 已有现成先例（`kafka_svc/messages.go` 默认 4KB、上限 1MB、带 `Truncated` 标志）。属 IPC 契约变更，另开。
- **文件列表虚拟化。** 5000 行本就不该全在 DOM 里，这是「全选后单击」那档的根治办法。会动到拖拽的 `elementFromPoint` 和跨行 DOM 查询，改动面和风险都明显更大。
- **etcd 结果表**（`EtcdResultTable.tsx:68`）：无虚拟化 + `break-all` 换行 + 值不截断，后端默认返回 1000 个 key 且对 value 大小无限制。实测 200 行 × 100KB = 1315ms vs 截断后 10ms。这是同类问题里最严重的一处，本 PR 未含。
- **Redis 集合表 / stream**（`RedisCollectionTable.tsx:106` 等）：同「值不截断」问题，本 PR 未含。
- 编辑态的 `<input defaultValue>` 仍装完整值（截断会毁数据），双击 1MB 单元格进编辑仍会卡一下。

## 关联 Issue / Related Issue

无

## 截图 / Screenshots

无视觉变更（超长值显示为 `…` 截断，原本也是 CSS ellipsis 截断的效果）。

## 自检 / Checklist

- [x]  Changes tested / 已完成测试 —— 新增 17 个测试（截断边界、单元格 DOM/tooltip 长度上限、复制与编辑仍拿到完整值、文件选中行为、Redis 四种视图输出）；`pnpm test` 2266 通过、`eslint` 与 `tsc` 干净；四项改动均在 `make dev-sandbox` 真实应用上前后对比实测，文件列表一项做了 A/B/A 回测
- [ ]  Code reviewed by human / 代码通过人工检查