### PR TITLE
🐛 支持本地终端运行 Shell 代码片段 #301

### DIFF
--- a/frontend/src/__tests__/snippetRun.test.ts
+++ b/frontend/src/__tests__/snippetRun.test.ts
@@ -7,11 +7,16 @@ const mocks = vi.hoisted(() => ({
   connect: vi.fn(),
   openQueryTab: vi.fn(),
   writeSSH: vi.fn(),
+  writeLocal: vi.fn(),
   terminalState: { tabData: {} as Record<string, unknown> },
   tabState: { tabs: [] as unknown[] },
 }));
 
 vi.mock("../stores/terminalStore", () => ({
+  TRANSPORTS: {
+    ssh: { write: mocks.writeSSH },
+    local: { write: mocks.writeLocal },
+  },
   useTerminalStore: { getState: () => ({ ...mocks.terminalState, connect: mocks.connect }) },
 }));
 
@@ -22,8 +27,6 @@ vi.mock("../stores/tabStore", () => ({
 vi.mock("../stores/queryStore", () => ({
   useQueryStore: { getState: () => ({ openQueryTab: mocks.openQueryTab }) },
 }));
-
-vi.mock("../../wailsjs/go/ssh/SSH", () => ({ WriteSSH: mocks.writeSSH }));
 
 type Cat = { id: string; assetType: string };
 
@@ -65,7 +68,10 @@ describe("runSnippetOnAsset", () => {
   it("writes into an existing connected SSH pane without opening another connection", async () => {
     mocks.tabState.tabs = [{ id: "session-7", type: "terminal", meta: { assetId: 7 } }];
     mocks.terminalState.tabData = {
-      "session-7": { activePaneId: "pane-1", panes: { "pane-1": { connected: true } } },
+      "session-7": {
+        activePaneId: "pane-1",
+        panes: { "pane-1": { connected: true, transport: "ssh" } },
+      },
     };
 
     await runSnippetOnAsset(asset("ssh"), "echo hello");
@@ -81,6 +87,31 @@ describe("runSnippetOnAsset", () => {
 
     expect(mocks.connect).toHaveBeenCalledWith(target, "", false, { initialInput: "uptime" });
     expect(mocks.writeSSH).not.toHaveBeenCalled();
+  });
+
+  it("writes into an existing connected local pane through its transport", async () => {
+    mocks.tabState.tabs = [{ id: "local-session-7", type: "terminal", meta: { assetId: 7 } }];
+    mocks.terminalState.tabData = {
+      "local-session-7": {
+        activePaneId: "local-pane-1",
+        panes: { "local-pane-1": { connected: true, transport: "local" } },
+      },
+    };
+
+    await runSnippetOnAsset(asset("local"), "Get-Process");
+
+    expect(mocks.writeLocal).toHaveBeenCalledWith("local-pane-1", btoa("Get-Process"));
+    expect(mocks.writeSSH).not.toHaveBeenCalled();
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it("opens a new local terminal with initial input when no connected pane exists", async () => {
+    const target = asset("local");
+
+    await runSnippetOnAsset(target, "Get-Service");
+
+    expect(mocks.connect).toHaveBeenCalledWith(target, "", false, { initialInput: "Get-Service" });
+    expect(mocks.writeLocal).not.toHaveBeenCalled();
   });
 
   it("opens database snippets as initial SQL", async () => {

--- a/frontend/src/__tests__/snippetTarget.test.ts
+++ b/frontend/src/__tests__/snippetTarget.test.ts
@@ -55,6 +55,27 @@ describe("resolveSnippetTarget", () => {
     expect(res).toEqual({ kind: "active", asset: a });
   });
 
+  it("shell snippet + active local terminal tab whose asset is known → active", () => {
+    const a = asset(8, "local");
+    const res = resolveSnippetTarget({
+      snippet: snippet("shell"),
+      activeTab: terminalTab(8),
+      assetsById: new Map([[8, a]]),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "active", asset: a });
+  });
+
+  it("shell snippet + unsupported terminal asset → pick", () => {
+    const res = resolveSnippetTarget({
+      snippet: snippet("shell"),
+      activeTab: terminalTab(10),
+      assetsById: new Map([[10, asset(10, "serial")]]),
+      categories: CATEGORIES,
+    });
+    expect(res).toEqual({ kind: "pick" });
+  });
+
   it("sql snippet + active database query tab whose asset is known → active", () => {
     const a = asset(9, "database");
     const res = resolveSnippetTarget({

--- a/frontend/src/components/asset/AssetMultiSelect.tsx
+++ b/frontend/src/components/asset/AssetMultiSelect.tsx
@@ -5,8 +5,10 @@ import { useAssetTree } from "@/lib/assetTree";
 interface AssetMultiSelectProps {
   values: number[];
   onValuesChange: (values: number[]) => void;
-  /** Filter assets by type (e.g., "ssh"). Default: all types */
+  /** Filter assets by one type (e.g. "ssh"). Default: all types */
   filterType?: string;
+  /** Filter assets by any of these types. */
+  filterTypes?: readonly string[];
   /** Only include assets with Status === 1 (default: true) */
   activeOnly?: boolean;
   searchPlaceholder?: string;
@@ -23,13 +25,14 @@ export function AssetMultiSelect({
   values,
   onValuesChange,
   filterType,
+  filterTypes,
   activeOnly = true,
   searchPlaceholder,
   emptyText,
   className,
 }: AssetMultiSelectProps) {
   const { t } = useTranslation();
-  const tree = useAssetTree({ filterType, activeOnly });
+  const tree = useAssetTree({ filterType, filterTypes, activeOnly });
 
   return (
     <TreeCheckList

--- a/frontend/src/components/snippet/SnippetAssetDrawer.tsx
+++ b/frontend/src/components/snippet/SnippetAssetDrawer.tsx
@@ -11,6 +11,7 @@ import { snippet_entity } from "../../../wailsjs/go/models";
 import { GetSnippetLastAssets } from "../../../wailsjs/go/extension/Extension";
 import { SetSnippetLastAssets, RecordSnippetUse } from "../../../wailsjs/go/extension/Extension";
 import { runSnippetOnAsset } from "./snippetRun";
+import { getSnippetRunnerAssetTypes } from "@/lib/snippetRunners";
 
 interface SnippetAssetDrawerProps {
   snippet: snippet_entity.Snippet;
@@ -24,11 +25,11 @@ export function SnippetAssetDrawer({ snippet, onClose }: SnippetAssetDrawerProps
   const allAssets = useAssetStore((s) => s.assets);
 
   const category = useMemo(() => categories.find((c) => c.id === snippet.Category), [categories, snippet.Category]);
-  const assetType = category?.assetType ?? "";
+  const assetTypes = useMemo(() => getSnippetRunnerAssetTypes(category?.assetType ?? ""), [category?.assetType]);
 
   const matchingAssetIds = useMemo(
-    () => new Set(filterAssetTreeAssets(allAssets, { filterType: assetType, activeOnly: true }).map((a) => a.ID)),
-    [allAssets, assetType]
+    () => new Set(filterAssetTreeAssets(allAssets, { filterTypes: assetTypes, activeOnly: true }).map((a) => a.ID)),
+    [allAssets, assetTypes]
   );
 
   const [selected, setSelected] = useState<number[]>([]);
@@ -91,7 +92,7 @@ export function SnippetAssetDrawer({ snippet, onClose }: SnippetAssetDrawerProps
         <AssetMultiSelect
           values={selected}
           onValuesChange={setSelected}
-          filterType={assetType}
+          filterTypes={assetTypes}
           searchPlaceholder={t("snippet.runDrawer.searchPlaceholder")}
           emptyText={t("snippet.runDrawer.noAssets")}
           className="flex-1 mt-2"

--- a/frontend/src/components/snippet/__tests__/SnippetAssetDrawer.test.tsx
+++ b/frontend/src/components/snippet/__tests__/SnippetAssetDrawer.test.tsx
@@ -17,6 +17,7 @@ const assets = [
   { ID: 1, Name: "prod-mysql", Type: "database", Status: 1, Config: "{}" },
   { ID: 2, Name: "staging-mysql", Type: "database", Status: 1, Config: "{}" },
   { ID: 3, Name: "a-ssh", Type: "ssh", Status: 1, Config: "{}" },
+  { ID: 4, Name: "local-powershell", Type: "local", Status: 1, Config: "{}" },
 ];
 
 vi.mock("@/stores/assetStore", () => ({
@@ -45,6 +46,15 @@ describe("SnippetAssetDrawer", () => {
     await waitFor(() => expect(screen.getByText("prod-mysql")).toBeInTheDocument());
     expect(screen.getByText("staging-mysql")).toBeInTheDocument();
     expect(screen.queryByText("a-ssh")).not.toBeInTheDocument();
+  });
+
+  it("shows SSH and local terminal assets for shell snippets", async () => {
+    const snippet = { ID: 11, Name: "shell", Category: "shell", Content: "Get-Process" };
+    render(<SnippetAssetDrawer snippet={snippet as never} onClose={() => {}} />);
+
+    expect(await screen.findByText("a-ssh")).toBeInTheDocument();
+    expect(screen.getByText("local-powershell")).toBeInTheDocument();
+    expect(screen.queryByText("prod-mysql")).not.toBeInTheDocument();
   });
 
   it("pre-checks the assets returned by GetSnippetLastAssets", async () => {

--- a/frontend/src/lib/assetTree.ts
+++ b/frontend/src/lib/assetTree.ts
@@ -83,8 +83,10 @@ export function collectLeafIds(node: TreeNode): number[] {
 }
 
 export interface UseAssetTreeOptions {
-  /** Filter assets by type (e.g. "ssh"). */
+  /** Filter assets by one type (e.g. "ssh"). */
   filterType?: string;
+  /** Filter assets by any of these types. An empty list matches no assets. */
+  filterTypes?: readonly string[];
   /** Asset IDs to exclude (e.g. exclude self for jump host selection). */
   excludeIds?: Iterable<number>;
   /** Only include assets with Status === 1. */
@@ -94,12 +96,14 @@ export interface UseAssetTreeOptions {
 /** Shared asset filtering for tree/picker UIs. Keep status/type/exclude semantics in one place. */
 export function filterAssetTreeAssets(
   assets: asset_entity.Asset[],
-  { filterType, excludeIds, activeOnly }: UseAssetTreeOptions = {}
+  { filterType, filterTypes, excludeIds, activeOnly }: UseAssetTreeOptions = {}
 ): asset_entity.Asset[] {
   const exclude = excludeIds ? new Set(excludeIds) : undefined;
+  const typeSet = filterTypes ? new Set(filterTypes) : undefined;
   return assets.filter((asset) => {
     if (activeOnly && asset.Status !== 1) return false;
     if (filterType && asset.Type !== filterType) return false;
+    if (typeSet && !typeSet.has(asset.Type)) return false;
     if (exclude?.has(asset.ID)) return false;
     return true;
   });
@@ -110,12 +114,17 @@ export function filterAssetTreeAssets(
  * applies common filters, and returns a TreeNode[] with per-entity icons resolved.
  * Use this in any new asset picker so icon/filter behaviour stays consistent.
  */
-export function useAssetTree({ filterType, excludeIds, activeOnly }: UseAssetTreeOptions = {}): TreeNode[] {
+export function useAssetTree({
+  filterType,
+  filterTypes,
+  excludeIds,
+  activeOnly,
+}: UseAssetTreeOptions = {}): TreeNode[] {
   const { assets, groups } = useAssetStore();
 
   return useMemo(
-    () => buildAssetTree(assets, groups, { filterType, excludeIds, activeOnly }),
-    [assets, groups, filterType, excludeIds, activeOnly]
+    () => buildAssetTree(assets, groups, { filterType, filterTypes, excludeIds, activeOnly }),
+    [assets, groups, filterType, filterTypes, excludeIds, activeOnly]
   );
 }
 

--- a/frontend/src/lib/snippetRunners.ts
+++ b/frontend/src/lib/snippetRunners.ts
@@ -1,30 +1,46 @@
 import type { asset_entity } from "../../wailsjs/go/models";
-import { WriteSSH } from "../../wailsjs/go/ssh/SSH";
 import { useQueryStore } from "@/stores/queryStore";
 import { useTabStore, type TerminalTabMeta } from "@/stores/tabStore";
-import { useTerminalStore, type TerminalTabData } from "@/stores/terminalStore";
+import { TRANSPORTS, useTerminalStore, type TerminalTabData, type TerminalTransport } from "@/stores/terminalStore";
 import { bytesToBase64 } from "@/lib/terminalEncode";
 
 export type SnippetRunner = (asset: asset_entity.Asset, content: string) => Promise<void> | void;
 
-const runners = new Map<string, SnippetRunner>();
+interface SnippetRunnerRegistration {
+  runner: SnippetRunner;
+  assetTypes: readonly string[];
+}
 
-export function registerSnippetRunner(assetType: string, runner: SnippetRunner): void {
-  runners.set(assetType, runner);
+const runners = new Map<string, SnippetRunnerRegistration>();
+
+export function registerSnippetRunner(assetType: string, runner: SnippetRunner, aliases: readonly string[] = []): void {
+  const registration = { runner, assetTypes: [...new Set([assetType, ...aliases])] };
+  for (const type of registration.assetTypes) runners.set(type, registration);
 }
 
 export function getSnippetRunner(assetType: string): SnippetRunner | undefined {
-  return runners.get(assetType);
+  return runners.get(assetType)?.runner;
 }
 
-registerSnippetRunner("ssh", async (asset, content) => {
+export function getSnippetRunnerAssetTypes(assetType: string): readonly string[] {
+  return runners.get(assetType)?.assetTypes ?? [];
+}
+
+export function isSnippetRunnerCompatible(leftAssetType: string, rightAssetType: string): boolean {
+  const runner = runners.get(leftAssetType);
+  return runner !== undefined && runner === runners.get(rightAssetType);
+}
+
+const terminalSnippetRunner: SnippetRunner = async (asset, content) => {
   const existing = findExistingConnectedPane(asset.ID);
   if (existing) {
-    await WriteSSH(existing.paneId, bytesToBase64(new TextEncoder().encode(content)));
+    await TRANSPORTS[existing.transport].write(existing.paneId, bytesToBase64(new TextEncoder().encode(content)));
     return;
   }
   await useTerminalStore.getState().connect(asset, "", false, { initialInput: content });
-});
+};
+
+registerSnippetRunner("ssh", terminalSnippetRunner, ["local"]);
 
 registerSnippetRunner("database", (asset, content) => {
   useQueryStore.getState().openQueryTab(asset, { initialSQL: content });
@@ -34,7 +50,7 @@ registerSnippetRunner("mongodb", (asset, content) => {
   useQueryStore.getState().openQueryTab(asset, { initialMongo: content });
 });
 
-function findExistingConnectedPane(assetId: number): { paneId: string } | null {
+function findExistingConnectedPane(assetId: number): { paneId: string; transport: TerminalTransport } | null {
   const { tabData } = useTerminalStore.getState();
   const tabs = useTabStore.getState().tabs;
 
@@ -47,8 +63,9 @@ function findExistingConnectedPane(assetId: number): { paneId: string } | null {
     if (!data) continue;
 
     const paneId = data.activePaneId;
-    if (paneId && data.panes[paneId]?.connected) {
-      return { paneId };
+    const pane = data.panes[paneId];
+    if (paneId && pane?.connected) {
+      return { paneId, transport: pane.transport };
     }
   }
   return null;

--- a/frontend/src/lib/snippetTarget.ts
+++ b/frontend/src/lib/snippetTarget.ts
@@ -1,4 +1,5 @@
 import type { Tab } from "@/stores/tabStore";
+import { isSnippetRunnerCompatible } from "@/lib/snippetRunners";
 import type { asset_entity, snippet_entity, snippet_svc } from "../../wailsjs/go/models";
 
 type Asset = asset_entity.Asset;
@@ -13,10 +14,9 @@ type Category = snippet_svc.Category;
  */
 export type SnippetTarget = { kind: "active"; asset: Asset } | { kind: "pick" };
 
-/** Asset type implied by the active tab's tool, or null if it targets no asset. */
-function activeTabAsset(tab: Tab): { assetType: string; assetId: number } | null {
-  if (tab.meta.type === "terminal") return { assetType: "ssh", assetId: tab.meta.assetId };
-  if (tab.meta.type === "query") return { assetType: tab.meta.assetType, assetId: tab.meta.assetId };
+/** Asset ID implied by the active tab's tool, or null if it targets no asset. */
+function activeTabAssetId(tab: Tab): number | null {
+  if (tab.meta.type === "terminal" || tab.meta.type === "query") return tab.meta.assetId;
   return null;
 }
 
@@ -37,11 +37,11 @@ export function resolveSnippetTarget(params: {
   const assetType = categories.find((c) => c.id === snippet.Category)?.assetType ?? "";
   if (!assetType || !activeTab) return { kind: "pick" };
 
-  const active = activeTabAsset(activeTab);
-  if (!active || active.assetType !== assetType) return { kind: "pick" };
+  const activeAssetId = activeTabAssetId(activeTab);
+  if (activeAssetId === null) return { kind: "pick" };
 
-  const asset = assetsById.get(active.assetId);
-  if (!asset) return { kind: "pick" };
+  const asset = assetsById.get(activeAssetId);
+  if (!asset || !isSnippetRunnerCompatible(assetType, asset.Type)) return { kind: "pick" };
 
   return { kind: "active", asset };
 }


### PR DESCRIPTION
## 变更说明 / Summary

- Shell 代码片段 runner 同时注册 `ssh` 与 `local` 资产类型
- 已连接终端按活动 pane 的 transport 写入片段，分别走 SSH 或本地 PTY 输入通道
- 未连接的本地终端通过现有 `terminalStore.connect` 建连，并在连接成功后写入初始片段
- Shell 片段资产选择器同时展示 SSH 与本地终端
- 活动标签按 runner 兼容性匹配，避免串口等终端资产被误选
- 保持现有语义：插入片段但不自动发送回车

## 关联 Issue / Related Issue

Closes #301

## 截图 / Screenshots

无视觉样式修改。Windows 11 PowerShell / CMD / WSL 实机验证待完成。

## 测试 / Tests

- `frontend: vitest run`：244 files / 2325 tests passed
- `frontend: eslint .`
- `frontend: tsc -b`
- `make test`
- `make lint`

## 自检 / Checklist

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试