### PR TITLE
🐛 修正内容面 Ctrl/Cmd+C 被资产引用抢占，并支持网格键盘复制与粘贴行

### DIFF
--- a/docs/specs/2026-09-10-content-clipboard-ux.md
+++ b/docs/specs/2026-09-10-content-clipboard-ux.md
@@ -1,0 +1,106 @@
+# Content clipboard and selection UX
+
+> Status: Draft
+> Owner: OpsKat maintainers
+> Last updated: 2026-09-10
+
+**Objective:** Make `Ctrl/Cmd+C` copy what the user has selected in the focused content surface — asset references only from the asset sidebar — and let the database result grid copy and paste rows with the keyboard.
+
+**Hard invariant:** Except for the mis-captured keys named below, existing observable behaviour is unchanged: the asset-tree context menu still copies a reference; the grid context menu copy / copy-as / paste-cell / delete actions; the pending-edit → SQL-preview save flow; and the SFTP file manager's copy / cut / paste of files all keep their current result.
+
+## Problem
+
+1. **A global shortcut steals `Ctrl/Cmd+C` from every non-input surface.** `useKeyboardShortcuts` listens on `window` in the capture phase and, whenever an asset is selected, calls `shouldCopyAssetRef` (`frontend/src/hooks/useKeyboardShortcuts.ts:22`–`31`). That predicate (`frontend/src/lib/assetRef.ts:104`) only rules out inputs and a non-collapsed DOM selection, so a grid cell click — which produces a custom selection, not a DOM range — is read as "the user wants the asset reference". The reported symptom is a database user pressing `Ctrl/Cmd+C` on a selected cell and getting "Asset reference copied".
+2. **The same capture makes the SFTP file manager's clipboard keys dead.** `FileManagerPanel` registers its own non-capturing `window` keydown for copy / cut / paste of files (`frontend/src/components/terminal/FileManagerPanel.tsx:704`–`733`), but the capturing handler runs first and calls `stopPropagation`, so the SFTP listener never sees the event while an asset is selected. This is a real bug, not only a wrong reference copied.
+3. **The result grid has no keyboard copy.** `QueryResultTable` handles only arrow navigation, `Enter`/`F2` and `Escape` (`frontend/src/components/query/QueryResultTable.tsx:1159`). Copying a cell, a whole row, a column or several rows is reachable only through the row/cell context menu, even though the selection and the selection→TSV code already exist.
+4. **The editable grid cannot paste rows.** The only paste is the single-cell context-menu action (`QueryResultTable.tsx:796`), which writes the clipboard verbatim into one cell. There is no way to copy a row and paste it as a row, or to paste several rows — not even onto a newly added blank row, which is the flow the report names.
+5. **Lists that offer copy only in a menu.** The OSS object list has a multi-select (`selection`) but no keyboard copy; the Redis key list has a selected key and a "copy key name" menu item (`frontend/src/components/query/RedisKeyBrowser.tsx:441`, `:713`) but no keyboard copy. Both are currently stolen by problem 1.
+6. **A lying success message.** `OSSObjectDetail` reports the copy of the object key with `notifyCopied(t("oss.detail.copyKey"))` (`frontend/src/components/oss/OSSObjectDetail.tsx:46`) — `oss.detail.copyKey` is the button label ("复制键名"), so the toast says "Copy key name" instead of "Copied".
+
+## Actors and user stories
+
+1. As a user working in any content surface, I want `Ctrl/Cmd+C` to copy what I selected there, so that list and grid selections are not silently replaced by an asset reference.
+2. As a database user, I want to select a cell, a column, a row or several rows and copy them, so that moving data between environments needs no context-menu trip.
+3. As a database user, I want to paste a copied row (or several rows) into a new row of an editable table, so that inserting repeated data does not mean retyping every column.
+4. As a user browsing object storage or Redis keys, I want `Ctrl/Cmd+C` to copy the selected keys, so that I can paste them into a terminal or another tool.
+5. As an SFTP user, I want `Ctrl/Cmd+C/X/V` to copy, cut and paste files again.
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | The asset-reference shortcut fires **only while the asset sidebar is the focused surface**. Focus is granted to the sidebar when the user clicks a non-interactive part of it (asset row, group row, empty area). | The shortcut's intent is "copy the asset I am pointing at"; binding it to the surface that owns asset selection removes the cross-surface conflict at the root. Rejected: keeping the global fallback and having each content surface opt out — unmarked surfaces stay broken, which is the bug being fixed. Rejected: matching the event target against a data attribute — it cannot distinguish "an asset is selected elsewhere" from "this surface is what the user is acting on". |
+| 2 | Grid keyboard copy reuses the existing selection→TSV logic behind the context-menu copy, with precedence **row selection → column selection → focused cell**. | One code path means keyboard and menu copy cannot drift; the precedence matches the grid's existing mutual exclusion between row, column and cell selection. Rejected: a second, keyboard-specific serialiser — two sources of truth for the same action. |
+| 3 | A DOM text selection inside the grid, or an active cell editor, is left to the browser. | Dragging across cells to copy literal text, or copying inside the editor's input, must keep working. Rejected: always overriding — it would break copying a partial cell value. |
+| 4 | Grid keyboard paste parses clipboard text as tab-separated values with the project's existing parser, and writes the result as **pending edits** from an anchor cell. | Pending edits are the grid's established staging area; a paste therefore follows the same save and preview path as typing. The parser already exists in `frontend/src/lib/tableImport.ts`. Rejected: executing inserts directly — it would bypass the reviewed save flow. Rejected: comma detection — a single value containing commas must stay one cell when pasted. |
+| 5 | Paste that runs past the last displayed row appends that many unsaved rows, the same state the "+ 新增行" affordance creates. | The report explicitly asks to paste a row into a new row; appending is the existing mechanism for a row that does not exist in the database yet. Rejected: refusing the overflow — it forces the user to add rows by hand before pasting. |
+| 6 | Paste maps columns by their on-screen order from the anchor cell, and ignores cells beyond the last visible column. | It matches how copy writes the selection (visible columns in display order), so copy→paste round-trips inside the app. Rejected: matching by header name — the clipboard usually has no header row, and inventing one is a separate feature. |
+| 7 | Read-only grids copy but never paste. | SQL results and MongoDB documents have no pending-edit path; a paste target that cannot be saved would be a dead end. |
+| 8 | OSS and Redis list copy is bound to the platform copy key, not to a configurable shortcut. | It is the standard system copy key, and these lists have no shortcut entry today. Rejected: reusing `asset.copyRef` — it is a different action and the user may rebind it. |
+| 9 | The SFTP file manager is not restructured; only its captured keys are freed. | Its handler already has the correct semantics and its own open/active guard; the defect is upstream. Rejected: migrating it to a container-scoped handler — a drive-by refactor outside this change. |
+
+## Asset-reference shortcut scope
+
+While the asset sidebar is the focused surface, the asset-reference shortcut (default `Ctrl/Cmd+C`, rebindable in Settings) copies the selected asset's Markdown reference and shows the existing confirmation, provided an asset is selected and there is no non-collapsed text selection. While any other surface is focused, the shortcut does nothing and the key reaches whatever owns the focus.
+
+Clicking a non-interactive part of the sidebar — an asset row, a group row, or empty space — makes the sidebar the focused surface. Clicking a control inside it (the search field, the add buttons, a menu item) keeps that control's own behaviour; the search field keeps native copy. Taking this focus draws no focus ring, so selecting an asset looks unchanged.
+
+Because the global capture no longer applies outside the sidebar, the SFTP file manager's copy, cut and paste of files respond again, and every other content surface keeps native copying.
+
+## Result grid keyboard copy
+
+With the result grid focused and no cell editor open, `Ctrl/Cmd+C`:
+
+- copies every selected row across the visible columns, in current display order, when one or more rows are selected;
+- otherwise copies every displayed row across the selected columns, in current display order, when one or more columns are selected;
+- otherwise copies the focused cell's value;
+- otherwise does nothing.
+
+The clipboard receives tab-separated cells with newline-separated rows, identical to what the context-menu copy produces for the same selection. On success the user sees the existing "copied" confirmation. When text is selected in the page or a cell editor has focus, the key is left to the browser and no confirmation appears.
+
+This applies to the editable table grid, the SQL result grid and the MongoDB result grid.
+
+## Editable grid keyboard paste
+
+With an editable grid focused, a cell editor closed and non-empty clipboard text, `Ctrl/Cmd+V` pastes a table of tab-separated values starting at the focused cell. When only rows are selected, the anchor is the first selected row's first visible column. With no cell and no row selected, nothing is pasted.
+
+Each pasted value becomes a pending edit of the corresponding cell, exactly as if it had been typed. A single value pastes into the anchor cell. A paste whose rows or columns run past the end of the current page appends the missing rows as unsaved rows, so pasting a copied row into a newly added blank row fills that row, and pasting several rows adds as many rows as needed. Once editing is complete the user saves through the existing preview/confirm flow; no statement is executed by the paste itself.
+
+Values falling beyond the last visible column are discarded. When the clipboard cannot be read or contains only whitespace, nothing changes and no error is shown. Read-only grids ignore the paste entirely.
+
+## List keyboard copy
+
+With the OSS object list focused and one or more objects selected, `Ctrl/Cmd+C` copies the selected object keys, one per line, and confirms. With nothing selected it copies the object that has focus.
+
+With the Redis key list focused and a key selected, `Ctrl/Cmd+C` copies the key name and confirms.
+
+Copying the object key from the OSS detail panel now reports success with a "copied" message instead of the button label.
+
+## Consistency
+
+- The grid context menu's copy item shows the copy key binding next to it, as the asset tree's reference item already does.
+- The asset-reference entry in Settings states that it applies while the asset sidebar is focused.
+
+## Out of scope
+
+- Cell/row copy for the plain etcd and Kubernetes resource tables: they have no selection model, and adding one is a separate feature.
+- Pasting from the clipboard into the import dialog, which today reads a file.
+- CSV auto-detection, header-name column mapping, and rectangular (drag) selection in the grid.
+- Restructuring the SFTP file manager's keyboard handling.
+
+## Testing decisions
+
+| Seam | What it verifies | Prior art |
+|---|---|---|
+| `shouldCopyAssetRef` | Returns true only for a target inside the asset sidebar, with an asset selected and no text selection | `frontend/src/lib/assetRef.test.ts` |
+| `useKeyboardShortcuts` | Copies the reference when the sidebar is focused; leaves the key untouched elsewhere, including a grid surface | `frontend/src/__tests__/useKeyboardShortcuts.terminal.test.tsx` |
+| `QueryResultTable` keyboard copy | Cell / column / row / multi-row selections each write the expected TSV; text selection and editor focus defer to the browser | `frontend/src/__tests__/QueryResultTable.test.tsx` (clipboard mock, context-menu copy cases) |
+| `TableDataTab` keyboard paste | A pasted block becomes pending edits; overflow appends unsaved rows; a read-only grid has no paste | `frontend/src/__tests__/TableDataTab.toolbar.test.tsx`, `tableSql.test.ts` |
+| OSS / Redis list copy | The focused row's platform copy key writes the selected keys | `frontend/src/components/oss/__tests__/OSSObjectList.test.tsx`, `frontend/src/__tests__/RedisKeyBrowser.test.tsx` |
+| SFTP file manager | Copy with a file selected writes file paths, not an asset reference, while an asset is selected | `frontend/src/__tests__/FileManagerPanel.test.tsx` |
+
+The interaction is also exercised in the sandbox against a real database table (select → copy → add row → paste), because jsdom cannot render the virtualised grid's scroll geometry.
+
+## Open questions
+
+None.

--- a/docs/specs/2026-09-10-content-clipboard-ux.md
+++ b/docs/specs/2026-09-10-content-clipboard-ux.md
@@ -64,6 +64,8 @@ This applies to the editable table grid, the SQL result grid and the MongoDB res
 
 With an editable grid focused, a cell editor closed and non-empty clipboard text, `Ctrl/Cmd+V` pastes a table of tab-separated values starting at the focused cell. When only rows are selected, the anchor is the first selected row's first visible column. With no cell and no row selected, nothing is pasted.
 
+Closing a cell editor returns the keyboard focus to the grid, whether it is dismissed with `Esc` or committed with `Enter`, so the keys above keep working without an extra click: adding a row and pasting the copied row straight away fills that row.
+
 Each pasted value becomes a pending edit of the corresponding cell, exactly as if it had been typed. A single value pastes into the anchor cell. A paste whose rows or columns run past the end of the current page appends the missing rows as unsaved rows, so pasting a copied row into a newly added blank row fills that row, and pasting several rows adds as many rows as needed. Once editing is complete the user saves through the existing preview/confirm flow; no statement is executed by the paste itself.
 
 Values falling beyond the last visible column are discarded. A clipboard containing only whitespace changes nothing and shows no error. A clipboard that cannot be read also leaves the staged cells unchanged, but reports the failure — a denied clipboard permission is a real fault, not an empty selection. Read-only grids ignore the paste entirely.

--- a/docs/specs/2026-09-10-content-clipboard-ux.md
+++ b/docs/specs/2026-09-10-content-clipboard-ux.md
@@ -66,7 +66,7 @@ With an editable grid focused, a cell editor closed and non-empty clipboard text
 
 Each pasted value becomes a pending edit of the corresponding cell, exactly as if it had been typed. A single value pastes into the anchor cell. A paste whose rows or columns run past the end of the current page appends the missing rows as unsaved rows, so pasting a copied row into a newly added blank row fills that row, and pasting several rows adds as many rows as needed. Once editing is complete the user saves through the existing preview/confirm flow; no statement is executed by the paste itself.
 
-Values falling beyond the last visible column are discarded. When the clipboard cannot be read or contains only whitespace, nothing changes and no error is shown. Read-only grids ignore the paste entirely.
+Values falling beyond the last visible column are discarded. A clipboard containing only whitespace changes nothing and shows no error. A clipboard that cannot be read also leaves the staged cells unchanged, but reports the failure — a denied clipboard permission is a real fault, not an empty selection. Read-only grids ignore the paste entirely.
 
 ## List keyboard copy
 

--- a/frontend/src/__tests__/AssetTreeSidebarFocus.test.tsx
+++ b/frontend/src/__tests__/AssetTreeSidebarFocus.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TooltipProvider } from "@opskat/ui";
+import { AssetTree } from "@/components/layout/AssetTree";
+import { useAssetStore } from "@/stores/assetStore";
+import { ASSET_SIDEBAR_ATTR } from "@/lib/assetRef";
+import { asset_entity, group_entity } from "../../wailsjs/go/models";
+
+// The asset-reference shortcut is scoped to the asset sidebar, so the sidebar root
+// must carry the marker the predicate looks for and must take focus when the user
+// presses a non-interactive part of it (an asset row, a group row, empty space) —
+// otherwise the shortcut would never fire from the surface that owns it.
+
+function makeGroup(id: number, name: string): group_entity.Group {
+  return new group_entity.Group({ ID: id, Name: name, ParentID: 0, Icon: "", SortOrder: id, Status: 1 });
+}
+
+function makeAsset(id: number, name: string, groupId: number): asset_entity.Asset {
+  return new asset_entity.Asset({ ID: id, Name: name, Type: "ssh", GroupID: groupId, Icon: "", Status: 1 });
+}
+
+function renderTree() {
+  return render(
+    <TooltipProvider>
+      <AssetTree
+        collapsed={false}
+        onAddAsset={vi.fn()}
+        onAddGroup={vi.fn()}
+        onEditGroup={vi.fn()}
+        onGroupDetail={vi.fn()}
+        onEditAsset={vi.fn()}
+        onCopyAsset={vi.fn()}
+        onConnectAsset={vi.fn()}
+        onSelectAsset={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("AssetTree sidebar focus surface", () => {
+  beforeEach(() => {
+    useAssetStore.setState({
+      assets: [makeAsset(101, "Asset A", 1)],
+      groups: [makeGroup(1, "Folder A")],
+      selectedAssetId: null,
+      collapsedGroupIds: [],
+      initialized: true,
+      loading: false,
+    });
+  });
+
+  it("marks the sidebar root as the asset-reference surface", () => {
+    const { container } = renderTree();
+    expect(container.querySelector(`[${ASSET_SIDEBAR_ATTR}]`)).not.toBeNull();
+  });
+
+  it("takes focus when an asset row is pressed", () => {
+    const { container } = renderTree();
+    const sidebar = container.querySelector(`[${ASSET_SIDEBAR_ATTR}]`) as HTMLElement;
+
+    fireEvent.mouseDown(screen.getByText("Asset A"));
+
+    expect(document.activeElement).toBe(sidebar);
+  });
+
+  it("leaves focus in the search field", () => {
+    renderTree();
+    const input = screen.getByPlaceholderText("asset.search");
+    input.focus();
+
+    fireEvent.mouseDown(input);
+
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/frontend/src/__tests__/FileManagerPanel.test.tsx
+++ b/frontend/src/__tests__/FileManagerPanel.test.tsx
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect, useRef } from "react";
 import { FileManagerPanel } from "../components/terminal/FileManagerPanel";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import { useAssetStore } from "../stores/assetStore";
+import { isMac } from "../stores/shortcutStore";
 import { useTerminalStore, type TerminalDirectorySyncState } from "../stores/terminalStore";
 import { useSFTPStore, type SFTPTransfer } from "../stores/sftpStore";
 import { useExternalEditStore } from "../stores/externalEditStore";
@@ -295,6 +298,45 @@ describe("FileManagerPanel", () => {
 
     await waitFor(() => expect(clipboardWriteText).toHaveBeenCalledWith("/srv/app/demo.txt"));
     expect(toastSuccess).toHaveBeenCalledWith("sftp.filePathCopied", { position: "top-center", duration: 1000 });
+  });
+
+  it("keeps Ctrl/Cmd+C for the file manager while an asset is selected", async () => {
+    vi.mocked(SFTPListDir).mockResolvedValue([{ name: "demo.txt", isDir: false, size: 12, modTime: 0 }]);
+    useAssetStore.setState({ selectedAssetId: 1 });
+
+    // Mount the app-level shortcut listener: it used to capture Ctrl/Cmd+C globally
+    // and stop propagation, so the file manager's own listener never saw the key.
+    function ShortcutHost() {
+      useKeyboardShortcuts({ onToggleAIPanel: vi.fn(), onToggleSidebar: vi.fn(), onToggleCommandPalette: vi.fn() });
+      return null;
+    }
+
+    render(
+      <>
+        <ShortcutHost />
+        <FileManagerPanel tabId="tab1" sessionId="s1" isOpen width={280} onWidthChange={vi.fn()} />
+      </>
+    );
+
+    fireEvent.click(await screen.findByText("demo.txt"));
+
+    act(() => {
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "KeyC",
+          key: "c",
+          metaKey: isMac,
+          ctrlKey: !isMac,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("sftp-status-bar")).getByText("sftp.clipboardCopy")).toBeInTheDocument()
+    );
+    expect(clipboardWriteText).not.toHaveBeenCalled();
   });
 
   it("syncs the file manager to the active terminal cwd", async () => {

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -1037,25 +1037,25 @@ describe("QueryResultTable — keyboard copy", () => {
     expect(writeText).toHaveBeenCalledWith("alicia");
   });
 
-  it("copies displayed pending edits from a selected row", () => {
+  it("keeps the existing backing-value serialization for a selected row with pending edits", () => {
     renderGrid({ editable: true, edits: new Map([["0:name", "alicia"]]) });
     fireEvent.click(gutter(0));
 
     fireEvent.keyDown(gridContainer(), copyKey);
 
-    expect(writeText).toHaveBeenCalledWith("1\talicia");
+    expect(writeText).toHaveBeenCalledWith("1\talice");
   });
 
-  it("quotes delimiters in selected rows so the clipboard remains valid TSV", () => {
-    renderGrid({ editable: true, edits: new Map([["0:name", "alice\tadmin"]]) });
+  it("keeps the existing raw delimiter serialization for selected rows", () => {
+    render(<QueryResultTable columns={columns} rows={[{ id: 1, name: "alice\tadmin" }]} showRowNumber />);
     fireEvent.click(gutter(0));
 
     fireEvent.keyDown(gridContainer(), copyKey);
 
-    expect(writeText).toHaveBeenCalledWith('1\t"alice\tadmin"');
+    expect(writeText).toHaveBeenCalledWith("1\talice\tadmin");
   });
 
-  it("does not normalize date-looking text while quoting selected rows", () => {
+  it("does not normalize date-looking text in selected rows", () => {
     render(<QueryResultTable columns={["id", "value"]} rows={[{ id: 1, value: "2026/4/3" }]} showRowNumber />);
     fireEvent.click(gutter(0));
 
@@ -1081,6 +1081,26 @@ describe("QueryResultTable — keyboard copy", () => {
     fireEvent.keyDown(gridContainer(), copyKey);
 
     expect(writeText).toHaveBeenCalledWith("alice\nbob\ncarol");
+  });
+
+  it("keeps delimiter-containing context-menu row copy output unchanged", async () => {
+    render(<QueryResultTable columns={columns} rows={[{ id: 1, name: "alice\tadmin" }]} showRowNumber />);
+    fireEvent.click(gutter(0));
+
+    fireEvent.contextMenu(gutter(0), { clientX: 20, clientY: 40 });
+    fireEvent.click(screen.getByText("query.copyValue"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("1\talice\tadmin"));
+  });
+
+  it("keeps pending edits out of the existing context-menu row copy result", async () => {
+    renderGrid({ editable: true, edits: new Map([["0:name", "alicia"]]) });
+    fireEvent.click(gutter(0));
+
+    fireEvent.contextMenu(gutter(0), { clientX: 20, clientY: 40 });
+    fireEvent.click(screen.getByText("query.copyValue"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("1\talice"));
   });
 
   it("writes exactly the TSV the context menu writes for the same selection", async () => {
@@ -1225,9 +1245,12 @@ describe("QueryResultTable — keyboard paste", () => {
   it("appends after the last displayed row when the grid is sorted", async () => {
     readText.mockResolvedValue("7\tdave\n8\terin");
     const onPasteBlock = vi.fn();
-    renderGrid({ editable: false, onPasteBlock });
+    const { rerender } = render(
+      <QueryResultTable columns={columns} rows={rows} editable={false} showRowNumber onPasteBlock={onPasteBlock} />
+    );
     fireEvent.click(screen.getByTitle("query.columnActions:id"));
     fireEvent.click(screen.getByText("query.sortDesc"));
+    rerender(<QueryResultTable columns={columns} rows={rows} editable showRowNumber onPasteBlock={onPasteBlock} />);
     // Original row 0 is last on screen after sorting id descending.
     fireEvent.click(cell("0:id"));
 
@@ -1318,12 +1341,14 @@ describe("QueryResultTable — keyboard paste", () => {
     expect(readText).not.toHaveBeenCalled();
   });
 
-  it("never reads the clipboard when the grid does not accept block pastes", () => {
+  it("leaves the platform paste event untouched when the grid does not accept block pastes", () => {
     renderGrid({ editable: false });
     fireEvent.click(cell("1:name"));
+    const event = new KeyboardEvent("keydown", { ...pasteKey, bubbles: true, cancelable: true });
 
-    fireEvent.keyDown(gridContainer(), pasteKey);
+    gridContainer().dispatchEvent(event);
 
+    expect(event.defaultPrevented).toBe(false);
     expect(readText).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -1105,6 +1105,146 @@ describe("QueryResultTable — keyboard copy", () => {
   });
 });
 
+describe("QueryResultTable — keyboard paste", () => {
+  const columns = ["id", "name"];
+  const rows = [
+    { id: 1, name: "alice" },
+    { id: 2, name: "bob" },
+    { id: 3, name: "carol" },
+  ];
+
+  beforeEach(() => {
+    cleanup();
+    window.getSelection()?.removeAllRanges();
+  });
+
+  const gridContainer = () => document.querySelector(".query-table-scroll") as HTMLElement;
+  const cell = (key: string) => document.querySelector(`[data-cell-key="${key}"]`) as HTMLElement;
+  const gutter = (origIdx: number) => document.querySelector(`[data-row-header-key="${origIdx}"]`) as HTMLElement;
+  const pasteKey = { key: "v", code: "KeyV", ctrlKey: true, metaKey: true };
+
+  function renderGrid(props: Partial<React.ComponentProps<typeof QueryResultTable>> = {}) {
+    render(<QueryResultTable columns={columns} rows={rows} editable showRowNumber {...props} />);
+  }
+
+  it("pastes a tab-separated block from the focused cell as cell edits", async () => {
+    readText.mockResolvedValue("7\tdave");
+    const onPasteBlock = vi.fn();
+    renderGrid({ onPasteBlock });
+    fireEvent.click(cell("1:id"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() =>
+      expect(onPasteBlock).toHaveBeenCalledWith({
+        edits: [
+          { rowIdx: 1, col: "id", value: "7" },
+          { rowIdx: 1, col: "name", value: "dave" },
+        ],
+        newRowCount: 0,
+      })
+    );
+  });
+
+  it("anchors on the first selected row's first visible column when only rows are selected", async () => {
+    readText.mockResolvedValue("7\tdave");
+    const onPasteBlock = vi.fn();
+    renderGrid({ onPasteBlock });
+    fireEvent.click(gutter(2));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() =>
+      expect(onPasteBlock).toHaveBeenCalledWith({
+        edits: [
+          { rowIdx: 2, col: "id", value: "7" },
+          { rowIdx: 2, col: "name", value: "dave" },
+        ],
+        newRowCount: 0,
+      })
+    );
+  });
+
+  it("appends unsaved rows for a block that runs past the last row", async () => {
+    readText.mockResolvedValue("7\tdave\n8\terin");
+    const onPasteBlock = vi.fn();
+    renderGrid({ onPasteBlock });
+    fireEvent.click(cell("2:id"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() =>
+      expect(onPasteBlock).toHaveBeenCalledWith({
+        edits: [
+          { rowIdx: 2, col: "id", value: "7" },
+          { rowIdx: 2, col: "name", value: "dave" },
+          { rowIdx: 3, col: "id", value: "8" },
+          { rowIdx: 3, col: "name", value: "erin" },
+        ],
+        newRowCount: 1,
+      })
+    );
+  });
+
+  it("discards cells past the last visible column", async () => {
+    readText.mockResolvedValue("dave\toverflow");
+    const onPasteBlock = vi.fn();
+    renderGrid({ onPasteBlock });
+    fireEvent.click(cell("1:name"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() =>
+      expect(onPasteBlock).toHaveBeenCalledWith({
+        edits: [{ rowIdx: 1, col: "name", value: "dave" }],
+        newRowCount: 0,
+      })
+    );
+  });
+
+  it("ignores a clipboard that is empty or only whitespace", async () => {
+    readText.mockResolvedValue("   ");
+    const onPasteBlock = vi.fn();
+    renderGrid({ onPasteBlock });
+    fireEvent.click(cell("1:name"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() => expect(readText).toHaveBeenCalled());
+    expect(onPasteBlock).not.toHaveBeenCalled();
+  });
+
+  it("ignores an unreadable clipboard without reporting an error", async () => {
+    readText.mockRejectedValue(new Error("clipboard denied"));
+    const onPasteBlock = vi.fn();
+    renderGrid({ onPasteBlock });
+    fireEvent.click(cell("1:name"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() => expect(readText).toHaveBeenCalled());
+    expect(onPasteBlock).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("never reads the clipboard without a cell or row selection", () => {
+    renderGrid({ onPasteBlock: vi.fn() });
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    expect(readText).not.toHaveBeenCalled();
+  });
+
+  it("never reads the clipboard when the grid does not accept block pastes", () => {
+    renderGrid({ editable: false });
+    fireEvent.click(cell("1:name"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    expect(readText).not.toHaveBeenCalled();
+  });
+});
+
 describe("QueryResultTable — row context menu", () => {
   const columns = ["id", "name"];
   const rows = [

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -1037,6 +1037,33 @@ describe("QueryResultTable — keyboard copy", () => {
     expect(writeText).toHaveBeenCalledWith("alicia");
   });
 
+  it("copies displayed pending edits from a selected row", () => {
+    renderGrid({ editable: true, edits: new Map([["0:name", "alicia"]]) });
+    fireEvent.click(gutter(0));
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("1\talicia");
+  });
+
+  it("quotes delimiters in selected rows so the clipboard remains valid TSV", () => {
+    renderGrid({ editable: true, edits: new Map([["0:name", "alice\tadmin"]]) });
+    fireEvent.click(gutter(0));
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith('1\t"alice\tadmin"');
+  });
+
+  it("does not normalize date-looking text while quoting selected rows", () => {
+    render(<QueryResultTable columns={["id", "value"]} rows={[{ id: 1, value: "2026/4/3" }]} showRowNumber />);
+    fireEvent.click(gutter(0));
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("1\t2026/4/3");
+  });
+
   it("copies every selected row across the visible columns in display order", () => {
     renderGrid();
     fireEvent.click(gutter(0));
@@ -1247,7 +1274,30 @@ describe("QueryResultTable — keyboard paste", () => {
     expect(onPasteBlock).not.toHaveBeenCalled();
   });
 
-  it("ignores an unreadable clipboard without reporting an error", async () => {
+  it("preserves an all-empty row in the middle of a pasted block", async () => {
+    readText.mockResolvedValue("7\tdave\n\t\n9\tfrank");
+    const onPasteBlock = vi.fn();
+    renderGrid({ onPasteBlock });
+    fireEvent.click(cell("0:id"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() =>
+      expect(onPasteBlock).toHaveBeenCalledWith({
+        edits: [
+          { rowIdx: 0, col: "id", value: "7" },
+          { rowIdx: 0, col: "name", value: "dave" },
+          { rowIdx: 1, col: "id", value: "" },
+          { rowIdx: 1, col: "name", value: "" },
+          { rowIdx: 2, col: "id", value: "9" },
+          { rowIdx: 2, col: "name", value: "frank" },
+        ],
+        newRowCount: 0,
+      })
+    );
+  });
+
+  it("reports an unreadable clipboard without changing cells", async () => {
     readText.mockRejectedValue(new Error("clipboard denied"));
     const onPasteBlock = vi.fn();
     renderGrid({ onPasteBlock });
@@ -1257,7 +1307,7 @@ describe("QueryResultTable — keyboard paste", () => {
 
     await waitFor(() => expect(readText).toHaveBeenCalled());
     expect(onPasteBlock).not.toHaveBeenCalled();
-    expect(toastError).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith("Error: clipboard denied");
   });
 
   it("never reads the clipboard without a cell or row selection", () => {

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -1328,6 +1328,53 @@ describe("QueryResultTable — keyboard paste", () => {
   });
 });
 
+describe("QueryResultTable — cell editor focus", () => {
+  const columns = ["id", "name"];
+  const rows = [
+    { id: 1, name: "alice" },
+    { id: 2, name: "bob" },
+  ];
+
+  beforeEach(cleanup);
+
+  const gridContainer = () => document.querySelector(".query-table-scroll") as HTMLElement;
+  const cell = (key: string) => document.querySelector(`[data-cell-key="${key}"]`) as HTMLElement;
+  // The grid binds the platform paste key itself, not a registry binding.
+  const pasteKey = { key: "v", code: "KeyV", ctrlKey: true, metaKey: true };
+
+  function renderGrid(props: Partial<React.ComponentProps<typeof QueryResultTable>> = {}) {
+    render(<QueryResultTable columns={columns} rows={rows} editable showRowNumber {...props} />);
+  }
+
+  it("returns focus to the grid when the editor is dismissed, so the next key still reaches it", async () => {
+    readText.mockResolvedValue("bob");
+    const onPasteBlock = vi.fn();
+    renderGrid({ onPasteBlock });
+    fireEvent.click(cell("0:name"));
+    fireEvent.doubleClick(cell("0:name"));
+    const input = document.querySelector('[data-cell-key="0:name"] input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    // A real key press is delivered to whatever has focus.
+    expect(document.activeElement).toBe(gridContainer());
+    fireEvent.keyDown(document.activeElement as HTMLElement, pasteKey);
+    await waitFor(() => expect(onPasteBlock).toHaveBeenCalled());
+  });
+
+  it("returns focus to the grid when the editor is committed with Enter", () => {
+    renderGrid();
+    fireEvent.click(cell("0:name"));
+    fireEvent.doubleClick(cell("0:name"));
+    const input = document.querySelector('[data-cell-key="0:name"] input') as HTMLInputElement;
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(document.activeElement).toBe(gridContainer());
+  });
+});
+
 describe("QueryResultTable — row context menu", () => {
   const columns = ["id", "name"];
   const rows = [

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import userEvent from "@testing-library/user-event";
 import { QueryResultTable } from "@/components/query/QueryResultTable";
 import { CELL_DISPLAY_MAX_CHARS, cellValueToDisplayText, cellValueToText } from "@/lib/cellValue";
+import { formatModKey } from "@/stores/shortcutStore";
 
 const { toastError, toastSuccess } = vi.hoisted(() => ({
   toastError: vi.fn(),
@@ -449,7 +450,8 @@ describe("QueryResultTable — cell context actions", () => {
       })
       .filter(Boolean);
 
-    const copyIndex = labels.indexOf("query.copyValue");
+    // The copy item carries its key hint, so match its label by prefix.
+    const copyIndex = labels.findIndex((label) => label?.startsWith("query.copyValue"));
     expect(labels[copyIndex + 1]).toBe("query.copyAs");
   });
 
@@ -989,6 +991,117 @@ describe("QueryResultTable — row selection", () => {
 
     expect(cornerCell().style.width).toBe("80px");
     expect(gutter(0).style.width).toBe("80px");
+  });
+});
+
+describe("QueryResultTable — keyboard copy", () => {
+  const columns = ["id", "name"];
+  const rows = [
+    { id: 1, name: "alice" },
+    { id: 2, name: "bob" },
+    { id: 3, name: "carol" },
+  ];
+
+  beforeEach(() => {
+    cleanup();
+    window.getSelection()?.removeAllRanges();
+  });
+
+  const gridContainer = () => document.querySelector(".query-table-scroll") as HTMLElement;
+  const cell = (key: string) => document.querySelector(`[data-cell-key="${key}"]`) as HTMLElement;
+  const gutter = (origIdx: number) => document.querySelector(`[data-row-header-key="${origIdx}"]`) as HTMLElement;
+  // The grid binds the platform copy key itself, not a registry binding.
+  const copyKey = { key: "c", code: "KeyC", ctrlKey: true, metaKey: true };
+
+  function renderGrid(props: Partial<React.ComponentProps<typeof QueryResultTable>> = {}) {
+    render(<QueryResultTable columns={columns} rows={rows} showRowNumber {...props} />);
+  }
+
+  it("copies the focused cell value", async () => {
+    renderGrid();
+    fireEvent.click(cell("0:name"));
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("alice");
+    // The confirmation lands after the clipboard write resolves.
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+  });
+
+  it("copies every selected row across the visible columns in display order", () => {
+    renderGrid();
+    fireEvent.click(gutter(0));
+    fireEvent.click(gutter(2), { ctrlKey: true });
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("1\talice\n3\tcarol");
+  });
+
+  it("copies every visible row across the selected columns", () => {
+    renderGrid();
+    fireEvent.click(screen.getByText("name"));
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("alice\nbob\ncarol");
+  });
+
+  it("writes exactly the TSV the context menu writes for the same selection", async () => {
+    renderGrid({ editable: true });
+    fireEvent.click(gutter(0));
+    fireEvent.click(gutter(2), { ctrlKey: true });
+
+    fireEvent.contextMenu(gutter(2), { clientX: 20, clientY: 40 });
+    fireEvent.click(screen.getByText("query.copyValue"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const menuText = writeText.mock.calls[0][0] as string;
+    writeText.mockReset();
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(menuText).toBe("1\talice\n3\tcarol");
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(menuText));
+  });
+
+  it("leaves Ctrl/Cmd+C to the browser while page text is selected", () => {
+    renderGrid();
+    fireEvent.click(cell("0:name"));
+    const range = document.createRange();
+    range.selectNodeContents(cell("0:name"));
+    const selection = window.getSelection()!;
+    selection.addRange(range);
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("leaves Ctrl/Cmd+C to the open cell editor", () => {
+    renderGrid({ editable: true });
+    fireEvent.click(cell("0:name"));
+    fireEvent.keyDown(gridContainer(), { key: "F2" });
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("copies nothing when there is no selection", () => {
+    renderGrid();
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("shows the copy key binding next to the context menu copy item", () => {
+    renderGrid();
+
+    fireEvent.contextMenu(cell("0:name"), { clientX: 20, clientY: 40 });
+
+    const item = screen.getByText("query.copyValue").closest("button")!;
+    expect(within(item).getByText(formatModKey("KeyC"))).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/__tests__/QueryResultTable.test.tsx
+++ b/frontend/src/__tests__/QueryResultTable.test.tsx
@@ -1028,6 +1028,15 @@ describe("QueryResultTable — keyboard copy", () => {
     await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
   });
 
+  it("copies the displayed pending edit from the focused cell", () => {
+    renderGrid({ editable: true, edits: new Map([["0:name", "alicia"]]) });
+    fireEvent.click(cell("0:name"));
+
+    fireEvent.keyDown(gridContainer(), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("alicia");
+  });
+
   it("copies every selected row across the visible columns in display order", () => {
     renderGrid();
     fireEvent.click(gutter(0));
@@ -1178,6 +1187,30 @@ describe("QueryResultTable — keyboard paste", () => {
         edits: [
           { rowIdx: 2, col: "id", value: "7" },
           { rowIdx: 2, col: "name", value: "dave" },
+          { rowIdx: 3, col: "id", value: "8" },
+          { rowIdx: 3, col: "name", value: "erin" },
+        ],
+        newRowCount: 1,
+      })
+    );
+  });
+
+  it("appends after the last displayed row when the grid is sorted", async () => {
+    readText.mockResolvedValue("7\tdave\n8\terin");
+    const onPasteBlock = vi.fn();
+    renderGrid({ editable: false, onPasteBlock });
+    fireEvent.click(screen.getByTitle("query.columnActions:id"));
+    fireEvent.click(screen.getByText("query.sortDesc"));
+    // Original row 0 is last on screen after sorting id descending.
+    fireEvent.click(cell("0:id"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() =>
+      expect(onPasteBlock).toHaveBeenCalledWith({
+        edits: [
+          { rowIdx: 0, col: "id", value: "7" },
+          { rowIdx: 0, col: "name", value: "dave" },
           { rowIdx: 3, col: "id", value: "8" },
           { rowIdx: 3, col: "name", value: "erin" },
         ],

--- a/frontend/src/__tests__/RedisKeyBrowser.test.tsx
+++ b/frontend/src/__tests__/RedisKeyBrowser.test.tsx
@@ -298,7 +298,7 @@ describe("RedisKeyBrowser", () => {
   });
 
   it("copies the selected key name with Ctrl/Cmd+C", () => {
-    const writeText = vi.fn();
+    const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
     const state = useQueryStore.getState().redisStates["query-10"];
     useQueryStore.setState({
@@ -326,6 +326,34 @@ describe("RedisKeyBrowser", () => {
     screen.getByTestId("redis-key-tree").dispatchEvent(ev);
 
     expect(ev.defaultPrevented).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("leaves Ctrl/Cmd+C to the browser while key text is selected", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    const state = useQueryStore.getState().redisStates["query-10"];
+    useQueryStore.setState({
+      redisStates: { "query-10": { ...state, selectedKey: "common:user:2" } },
+    });
+    render(<RedisKeyBrowser tabId="query-10" />);
+    fireEvent.click(screen.getByTitle("query.listView"));
+    const label = screen.getByText("common:user:2");
+    const range = document.createRange();
+    range.selectNodeContents(label);
+    window.getSelection()!.removeAllRanges();
+    window.getSelection()!.addRange(range);
+    const event = new KeyboardEvent("keydown", {
+      key: "c",
+      ctrlKey: true,
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    label.closest("button")!.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
     expect(writeText).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/RedisKeyBrowser.test.tsx
+++ b/frontend/src/__tests__/RedisKeyBrowser.test.tsx
@@ -296,4 +296,36 @@ describe("RedisKeyBrowser", () => {
 
     expect(RedisScanKeys).toHaveBeenCalledWith(expect.objectContaining({ match: "dispatcher", exact: true }));
   });
+
+  it("copies the selected key name with Ctrl/Cmd+C", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    const state = useQueryStore.getState().redisStates["query-10"];
+    useQueryStore.setState({
+      redisStates: { "query-10": { ...state, selectedKey: "common:user:2" } },
+    });
+    render(<RedisKeyBrowser tabId="query-10" />);
+
+    fireEvent.keyDown(screen.getByTestId("redis-key-tree"), { key: "c", ctrlKey: true, metaKey: true });
+
+    expect(writeText).toHaveBeenCalledWith("common:user:2");
+  });
+
+  it("leaves Ctrl/Cmd+C alone when no key is selected", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    render(<RedisKeyBrowser tabId="query-10" />);
+
+    const ev = new KeyboardEvent("keydown", {
+      key: "c",
+      ctrlKey: true,
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    screen.getByTestId("redis-key-tree").dispatchEvent(ev);
+
+    expect(ev.defaultPrevented).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/__tests__/TableDataTab.paste.test.tsx
+++ b/frontend/src/__tests__/TableDataTab.paste.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { TableDataTab } from "@/components/query/TableDataTab";
 import { useQueryStore } from "@/stores/queryStore";
 import { useTabStore } from "@/stores/tabStore";
@@ -108,6 +109,28 @@ describe("TableDataTab keyboard paste", () => {
 
     await waitFor(() => expect(insertCalls()).toHaveLength(1));
     expect(insertCalls()[0]).toContain("(`id`, `name`) VALUES ('9', 'zoe')");
+  });
+
+  it("anchors a newly added row at the first visible column", async () => {
+    const user = userEvent.setup();
+    await renderLoaded();
+
+    await user.click(screen.getByTitle("query.displaySettings"));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "id" }));
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByTitle("query.addRow"));
+
+    expect(document.querySelector('[data-cell-key="2:name"] input')).toBeTruthy();
+    fireEvent.keyDown(document.querySelector('[data-cell-key="2:name"] input') as HTMLInputElement, { key: "Escape" });
+    readText.mockResolvedValue("zoe");
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn(), readText },
+    });
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() => expect(cell("2:name")).toHaveTextContent("zoe"));
   });
 
   it("appends unsaved rows for a block past the last row and inserts them", async () => {

--- a/frontend/src/__tests__/TableDataTab.paste.test.tsx
+++ b/frontend/src/__tests__/TableDataTab.paste.test.tsx
@@ -111,6 +111,20 @@ describe("TableDataTab keyboard paste", () => {
     expect(insertCalls()[0]).toContain("(`id`, `name`) VALUES ('9', 'zoe')");
   });
 
+  it("pastes into a newly added row right after its editor is closed", async () => {
+    readText.mockResolvedValue("9\tzoe");
+    await renderLoaded();
+
+    fireEvent.click(screen.getByTitle("query.addRow"));
+    fireEvent.keyDown(document.querySelector('[data-cell-key="2:id"] input') as HTMLInputElement, { key: "Escape" });
+
+    // A real platform key press goes to the focused element, which must be the grid again.
+    fireEvent.keyDown(document.activeElement as HTMLElement, pasteKey);
+
+    await waitFor(() => expect(cell("2:id")).toHaveTextContent("9"));
+    expect(cell("2:name")).toHaveTextContent("zoe");
+  });
+
   it("anchors a newly added row at the first visible column", async () => {
     const user = userEvent.setup();
     await renderLoaded();

--- a/frontend/src/__tests__/TableDataTab.paste.test.tsx
+++ b/frontend/src/__tests__/TableDataTab.paste.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { TableDataTab } from "@/components/query/TableDataTab";
+import { useQueryStore } from "@/stores/queryStore";
+import { useTabStore } from "@/stores/tabStore";
+import { ExecuteSQL, OpenTable } from "../../wailsjs/go/query/Query";
+
+// Pasting a copied row into an editable table is the flow the report names: copy a row in
+// one table, add a blank row here, paste. These tests drive the real tab, so the row-index
+// arithmetic between the grid's coordinate space and the pending-edit staging is covered.
+
+const readText = vi.fn();
+
+function openTablePayload(rows: Record<string, unknown>[]) {
+  return JSON.stringify({
+    columns: ["id", "name"],
+    columnTypes: {},
+    columnRules: [],
+    primaryKeys: ["id"],
+    totalCount: rows.length,
+    firstPage: rows,
+    pageSize: 1000,
+  });
+}
+
+function setupStores() {
+  useTabStore.setState({
+    tabs: [
+      {
+        id: "query-1",
+        type: "query",
+        label: "db",
+        meta: {
+          type: "query",
+          assetId: 1,
+          assetName: "db",
+          assetIcon: "",
+          assetType: "database",
+          driver: "mysql",
+        },
+      },
+    ],
+    activeTabId: "query-1",
+  });
+  useQueryStore.setState({
+    dbStates: {
+      "query-1": {
+        databases: ["appdb"],
+        tables: { appdb: ["users"] },
+        loadingTables: {},
+        expandedDbs: ["appdb"],
+        expandedSchemas: {},
+        loadingDbs: false,
+        innerTabs: [{ id: "table-1", type: "table", database: "appdb", table: "users" }],
+        activeInnerTabId: "table-1",
+        error: null,
+      },
+    },
+  });
+}
+
+const ROWS = [
+  { id: 1, name: "ada" },
+  { id: 2, name: "bob" },
+];
+
+const gridContainer = () => document.querySelector(".query-table-scroll") as HTMLElement;
+const cell = (key: string) => document.querySelector(`[data-cell-key="${key}"]`) as HTMLElement;
+const pasteKey = { key: "v", code: "KeyV", ctrlKey: true, metaKey: true };
+
+const executeSqlCalls = () => vi.mocked(ExecuteSQL).mock.calls.map(([, sql]) => String(sql));
+const insertCalls = () => executeSqlCalls().filter((sql) => sql.startsWith("INSERT"));
+
+async function renderLoaded() {
+  vi.mocked(OpenTable).mockResolvedValue(openTablePayload(ROWS));
+  render(<TableDataTab tabId="query-1" innerTabId="table-1" database="appdb" table="users" />);
+  await waitFor(() => expect(cell("0:id")).toBeTruthy());
+}
+
+describe("TableDataTab keyboard paste", () => {
+  beforeEach(() => {
+    readText.mockReset();
+    vi.mocked(ExecuteSQL).mockReset();
+    vi.mocked(OpenTable).mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn(), readText },
+    });
+    setupStores();
+  });
+
+  it("fills a blank row added for the paste and inserts the pasted values", async () => {
+    vi.mocked(ExecuteSQL).mockResolvedValue(JSON.stringify({ affected_rows: 1 }));
+    readText.mockResolvedValue("9\tzoe");
+    await renderLoaded();
+
+    fireEvent.click(screen.getByTitle("query.addRow"));
+    // Adding a row opens the first cell's editor; the grid only pastes with the editor closed.
+    fireEvent.keyDown(document.querySelector('[data-cell-key="2:id"] input') as HTMLInputElement, { key: "Escape" });
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() => expect(cell("2:id")).toHaveTextContent("9"));
+    expect(cell("2:name")).toHaveTextContent("zoe");
+
+    fireEvent.click(screen.getByTitle("query.applyChanges"));
+    fireEvent.click(screen.getByText("query.confirmExecute"));
+
+    await waitFor(() => expect(insertCalls()).toHaveLength(1));
+    expect(insertCalls()[0]).toContain("(`id`, `name`) VALUES ('9', 'zoe')");
+  });
+
+  it("appends unsaved rows for a block past the last row and inserts them", async () => {
+    vi.mocked(ExecuteSQL).mockResolvedValue(JSON.stringify({ affected_rows: 1 }));
+    readText.mockResolvedValue("8\terin\n9\tzoe");
+    await renderLoaded();
+
+    fireEvent.click(cell("1:id"));
+
+    fireEvent.keyDown(gridContainer(), pasteKey);
+
+    await waitFor(() => expect(cell("1:id")).toHaveTextContent("8"));
+    expect(cell("2:name")).toHaveTextContent("zoe");
+
+    fireEvent.click(screen.getByTitle("query.applyChanges"));
+    fireEvent.click(screen.getByText("query.confirmExecute"));
+
+    await waitFor(() => expect(insertCalls()).toHaveLength(1));
+    expect(insertCalls()[0]).toContain("(`id`, `name`) VALUES ('9', 'zoe')");
+    // The first pasted row overwrites the existing row 2, so it stages an UPDATE.
+    expect(executeSqlCalls().some((sql) => sql.startsWith("UPDATE") && sql.includes("'8'"))).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/tableImport.test.ts
+++ b/frontend/src/__tests__/tableImport.test.ts
@@ -34,6 +34,14 @@ describe("parseTabSeparatedRows", () => {
   it("keeps quotes that occur inside an unquoted clipboard value", () => {
     expect(parseTabSeparatedRows('1\tO"Reilly')).toEqual([["1", 'O"Reilly']]);
   });
+
+  it("keeps an unmatched leading quote in a clipboard value", () => {
+    expect(parseTabSeparatedRows('1\t"draft')).toEqual([["1", '"draft']]);
+  });
+
+  it("still parses complete quoted clipboard fields", () => {
+    expect(parseTabSeparatedRows('1\t"line\nbreak"\t"say ""hi"""')).toEqual([["1", "line\nbreak", 'say "hi"']]);
+  });
 });
 
 describe("table import helpers", () => {

--- a/frontend/src/__tests__/tableImport.test.ts
+++ b/frontend/src/__tests__/tableImport.test.ts
@@ -37,6 +37,13 @@ describe("parseTabSeparatedRows", () => {
 });
 
 describe("table import helpers", () => {
+  it("keeps the existing qualifier handling for file imports", () => {
+    expect(parseDelimitedText('name\nO"Reilly', ",")).toEqual({
+      headers: ["name"],
+      rows: [["OReilly"]],
+    });
+  });
+
   it("parses quoted CSV cells with commas, quotes, and embedded newlines", () => {
     expect(parseDelimitedText('id,name,note\n1,"Alice, A.","line\nbreak"\n2,"say ""hi""",ok', ",")).toEqual({
       headers: ["id", "name", "note"],

--- a/frontend/src/__tests__/tableImport.test.ts
+++ b/frontend/src/__tests__/tableImport.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { buildImportInsertSql, detectDelimiter, parseDelimitedText, parseImportSourceText } from "@/lib/tableImport";
+import {
+  buildImportInsertSql,
+  detectDelimiter,
+  parseDelimitedText,
+  parseImportSourceText,
+  parseTabSeparatedRows,
+} from "@/lib/tableImport";
+
+describe("parseTabSeparatedRows", () => {
+  it("parses a pasted block without treating the first row as a header", () => {
+    expect(parseTabSeparatedRows("1\tAlice\n2\tBob")).toEqual([
+      ["1", "Alice"],
+      ["2", "Bob"],
+    ]);
+  });
+
+  it("keeps a value containing a comma in one cell", () => {
+    expect(parseTabSeparatedRows("1\tAlice, A.")).toEqual([["1", "Alice, A."]]);
+  });
+
+  it("keeps empty cells and drops a trailing blank line", () => {
+    expect(parseTabSeparatedRows("1\t\t3\n")).toEqual([["1", "", "3"]]);
+  });
+});
 
 describe("table import helpers", () => {
   it("parses quoted CSV cells with commas, quotes, and embedded newlines", () => {

--- a/frontend/src/__tests__/tableImport.test.ts
+++ b/frontend/src/__tests__/tableImport.test.ts
@@ -22,6 +22,18 @@ describe("parseTabSeparatedRows", () => {
   it("keeps empty cells and drops a trailing blank line", () => {
     expect(parseTabSeparatedRows("1\t\t3\n")).toEqual([["1", "", "3"]]);
   });
+
+  it("preserves all-empty rows inside a pasted block", () => {
+    expect(parseTabSeparatedRows("1\tAlice\n\t\n3\tCarol")).toEqual([
+      ["1", "Alice"],
+      ["", ""],
+      ["3", "Carol"],
+    ]);
+  });
+
+  it("keeps quotes that occur inside an unquoted clipboard value", () => {
+    expect(parseTabSeparatedRows('1\tO"Reilly')).toEqual([["1", 'O"Reilly']]);
+  });
 });
 
 describe("table import helpers", () => {

--- a/frontend/src/__tests__/useKeyboardShortcuts.terminal.test.tsx
+++ b/frontend/src/__tests__/useKeyboardShortcuts.terminal.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/lib/assetRef", async () => {
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { useShortcutStore, DEFAULT_SHORTCUTS, isMac, type ShortcutBinding } from "../stores/shortcutStore";
 import { useAssetStore } from "../stores/assetStore";
+import { ASSET_SIDEBAR_ATTR } from "../lib/assetRef";
 
 // Build a keydown event whose modifier flags match `binding` the same way
 // eventMatchesBinding() reads them, so the test works on both macOS and non-mac.
@@ -111,19 +112,32 @@ describe("useKeyboardShortcuts — asset.copyRef", () => {
     useAssetStore.setState({ selectedAssetId: 1 });
   });
 
-  it("copies the selected asset markdown ref on Ctrl/Cmd+C", () => {
+  it("copies the selected asset markdown ref when the asset sidebar is focused", () => {
     renderShortcuts();
-    const div = document.createElement("div");
-    document.body.appendChild(div);
-    const ev = keydownFrom(div, DEFAULT_SHORTCUTS["asset.copyRef"]);
+    const sidebar = document.createElement("div");
+    sidebar.setAttribute(ASSET_SIDEBAR_ATTR, "");
+    document.body.appendChild(sidebar);
+    const ev = keydownFrom(sidebar, DEFAULT_SHORTCUTS["asset.copyRef"]);
     expect(ev.defaultPrevented).toBe(true);
     expect(copySelectedAssetMarkdownRef).toHaveBeenCalledTimes(1);
   });
 
-  it("does not steal Ctrl/Cmd+C from an input", () => {
+  it("leaves Ctrl/Cmd+C to a surface outside the asset sidebar", () => {
     renderShortcuts();
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const ev = keydownFrom(div, DEFAULT_SHORTCUTS["asset.copyRef"]);
+    expect(ev.defaultPrevented).toBe(false);
+    expect(copySelectedAssetMarkdownRef).not.toHaveBeenCalled();
+  });
+
+  it("does not steal Ctrl/Cmd+C from an input inside the asset sidebar", () => {
+    renderShortcuts();
+    const sidebar = document.createElement("div");
+    sidebar.setAttribute(ASSET_SIDEBAR_ATTR, "");
     const input = document.createElement("input");
-    document.body.appendChild(input);
+    sidebar.appendChild(input);
+    document.body.appendChild(sidebar);
     const ev = keydownFrom(input, DEFAULT_SHORTCUTS["asset.copyRef"]);
     expect(ev.defaultPrevented).toBe(false);
     expect(copySelectedAssetMarkdownRef).not.toHaveBeenCalled();

--- a/frontend/src/components/layout/AssetTree.tsx
+++ b/frontend/src/components/layout/AssetTree.tsx
@@ -133,6 +133,17 @@ function saveHideEmpty(value: boolean) {
   localStorage.setItem(HIDE_EMPTY_LS_KEY, value ? "true" : "false");
 }
 
+// Controls inside the sidebar keep their own focus and behaviour (the search field keeps
+// native copy). Any other press — an asset row, a group row, empty space — makes the
+// sidebar the focused surface, which is what grants the asset-reference shortcut.
+const SIDEBAR_INTERACTIVE_SELECTOR = "input, textarea, select, button, a[href], [contenteditable]";
+
+function focusSidebarUnlessInteractive(e: React.MouseEvent<HTMLDivElement>) {
+  const target = e.target as HTMLElement | null;
+  if (target?.closest(SIDEBAR_INTERACTIVE_SELECTOR)) return;
+  e.currentTarget.focus({ preventScroll: true });
+}
+
 function afterDragCleanupFrame() {
   return new Promise<void>((resolve) => {
     if (typeof window !== "undefined" && window.requestAnimationFrame) {
@@ -517,7 +528,13 @@ export function AssetTree({
   if (collapsed) return null;
 
   return (
-    <div data-testid="asset-tree" className="flex h-full w-full flex-col border-r border-panel-divider bg-sidebar">
+    <div
+      data-testid="asset-tree"
+      data-asset-sidebar=""
+      tabIndex={-1}
+      onMouseDown={focusSidebarUnlessInteractive}
+      className="flex h-full w-full flex-col border-r border-panel-divider bg-sidebar outline-none"
+    >
       {/* Drag region for frameless window */}
       <div
         className={`${isFullscreen ? "h-0" : "h-8"} w-full shrink-0`}

--- a/frontend/src/components/oss/OSSObjectDetail.tsx
+++ b/frontend/src/components/oss/OSSObjectDetail.tsx
@@ -43,7 +43,7 @@ export function OSSObjectDetail({
     [t("oss.detail.lastModified"), object.lastModified ? new Date(object.lastModified * 1000).toLocaleString() : "—"],
   ];
   const copyKey = () =>
-    void navigator.clipboard?.writeText(object.key).then(() => notifyCopied(t("oss.detail.copyKey")));
+    void navigator.clipboard?.writeText(object.key).then(() => notifyCopied(t("oss.detail.copyKeyCopied")));
   const iconButtonClass =
     "cursor-pointer rounded-sm p-0.5 outline-none hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring/45";
 

--- a/frontend/src/components/oss/OSSObjectDetail.tsx
+++ b/frontend/src/components/oss/OSSObjectDetail.tsx
@@ -1,5 +1,6 @@
 import { createElement } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { Button } from "@opskat/ui";
 import { Copy, Link, Download, Trash2, X, Pencil, MoveRight } from "lucide-react";
 import type { oss_svc } from "../../../wailsjs/go/models";
@@ -43,7 +44,10 @@ export function OSSObjectDetail({
     [t("oss.detail.lastModified"), object.lastModified ? new Date(object.lastModified * 1000).toLocaleString() : "—"],
   ];
   const copyKey = () =>
-    void navigator.clipboard?.writeText(object.key).then(() => notifyCopied(t("oss.detail.copyKeyCopied")));
+    void navigator.clipboard
+      ?.writeText(object.key)
+      .then(() => notifyCopied(t("oss.detail.copyKeyCopied")))
+      .catch((error) => toast.error(String(error)));
   const iconButtonClass =
     "cursor-pointer rounded-sm p-0.5 outline-none hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring/45";
 

--- a/frontend/src/components/oss/OSSObjectList.tsx
+++ b/frontend/src/components/oss/OSSObjectList.tsx
@@ -45,6 +45,8 @@ export function OSSObjectList({
   // nothing is checked. Returns false when there is nothing to copy, so the caller leaves
   // the key to the browser.
   const copyKeys = (focusedFallback: string | null): boolean => {
+    const textSelection = window.getSelection();
+    if (textSelection && !textSelection.isCollapsed && textSelection.toString().length > 0) return false;
     const keys =
       selection.size > 0
         ? objects.filter((o) => selection.has(o.key)).map((o) => o.key)

--- a/frontend/src/components/oss/OSSObjectList.tsx
+++ b/frontend/src/components/oss/OSSObjectList.tsx
@@ -1,8 +1,10 @@
 import { createElement } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { Checkbox } from "@opskat/ui";
 import { Folder, Download } from "lucide-react";
 import type { oss_svc } from "../../../wailsjs/go/models";
+import { notifyCopied } from "@/lib/notify";
 import { prefixLeafName } from "@/lib/ossPrefixTree";
 import { formatBytes } from "@/lib/formatBytes";
 import { typeIcon, typeIconColor } from "@/lib/objectContentType";
@@ -39,6 +41,24 @@ export function OSSObjectList({
 }: OSSObjectListProps) {
   const { t } = useTranslation();
 
+  // Ctrl/Cmd+C on the list copies the checked objects, or the row under the cursor when
+  // nothing is checked. Returns false when there is nothing to copy, so the caller leaves
+  // the key to the browser.
+  const copyKeys = (focusedFallback: string | null): boolean => {
+    const keys =
+      selection.size > 0
+        ? objects.filter((o) => selection.has(o.key)).map((o) => o.key)
+        : focusedFallback != null
+          ? [focusedFallback]
+          : [];
+    if (keys.length === 0) return false;
+    void navigator.clipboard
+      .writeText(keys.join("\n"))
+      .then(() => notifyCopied(t("oss.keyCopied")))
+      .catch((e) => toast.error(String(e)));
+    return true;
+  };
+
   return (
     <OSSObjectCollectionFrame
       className="min-h-0 flex-1 overflow-auto"
@@ -71,6 +91,8 @@ export function OSSObjectList({
               onDoubleClick={() => onNavigatePrefix(p)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") onNavigatePrefix(p);
+                // A folder row has no key of its own, but the list's checked objects still copy.
+                if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c" && copyKeys(null)) e.preventDefault();
               }}
               data-testid={`oss-folder-${p}`}
             >
@@ -98,6 +120,7 @@ export function OSSObjectList({
               onClick={() => onFocusObject?.(o.key)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") onFocusObject?.(o.key);
+                if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c" && copyKeys(o.key)) e.preventDefault();
               }}
               data-testid={`oss-object-${o.key}`}
             >

--- a/frontend/src/components/oss/__tests__/OSSObjectDetail.test.tsx
+++ b/frontend/src/components/oss/__tests__/OSSObjectDetail.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { OSSObjectDetail } from "../OSSObjectDetail";
 import type { oss_svc } from "../../../../wailsjs/go/models";
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({ toastSuccess: vi.fn(), toastError: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: toastSuccess, error: toastError } }));
 
 beforeEach(() => {
   vi.stubGlobal(
@@ -142,5 +145,27 @@ describe("OSSObjectDetail", () => {
 
     expect(screen.getByText("docs/report.pdf")).toHaveClass("select-text");
     expect(screen.getByText("STANDARD")).toHaveClass("select-text");
+  });
+
+  it("confirms the copied object key instead of repeating the button label", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    toastSuccess.mockClear();
+
+    render(
+      <OSSObjectDetail
+        object={obj()}
+        onEnsureThumbnail={vi.fn()}
+        onShare={vi.fn()}
+        onDownload={vi.fn()}
+        onDelete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("oss-detail-copy-key"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("docs/report.pdf"));
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("oss.detail.copyKeyCopied", expect.anything()));
   });
 });

--- a/frontend/src/components/oss/__tests__/OSSObjectDetail.test.tsx
+++ b/frontend/src/components/oss/__tests__/OSSObjectDetail.test.tsx
@@ -168,4 +168,25 @@ describe("OSSObjectDetail", () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith("docs/report.pdf"));
     await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("oss.detail.copyKeyCopied", expect.anything()));
   });
+
+  it("reports a clipboard write failure without an unhandled rejection", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard denied"));
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    toastError.mockClear();
+
+    render(
+      <OSSObjectDetail
+        object={obj()}
+        onEnsureThumbnail={vi.fn()}
+        onShare={vi.fn()}
+        onDownload={vi.fn()}
+        onDelete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("oss-detail-copy-key"));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Error: clipboard denied"));
+  });
 });

--- a/frontend/src/components/oss/__tests__/OSSObjectList.test.tsx
+++ b/frontend/src/components/oss/__tests__/OSSObjectList.test.tsx
@@ -199,6 +199,8 @@ describe("OSSObjectList — keyboard copy", () => {
     writeText.mockReset();
     writeText.mockResolvedValue(undefined);
     toastSuccess.mockReset();
+    toastError.mockReset();
+    window.getSelection()?.removeAllRanges();
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
@@ -234,6 +236,20 @@ describe("OSSObjectList — keyboard copy", () => {
     fireEvent.keyDown(screen.getByTestId("oss-object-docs/b.txt"), copyKey);
 
     expect(writeText).toHaveBeenCalledWith("docs/b.txt");
+  });
+
+  it("leaves Ctrl/Cmd+C to the browser while object text is selected", () => {
+    render(<OSSObjectList {...base} focusedKey="docs/b.txt" prefixes={[]} objects={objects} />);
+    const label = screen.getByText("b.txt");
+    const range = document.createRange();
+    range.selectNodeContents(label);
+    window.getSelection()!.addRange(range);
+    const event = new KeyboardEvent("keydown", { ...copyKey, bubbles: true, cancelable: true });
+
+    screen.getByTestId("oss-object-docs/b.txt").dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it("copies the checked objects from a folder row too", () => {

--- a/frontend/src/components/oss/__tests__/OSSObjectList.test.tsx
+++ b/frontend/src/components/oss/__tests__/OSSObjectList.test.tsx
@@ -1,9 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { OSSObjectList } from "../OSSObjectList";
 import { formatBytes } from "@/lib/formatBytes";
 import { shouldLoadNextPage } from "@/lib/ossListScroll";
 import type { oss_svc } from "../../../../wailsjs/go/models";
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({ toastSuccess: vi.fn(), toastError: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: toastSuccess, error: toastError } }));
 
 function obj(key: string, size: number): oss_svc.ObjectItem {
   return {
@@ -186,5 +189,68 @@ describe("OSSObjectList", () => {
     expect(onScrollNearBottom).not.toHaveBeenCalled();
     fireEvent.scroll(list, { target: { scrollTop: 900 } });
     expect(onScrollNearBottom).toHaveBeenCalledOnce();
+  });
+});
+
+describe("OSSObjectList — keyboard copy", () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    toastSuccess.mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  const base = {
+    selection: new Set<string>(),
+    loading: false,
+    loadingPage: false,
+    truncated: false,
+    onNavigatePrefix: vi.fn(),
+    onToggleSelect: vi.fn(),
+    onScrollNearBottom: vi.fn(),
+  };
+  const copyKey = { key: "c", code: "KeyC", ctrlKey: true, metaKey: true };
+  const objects = [obj("docs/a.txt", 1), obj("docs/b.txt", 2), obj("docs/c.txt", 3)];
+
+  it("copies the selected object keys one per line", async () => {
+    render(
+      <OSSObjectList {...base} selection={new Set(["docs/a.txt", "docs/c.txt"])} prefixes={[]} objects={objects} />
+    );
+
+    fireEvent.keyDown(screen.getByTestId("oss-object-docs/a.txt"), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("docs/a.txt\ndocs/c.txt");
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("oss.keyCopied", expect.anything()));
+  });
+
+  it("copies the focused object when nothing is selected", () => {
+    render(<OSSObjectList {...base} focusedKey="docs/b.txt" prefixes={[]} objects={objects} />);
+
+    fireEvent.keyDown(screen.getByTestId("oss-object-docs/b.txt"), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("docs/b.txt");
+  });
+
+  it("copies the checked objects from a folder row too", () => {
+    render(<OSSObjectList {...base} selection={new Set(["docs/a.txt"])} prefixes={["docs/sub/"]} objects={objects} />);
+
+    fireEvent.keyDown(screen.getByTestId("oss-folder-docs/sub/"), copyKey);
+
+    expect(writeText).toHaveBeenCalledWith("docs/a.txt");
+  });
+
+  it("leaves Ctrl/Cmd+C alone on a folder row when nothing is checked", () => {
+    render(<OSSObjectList {...base} prefixes={["docs/sub/"]} objects={objects} />);
+
+    const ev = new KeyboardEvent("keydown", { ...copyKey, bubbles: true, cancelable: true });
+    screen.getByTestId("oss-folder-docs/sub/").dispatchEvent(ev);
+
+    expect(ev.defaultPrevented).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -648,6 +648,22 @@ function QueryResultTableImpl({
     }
   }, [editingCell]);
 
+  // Closing the editor unmounts the input, which drops focus to <body> and silently kills the
+  // grid's keyboard bindings (copy, paste, arrows). Hand focus back to the grid unless the
+  // closing interaction moved it somewhere else on purpose.
+  const editorWasOpenRef = useRef(false);
+  useEffect(() => {
+    if (editingCell) {
+      editorWasOpenRef.current = true;
+      return;
+    }
+    if (!editorWasOpenRef.current) return;
+    editorWasOpenRef.current = false;
+    const active = document.activeElement;
+    if (active && active !== document.body) return;
+    containerRef.current?.focus();
+  }, [editingCell]);
+
   // Close context menu on outside click / escape
   useEffect(() => {
     if (!ctxMenu) return;

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -28,6 +28,7 @@ import { toast } from "sonner";
 import { notifyCopied } from "@/lib/notify";
 import { formatModKey } from "@/stores/shortcutStore";
 import { cellValueToDisplayText, cellValueToText } from "@/lib/cellValue";
+import { parseTabSeparatedRows } from "@/lib/tableImport";
 import type { CellValueFilterOperator } from "@/lib/tableSql";
 import { TABLE_FILTER_OPERATOR_LABEL_KEYS, TABLE_FILTER_OPERATOR_OPTIONS } from "@/lib/tableFilterOperators";
 
@@ -74,6 +75,10 @@ interface QueryResultTableProps {
   onCellEdit?: (edit: CellEdit) => void;
   onSetCellValue?: (edit: CellEdit) => void;
   onPasteCell?: (edit: CellEdit) => void;
+  // Enables keyboard paste of a tab-separated block. Read-only grids and grids whose host
+  // has no pending-edit staging (SQL results, MongoDB documents) leave the prop out, and
+  // then Ctrl/Cmd+V pastes nothing there.
+  onPasteBlock?: (block: { edits: CellEdit[]; newRowCount: number }) => void;
   onGenerateUuid?: (edit: CellEdit) => void;
   onCopyAs?: (format: CopyAsFormat, ctx: CellActionContext) => void;
   onFilterByCellValue?: (ctx: CellActionContext) => void;
@@ -301,6 +306,7 @@ function QueryResultTableImpl({
   onCellEdit,
   onSetCellValue,
   onPasteCell,
+  onPasteBlock,
   onGenerateUuid,
   onCopyAs,
   onFilterByCellValue,
@@ -883,6 +889,49 @@ function QueryResultTableImpl({
     }
   }, [ctxMenu, pasteCellHandler]);
 
+  // Clipboard block paste: every pasted value becomes a pending edit of the cell it lands
+  // in, from the anchor cell rightwards and downwards. A block that runs past the last
+  // displayed row asks the host for that many unsaved rows, the same state the "add row"
+  // affordance creates. Values past the last visible column are discarded.
+  const pasteClipboardBlock = useCallback(async () => {
+    if (!onPasteBlock || displayColumns.length === 0) return;
+    const anchor = selectedCell
+      ? { rowIdx: selectedCell.origIdx, col: selectedCell.col }
+      : selectedRowIdxs.size > 0
+        ? { rowIdx: sortedIndices.find((rowIdx) => selectedRowIdxs.has(rowIdx)), col: displayColumns[0] }
+        : null;
+    if (!anchor || anchor.rowIdx == null) return;
+    const anchorRowIdx = anchor.rowIdx;
+    const startColIdx = displayColumns.indexOf(anchor.col);
+    if (startColIdx === -1) return;
+
+    let text: string;
+    try {
+      text = await navigator.clipboard.readText();
+    } catch {
+      // An unreadable clipboard is not an error worth reporting: the user just gets nothing.
+      return;
+    }
+    if (!text.trim()) return;
+
+    const edits: CellEdit[] = [];
+    let lastRowIdx = anchorRowIdx - 1;
+    parseTabSeparatedRows(text).forEach((cells, rowOffset) => {
+      const rowIdx = anchorRowIdx + rowOffset;
+      let wrote = false;
+      cells.forEach((value, colOffset) => {
+        const col = displayColumns[startColIdx + colOffset];
+        if (col == null) return;
+        edits.push({ rowIdx, col, value });
+        wrote = true;
+      });
+      if (wrote) lastRowIdx = rowIdx;
+    });
+    if (edits.length === 0) return;
+
+    onPasteBlock({ edits, newRowCount: Math.max(0, lastRowIdx - rows.length + 1) });
+  }, [onPasteBlock, displayColumns, selectedCell, selectedRowIdxs, sortedIndices, rows.length]);
+
   const handleGenerateUuid = useCallback(() => {
     if (!ctxMenu || ctxMenu.kind !== "cell") return;
     uuidCellHandler?.({ rowIdx: ctxMenu.rowIdx, col: ctxMenu.col, value: crypto.randomUUID() });
@@ -1249,6 +1298,13 @@ function QueryResultTableImpl({
         return;
       }
 
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "v") {
+        if (!selectedCell && selectedRowIdxs.size === 0) return;
+        e.preventDefault();
+        void pasteClipboardBlock();
+        return;
+      }
+
       if (!selectedCell) {
         if ((selectedRowIdxs.size > 0 || selectedColumns.size > 0) && e.key === "Escape") {
           e.preventDefault();
@@ -1313,6 +1369,7 @@ function QueryResultTableImpl({
       onSelectedRowsChange,
       selectCell,
       copySelectionToClipboard,
+      pasteClipboardBlock,
     ]
   );
 

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -826,7 +826,9 @@ function QueryResultTableImpl({
                 kind: "cell",
                 rowIdx: selectedCell.origIdx,
                 col: selectedCell.col,
-                value: rows[selectedCell.origIdx]?.[selectedCell.col],
+                value: edits?.has(cellKey(selectedCell.origIdx, selectedCell.col))
+                  ? edits.get(cellKey(selectedCell.origIdx, selectedCell.col))
+                  : rows[selectedCell.origIdx]?.[selectedCell.col],
               }
             : null;
     if (!target) return;
@@ -844,7 +846,7 @@ function QueryResultTableImpl({
     } catch (e) {
       toast.error(String(e));
     }
-  }, [selectedRowIdxs, selectedColumns, selectedCell, sortedIndices, displayColumns, rows, t]);
+  }, [selectedRowIdxs, selectedColumns, selectedCell, sortedIndices, displayColumns, edits, rows, t]);
 
   const handleCopyFieldName = useCallback(async () => {
     const col = ctxMenu?.kind === "cell" || ctxMenu?.kind === "column" ? ctxMenu.col : null;
@@ -902,8 +904,9 @@ function QueryResultTableImpl({
         : null;
     if (!anchor || anchor.rowIdx == null) return;
     const anchorRowIdx = anchor.rowIdx;
+    const anchorDisplayIdx = sortedIndices.indexOf(anchorRowIdx);
     const startColIdx = displayColumns.indexOf(anchor.col);
-    if (startColIdx === -1) return;
+    if (anchorDisplayIdx === -1 || startColIdx === -1) return;
 
     let text: string;
     try {
@@ -915,9 +918,10 @@ function QueryResultTableImpl({
     if (!text.trim()) return;
 
     const edits: CellEdit[] = [];
-    let lastRowIdx = anchorRowIdx - 1;
+    let newRowCount = 0;
     parseTabSeparatedRows(text).forEach((cells, rowOffset) => {
-      const rowIdx = anchorRowIdx + rowOffset;
+      const targetDisplayIdx = anchorDisplayIdx + rowOffset;
+      const rowIdx = sortedIndices[targetDisplayIdx] ?? rows.length + targetDisplayIdx - sortedIndices.length;
       let wrote = false;
       cells.forEach((value, colOffset) => {
         const col = displayColumns[startColIdx + colOffset];
@@ -925,11 +929,11 @@ function QueryResultTableImpl({
         edits.push({ rowIdx, col, value });
         wrote = true;
       });
-      if (wrote) lastRowIdx = rowIdx;
+      if (wrote && rowIdx >= rows.length) newRowCount = Math.max(newRowCount, rowIdx - rows.length + 1);
     });
     if (edits.length === 0) return;
 
-    onPasteBlock({ edits, newRowCount: Math.max(0, lastRowIdx - rows.length + 1) });
+    onPasteBlock({ edits, newRowCount });
   }, [onPasteBlock, displayColumns, selectedCell, selectedRowIdxs, sortedIndices, rows.length]);
 
   const handleGenerateUuid = useCallback(() => {

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -179,7 +179,6 @@ type CopyTarget = { kind: "row" | "column" | "cell"; rowIdx?: number; col?: stri
 function buildCopyText({
   target,
   rows,
-  edits,
   displayColumns,
   sortedIndices,
   selectedRowIdxs,
@@ -187,7 +186,6 @@ function buildCopyText({
 }: {
   target: CopyTarget;
   rows: Record<string, unknown>[];
-  edits?: Map<string, unknown>;
   displayColumns: string[];
   sortedIndices: number[];
   selectedRowIdxs: Set<number>;
@@ -210,20 +208,8 @@ function buildCopyText({
       ? selectedColumnOrder
       : [target.kind === "column" ? (target.col ?? "") : ""];
   const hasColumnSelection = columnCopyColumns.length > 0 && columnCopyColumns[0] !== "";
-  // Export serializers may normalize dates; clipboard copy must preserve displayed text.
   const copyGrid = (rowIndices: number[], columns: string[]) =>
-    rowIndices
-      .map((rowIdx) =>
-        columns
-          .map((col) => {
-            const key = cellKey(rowIdx, col);
-            const value = edits?.has(key) ? edits.get(key) : rows[rowIdx]?.[col];
-            const text = cellValueToText(value);
-            return /[\t"\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
-          })
-          .join("\t")
-      )
-      .join("\n");
+    rowIndices.map((rowIdx) => columns.map((col) => cellValueToText(rows[rowIdx]?.[col])).join("\t")).join("\n");
   if (target.kind === "row" || (target.kind === "cell" && rowCopyIndices[0] !== -1)) {
     return copyGrid(rowCopyIndices, displayColumns);
   }
@@ -827,7 +813,6 @@ function QueryResultTableImpl({
           value: ctxMenu.kind === "cell" ? ctxMenu.value : undefined,
         },
         rows,
-        edits,
         displayColumns,
         sortedIndices,
         selectedRowIdxs,
@@ -840,7 +825,7 @@ function QueryResultTableImpl({
     } finally {
       setCtxMenu(null);
     }
-  }, [ctxMenu, displayColumns, edits, rows, selectedColumns, selectedRowIdxs, sortedIndices, t]);
+  }, [ctxMenu, displayColumns, rows, selectedColumns, selectedRowIdxs, sortedIndices, t]);
 
   // Keyboard copy mirrors what a right-click on the current selection would copy:
   // rows first, then columns, then the focused cell.
@@ -865,7 +850,6 @@ function QueryResultTableImpl({
       const text = buildCopyText({
         target,
         rows,
-        edits,
         displayColumns,
         sortedIndices,
         selectedRowIdxs,
@@ -1333,7 +1317,7 @@ function QueryResultTableImpl({
       }
 
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "v") {
-        if (!selectedCell && selectedRowIdxs.size === 0) return;
+        if (!editable || !onPasteBlock || (!selectedCell && selectedRowIdxs.size === 0)) return;
         e.preventDefault();
         void pasteClipboardBlock();
         return;
@@ -1399,6 +1383,7 @@ function QueryResultTableImpl({
       sortedIndices,
       displayColumns,
       editable,
+      onPasteBlock,
       onSelectedCellChange,
       onSelectedRowsChange,
       selectCell,

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -26,6 +26,7 @@ import { Popover, PopoverContent, PopoverTrigger, computeContextMenuPosition } f
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { toast } from "sonner";
 import { notifyCopied } from "@/lib/notify";
+import { formatModKey } from "@/stores/shortcutStore";
 import { cellValueToDisplayText, cellValueToText } from "@/lib/cellValue";
 import type { CellValueFilterOperator } from "@/lib/tableSql";
 import { TABLE_FILTER_OPERATOR_LABEL_KEYS, TABLE_FILTER_OPERATOR_OPTIONS } from "@/lib/tableFilterOperators";
@@ -159,6 +160,61 @@ type ColumnContextMenu = {
 };
 
 type ContextMenuState = CellContextMenu | RowContextMenu | ColumnContextMenu;
+
+/**
+ * A copy target addressed the way a context menu addresses one. When the addressed
+ * row/column is part of the current selection, the whole selection is copied instead.
+ */
+type CopyTarget = { kind: "row" | "column" | "cell"; rowIdx?: number; col?: string; value?: unknown };
+
+/**
+ * The single source of truth for "selection → clipboard text". Both the context-menu copy
+ * and the keyboard copy build their text here, so the two can never disagree.
+ */
+function buildCopyText({
+  target,
+  rows,
+  displayColumns,
+  sortedIndices,
+  selectedRowIdxs,
+  selectedColumns,
+}: {
+  target: CopyTarget;
+  rows: Record<string, unknown>[];
+  displayColumns: string[];
+  sortedIndices: number[];
+  selectedRowIdxs: Set<number>;
+  selectedColumns: Set<string>;
+}): string {
+  const selectedRowOrder = sortedIndices.filter((rowIdx) => selectedRowIdxs.has(rowIdx));
+  const selectedColumnOrder = displayColumns.filter((col) => selectedColumns.has(col));
+  const rowCopyIndices =
+    (target.kind === "row" || target.kind === "cell") &&
+    target.rowIdx != null &&
+    selectedRowIdxs.has(target.rowIdx) &&
+    selectedRowOrder.length > 0
+      ? selectedRowOrder
+      : [target.kind === "row" ? (target.rowIdx ?? -1) : -1];
+  const columnCopyColumns =
+    (target.kind === "column" || target.kind === "cell") &&
+    target.col != null &&
+    selectedColumns.has(target.col) &&
+    selectedColumnOrder.length > 0
+      ? selectedColumnOrder
+      : [target.kind === "column" ? (target.col ?? "") : ""];
+  const hasColumnSelection = columnCopyColumns.length > 0 && columnCopyColumns[0] !== "";
+  if (target.kind === "row" || (target.kind === "cell" && rowCopyIndices[0] !== -1)) {
+    return rowCopyIndices
+      .map((rowIdx) => displayColumns.map((col) => cellValueToText(rows[rowIdx]?.[col])).join("\t"))
+      .join("\n");
+  }
+  if (target.kind === "column" || (target.kind === "cell" && hasColumnSelection)) {
+    return sortedIndices
+      .map((rowIdx) => columnCopyColumns.map((col) => cellValueToText(rows[rowIdx]?.[col])).join("\t"))
+      .join("\n");
+  }
+  return cellValueToText(target.value);
+}
 
 function getColumnTypeIcon(type?: string) {
   const normalized = type?.toLowerCase() ?? "";
@@ -729,31 +785,19 @@ function QueryResultTableImpl({
   const handleCopyCell = useCallback(async () => {
     if (!ctxMenu) return;
     try {
-      const selectedRowOrder = sortedIndices.filter((rowIdx) => selectedRowIdxs.has(rowIdx));
-      const selectedColumnOrder = displayColumns.filter((col) => selectedColumns.has(col));
-      const rowCopyIndices =
-        (ctxMenu.kind === "row" || ctxMenu.kind === "cell") &&
-        selectedRowIdxs.has(ctxMenu.rowIdx) &&
-        selectedRowOrder.length > 0
-          ? selectedRowOrder
-          : [ctxMenu.kind === "row" ? ctxMenu.rowIdx : -1];
-      const columnCopyColumns =
-        (ctxMenu.kind === "column" || ctxMenu.kind === "cell") &&
-        selectedColumns.has(ctxMenu.col) &&
-        selectedColumnOrder.length > 0
-          ? selectedColumnOrder
-          : [ctxMenu.kind === "column" ? ctxMenu.col : ""];
-      const hasColumnSelection = columnCopyColumns.length > 0 && columnCopyColumns[0] !== "";
-      const text =
-        ctxMenu.kind === "row" || (ctxMenu.kind === "cell" && rowCopyIndices.length > 0 && rowCopyIndices[0] !== -1)
-          ? rowCopyIndices
-              .map((rowIdx) => displayColumns.map((col) => cellValueToText(rows[rowIdx]?.[col])).join("\t"))
-              .join("\n")
-          : ctxMenu.kind === "column" || (ctxMenu.kind === "cell" && hasColumnSelection)
-            ? sortedIndices
-                .map((rowIdx) => columnCopyColumns.map((col) => cellValueToText(rows[rowIdx]?.[col])).join("\t"))
-                .join("\n")
-            : cellValueToText(ctxMenu.value);
+      const text = buildCopyText({
+        target: {
+          kind: ctxMenu.kind,
+          rowIdx: ctxMenu.kind === "cell" || ctxMenu.kind === "row" ? ctxMenu.rowIdx : undefined,
+          col: ctxMenu.kind === "cell" || ctxMenu.kind === "column" ? ctxMenu.col : undefined,
+          value: ctxMenu.kind === "cell" ? ctxMenu.value : undefined,
+        },
+        rows,
+        displayColumns,
+        sortedIndices,
+        selectedRowIdxs,
+        selectedColumns,
+      });
       await navigator.clipboard.writeText(text);
       notifyCopied(t("query.copied"));
     } catch (e) {
@@ -762,6 +806,39 @@ function QueryResultTableImpl({
       setCtxMenu(null);
     }
   }, [ctxMenu, displayColumns, rows, selectedColumns, selectedRowIdxs, sortedIndices, t]);
+
+  // Keyboard copy mirrors what a right-click on the current selection would copy:
+  // rows first, then columns, then the focused cell.
+  const copySelectionToClipboard = useCallback(async () => {
+    const target: CopyTarget | null =
+      selectedRowIdxs.size > 0
+        ? { kind: "row", rowIdx: sortedIndices.find((rowIdx) => selectedRowIdxs.has(rowIdx)) }
+        : selectedColumns.size > 0
+          ? { kind: "column", col: displayColumns.find((col) => selectedColumns.has(col)) }
+          : selectedCell
+            ? {
+                kind: "cell",
+                rowIdx: selectedCell.origIdx,
+                col: selectedCell.col,
+                value: rows[selectedCell.origIdx]?.[selectedCell.col],
+              }
+            : null;
+    if (!target) return;
+    try {
+      const text = buildCopyText({
+        target,
+        rows,
+        displayColumns,
+        sortedIndices,
+        selectedRowIdxs,
+        selectedColumns,
+      });
+      await navigator.clipboard.writeText(text);
+      notifyCopied(t("query.copied"));
+    } catch (e) {
+      toast.error(String(e));
+    }
+  }, [selectedRowIdxs, selectedColumns, selectedCell, sortedIndices, displayColumns, rows, t]);
 
   const handleCopyFieldName = useCallback(async () => {
     const col = ctxMenu?.kind === "cell" || ctxMenu?.kind === "column" ? ctxMenu.col : null;
@@ -1161,6 +1238,17 @@ function QueryResultTableImpl({
       // When editing, the input owns key events — only Escape handled here already
       // (the input's onKeyDown calls setEditingCell(null) on Escape).
       if (editingCell) return;
+
+      // Keyboard copy: the browser keeps the key while the user has page text selected.
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c") {
+        const textSelection = window.getSelection();
+        if (textSelection && !textSelection.isCollapsed && textSelection.toString().length > 0) return;
+        if (!selectedCell && selectedRowIdxs.size === 0 && selectedColumns.size === 0) return;
+        e.preventDefault();
+        void copySelectionToClipboard();
+        return;
+      }
+
       if (!selectedCell) {
         if ((selectedRowIdxs.size > 0 || selectedColumns.size > 0) && e.key === "Escape") {
           e.preventDefault();
@@ -1224,6 +1312,7 @@ function QueryResultTableImpl({
       onSelectedCellChange,
       onSelectedRowsChange,
       selectCell,
+      copySelectionToClipboard,
     ]
   );
 
@@ -1725,6 +1814,7 @@ function QueryResultTableImpl({
                 <button type="button" role="menuitem" className={CONTEXT_MENU_ITEM_CLASS} onClick={handleCopyCell}>
                   <Copy className="h-3.5 w-3.5" />
                   {t("query.copyValue")}
+                  <span className="ml-auto text-xs text-muted-foreground">{formatModKey("KeyC")}</span>
                 </button>
                 {onCopyAs && (
                   <div

--- a/frontend/src/components/query/QueryResultTable.tsx
+++ b/frontend/src/components/query/QueryResultTable.tsx
@@ -179,6 +179,7 @@ type CopyTarget = { kind: "row" | "column" | "cell"; rowIdx?: number; col?: stri
 function buildCopyText({
   target,
   rows,
+  edits,
   displayColumns,
   sortedIndices,
   selectedRowIdxs,
@@ -186,6 +187,7 @@ function buildCopyText({
 }: {
   target: CopyTarget;
   rows: Record<string, unknown>[];
+  edits?: Map<string, unknown>;
   displayColumns: string[];
   sortedIndices: number[];
   selectedRowIdxs: Set<number>;
@@ -208,15 +210,25 @@ function buildCopyText({
       ? selectedColumnOrder
       : [target.kind === "column" ? (target.col ?? "") : ""];
   const hasColumnSelection = columnCopyColumns.length > 0 && columnCopyColumns[0] !== "";
-  if (target.kind === "row" || (target.kind === "cell" && rowCopyIndices[0] !== -1)) {
-    return rowCopyIndices
-      .map((rowIdx) => displayColumns.map((col) => cellValueToText(rows[rowIdx]?.[col])).join("\t"))
+  // Export serializers may normalize dates; clipboard copy must preserve displayed text.
+  const copyGrid = (rowIndices: number[], columns: string[]) =>
+    rowIndices
+      .map((rowIdx) =>
+        columns
+          .map((col) => {
+            const key = cellKey(rowIdx, col);
+            const value = edits?.has(key) ? edits.get(key) : rows[rowIdx]?.[col];
+            const text = cellValueToText(value);
+            return /[\t"\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+          })
+          .join("\t")
+      )
       .join("\n");
+  if (target.kind === "row" || (target.kind === "cell" && rowCopyIndices[0] !== -1)) {
+    return copyGrid(rowCopyIndices, displayColumns);
   }
   if (target.kind === "column" || (target.kind === "cell" && hasColumnSelection)) {
-    return sortedIndices
-      .map((rowIdx) => columnCopyColumns.map((col) => cellValueToText(rows[rowIdx]?.[col])).join("\t"))
-      .join("\n");
+    return copyGrid(sortedIndices, columnCopyColumns);
   }
   return cellValueToText(target.value);
 }
@@ -799,6 +811,7 @@ function QueryResultTableImpl({
           value: ctxMenu.kind === "cell" ? ctxMenu.value : undefined,
         },
         rows,
+        edits,
         displayColumns,
         sortedIndices,
         selectedRowIdxs,
@@ -811,7 +824,7 @@ function QueryResultTableImpl({
     } finally {
       setCtxMenu(null);
     }
-  }, [ctxMenu, displayColumns, rows, selectedColumns, selectedRowIdxs, sortedIndices, t]);
+  }, [ctxMenu, displayColumns, edits, rows, selectedColumns, selectedRowIdxs, sortedIndices, t]);
 
   // Keyboard copy mirrors what a right-click on the current selection would copy:
   // rows first, then columns, then the focused cell.
@@ -836,6 +849,7 @@ function QueryResultTableImpl({
       const text = buildCopyText({
         target,
         rows,
+        edits,
         displayColumns,
         sortedIndices,
         selectedRowIdxs,
@@ -911,8 +925,8 @@ function QueryResultTableImpl({
     let text: string;
     try {
       text = await navigator.clipboard.readText();
-    } catch {
-      // An unreadable clipboard is not an error worth reporting: the user just gets nothing.
+    } catch (e) {
+      toast.error(String(e));
       return;
     }
     if (!text.trim()) return;

--- a/frontend/src/components/query/RedisKeyBrowser.tsx
+++ b/frontend/src/components/query/RedisKeyBrowser.tsx
@@ -568,7 +568,9 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
         className="flex-1 overflow-y-auto"
         onScroll={handleScroll}
         onKeyDown={(e) => {
-          if (state.selectedKey && (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c") {
+          const textSelection = window.getSelection();
+          const hasSelectedText = textSelection && !textSelection.isCollapsed && textSelection.toString().length > 0;
+          if (state.selectedKey && !hasSelectedText && (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c") {
             e.preventDefault();
             copyKeyName(state.selectedKey);
           }

--- a/frontend/src/components/query/RedisKeyBrowser.tsx
+++ b/frontend/src/components/query/RedisKeyBrowser.tsx
@@ -438,12 +438,21 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
     });
   }, []);
 
+  const copyKeyName = useCallback(
+    (key: string) => {
+      void navigator.clipboard
+        .writeText(key)
+        .then(() => notifyCopied(t("query.copied")))
+        .catch((err) => toast.error(String(err)));
+    },
+    [t]
+  );
+
   const handleCopyKeyName = useCallback(() => {
     if (!ctxMenu) return;
-    navigator.clipboard.writeText(ctxMenu.key);
-    notifyCopied(t("query.copied"));
+    copyKeyName(ctxMenu.key);
     setCtxMenu(null);
-  }, [ctxMenu, t]);
+  }, [ctxMenu, copyKeyName]);
 
   const handleDeleteFromCtx = useCallback(() => {
     if (!ctxMenu) return;
@@ -558,6 +567,12 @@ export function RedisKeyBrowser({ tabId }: RedisKeyBrowserProps) {
         data-counts-incomplete={treeCountsIncomplete ? "true" : "false"}
         className="flex-1 overflow-y-auto"
         onScroll={handleScroll}
+        onKeyDown={(e) => {
+          if (state.selectedKey && (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c") {
+            e.preventDefault();
+            copyKeyName(state.selectedKey);
+          }
+        }}
       >
         <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
           {renderRows.map((virtualRow) => {

--- a/frontend/src/components/query/TableDataTab.tsx
+++ b/frontend/src/components/query/TableDataTab.tsx
@@ -398,12 +398,13 @@ function TableDataTabContent({ tabId, innerTabId, database, table }: TableDataTa
   }, []);
 
   const handleAddInlineRow = useCallback(() => {
-    if (columns.length === 0) return;
+    const firstVisibleColumn = visibleColumns.find((column) => columns.includes(column)) ?? columns[0];
+    if (!firstVisibleColumn) return;
     const rowIdx = rows.length + newRows.length;
     setNewRows((prev) => [...prev, {}]);
     setSelectedRowIdx(rowIdx);
-    setFocusCellRequest({ rowIdx, col: columns[0], nonce: Date.now() });
-  }, [columns, newRows.length, rows.length]);
+    setFocusCellRequest({ rowIdx, col: firstVisibleColumn, nonce: Date.now() });
+  }, [columns, newRows.length, rows.length, visibleColumns]);
 
   // A pasted block addresses rows in the grid's own coordinate space, where unsaved rows
   // are appended after the loaded page. Materialise as many as the block reaches, then

--- a/frontend/src/components/query/TableDataTab.tsx
+++ b/frontend/src/components/query/TableDataTab.tsx
@@ -405,6 +405,20 @@ function TableDataTabContent({ tabId, innerTabId, database, table }: TableDataTa
     setFocusCellRequest({ rowIdx, col: columns[0], nonce: Date.now() });
   }, [columns, newRows.length, rows.length]);
 
+  // A pasted block addresses rows in the grid's own coordinate space, where unsaved rows
+  // are appended after the loaded page. Materialise as many as the block reaches, then
+  // stage the values as ordinary pending edits.
+  const handlePasteBlock = useCallback((block: { edits: CellEdit[]; newRowCount: number }) => {
+    if (block.newRowCount > 0) {
+      setNewRows((prev) => [...prev, ...Array.from({ length: block.newRowCount }, () => ({}))]);
+    }
+    setEdits((prev) => {
+      const next = new Map(prev);
+      for (const edit of block.edits) next.set(`${edit.rowIdx}:${edit.col}`, edit.value);
+      return next;
+    });
+  }, []);
+
   const removeNewRow = useCallback(
     (rowIdx: number) => {
       const newRowIdx = rowIdx - rows.length;
@@ -1126,6 +1140,7 @@ function TableDataTabContent({ tabId, innerTabId, database, table }: TableDataTa
               onCellEdit={handleCellEdit}
               onSetCellValue={handleCellEdit}
               onPasteCell={handleCellEdit}
+              onPasteBlock={handlePasteBlock}
               onGenerateUuid={handleCellEdit}
               onCopyAs={handleCopyAs}
               onFilterByCellValue={handleFilterByCellValue}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -2868,7 +2868,8 @@
       "type": "Type",
       "etag": "ETag",
       "storageClass": "Storage class",
-      "lastModified": "Last modified"
+      "lastModified": "Last modified",
+      "copyKeyCopied": "Object key copied"
     },
     "share": {
       "title": "Generate presigned URL",
@@ -2890,7 +2891,8 @@
       "warning": "This link expires in {{duration}} · anyone with it can access the object",
       "generateFailed": "Failed to generate URL",
       "copied": "Link copied"
-    }
+    },
+    "keyCopied": "Object key copied"
   },
   "etcd": {
     "form": {

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1314,7 +1314,7 @@
     "terminal.paste": "Terminal Paste",
     "terminal.selectAll": "Terminal Select All",
     "terminal.find": "Terminal Search",
-    "asset.copyRef": "Copy Asset Reference",
+    "asset.copyRef": "Copy Asset Reference (asset sidebar focused)",
     "page.home": "Switch to Home",
     "page.settings": "Switch to Settings",
     "page.sshkeys": "Switch to SSH Keys",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1314,7 +1314,7 @@
     "terminal.paste": "终端粘贴",
     "terminal.selectAll": "终端全选",
     "terminal.find": "终端搜索",
-    "asset.copyRef": "复制资产引用",
+    "asset.copyRef": "复制资产引用(资产侧栏聚焦时)",
     "page.home": "切换到首页",
     "page.settings": "切换到设置",
     "page.sshkeys": "切换到 SSH 密钥",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -2868,7 +2868,8 @@
       "type": "类型",
       "etag": "ETag",
       "storageClass": "存储类型",
-      "lastModified": "最后修改"
+      "lastModified": "最后修改",
+      "copyKeyCopied": "已复制键名"
     },
     "share": {
       "title": "生成预签名 URL",
@@ -2890,7 +2891,8 @@
       "warning": "链接将在 {{duration}}后失效 · 任何持有此链接的人都可访问该对象",
       "generateFailed": "生成 URL 失败",
       "copied": "链接已复制"
-    }
+    },
+    "keyCopied": "已复制键名"
   },
   "etcd": {
     "form": {

--- a/frontend/src/lib/assetRef.test.ts
+++ b/frontend/src/lib/assetRef.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
+  ASSET_SIDEBAR_ATTR,
   formatAssetMarkdownRef,
   parseOpsctlAssetHref,
   parseOpsctlAssetMarkdown,
@@ -21,35 +22,50 @@ describe("formatAssetMarkdownRef", () => {
 
 describe("shouldCopyAssetRef", () => {
   beforeEach(() => {
+    document.body.innerHTML = "";
+    window.getSelection()?.removeAllRanges();
     useAssetStore.setState({ selectedAssetId: 1 });
   });
 
-  it("allows copy from a non-editable target when an asset is selected", () => {
+  // Mounts a child of the asset sidebar root, which is the only surface that owns
+  // the asset-reference shortcut.
+  function mountSidebarChild<K extends keyof HTMLElementTagNameMap>(tag: K): HTMLElementTagNameMap[K] {
+    const root = document.createElement("div");
+    root.setAttribute(ASSET_SIDEBAR_ATTR, "");
+    const child = document.createElement(tag);
+    root.appendChild(child);
+    document.body.appendChild(root);
+    return child;
+  }
+
+  it("copies from a target inside the asset sidebar when an asset is selected", () => {
+    expect(shouldCopyAssetRef(mountSidebarChild("div"))).toBe(true);
+  });
+
+  it("does not steal copy from a surface outside the asset sidebar", () => {
     const div = document.createElement("div");
     document.body.appendChild(div);
-    expect(shouldCopyAssetRef(div)).toBe(true);
+    expect(shouldCopyAssetRef(div)).toBe(false);
   });
 
-  it("does not steal copy from an input", () => {
-    const input = document.createElement("input");
-    document.body.appendChild(input);
-    expect(shouldCopyAssetRef(input)).toBe(false);
+  it("does not steal copy from a text input inside the asset sidebar", () => {
+    expect(shouldCopyAssetRef(mountSidebarChild("input"))).toBe(false);
   });
 
-  it("does not steal copy from a terminal", () => {
-    const xterm = document.createElement("div");
-    xterm.className = "xterm";
-    const ta = document.createElement("textarea");
-    xterm.appendChild(ta);
-    document.body.appendChild(xterm);
-    expect(shouldCopyAssetRef(ta)).toBe(false);
+  it("does not steal copy while text is selected inside the asset sidebar", () => {
+    const target = mountSidebarChild("div");
+    target.textContent = "web-01";
+    const range = document.createRange();
+    range.selectNodeContents(target);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(shouldCopyAssetRef(target)).toBe(false);
   });
 
   it("does nothing when no asset is selected", () => {
     useAssetStore.setState({ selectedAssetId: null });
-    const div = document.createElement("div");
-    document.body.appendChild(div);
-    expect(shouldCopyAssetRef(div)).toBe(false);
+    expect(shouldCopyAssetRef(mountSidebarChild("div"))).toBe(false);
   });
 });
 

--- a/frontend/src/lib/assetRef.ts
+++ b/frontend/src/lib/assetRef.ts
@@ -9,6 +9,12 @@ const OPSCTL_ASSET_HREF_RE = /^opsctl:\/\/asset\/(\d+)$/i;
 const OPSCTL_ASSET_MARKDOWN_RE = /\[((?:\\.|[^\]])*)\]\((opsctl:\/\/asset\/\d+)\)/gi;
 const OPSCTL_ASSET_URI_RE = /opsctl:\/\/asset\/(\d+)/gi;
 
+/**
+ * Marks the asset sidebar root. The asset-reference shortcut is scoped to this
+ * surface: see {@link shouldCopyAssetRef}.
+ */
+export const ASSET_SIDEBAR_ATTR = "data-asset-sidebar";
+
 export function formatAssetMarkdownRef(name: string, id: number): string {
   const escaped = name.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
   return `[${escaped}](opsctl://asset/${id})`;
@@ -104,7 +110,10 @@ export async function copySelectedAssetMarkdownRef(): Promise<string | null> {
 export function shouldCopyAssetRef(target: EventTarget | null): boolean {
   const el = target instanceof HTMLElement ? target : null;
   if (!el) return false;
-  if (el.closest(".xterm")) return false;
+  // Only the focused asset sidebar owns this shortcut. A keydown targets the focused
+  // element, so containment here means "the sidebar is the surface the user is acting on"
+  // — every other surface (grid, terminal, SFTP list, OSS list) keeps the copy key.
+  if (!el.closest(`[${ASSET_SIDEBAR_ATTR}]`)) return false;
   if (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT" || el.isContentEditable) {
     return false;
   }

--- a/frontend/src/lib/tableImport.ts
+++ b/frontend/src/lib/tableImport.ts
@@ -87,6 +87,7 @@ interface ParseDelimitedRowsOptions {
   recordDelimiter?: ImportRecordDelimiter;
   textQualifier?: ImportTextQualifier;
   preserveEmptyRows?: boolean;
+  preserveQuotesInUnquotedValues?: boolean;
 }
 
 function parseDelimitedRows(
@@ -108,7 +109,11 @@ function parseDelimitedRows(
     const ch = text[i];
     const next = text[i + 1];
 
-    if (useQualifier && ch === qualifier && (inQuotes || current.length === 0)) {
+    if (
+      useQualifier &&
+      ch === qualifier &&
+      (!options.preserveQuotesInUnquotedValues || inQuotes || current.length === 0)
+    ) {
       rowStarted = true;
       if (inQuotes && next === qualifier) {
         current += qualifier;
@@ -161,7 +166,7 @@ export function parseDelimitedText(text: string, delimiter: Delimiter = detectDe
  * table has no trustworthy first row, and a value containing commas must stay one cell.
  */
 export function parseTabSeparatedRows(text: string): string[][] {
-  return parseDelimitedRows(text, "\t", { preserveEmptyRows: true });
+  return parseDelimitedRows(text, "\t", { preserveEmptyRows: true, preserveQuotesInUnquotedValues: true });
 }
 
 function normalizeCell(value: unknown): string {

--- a/frontend/src/lib/tableImport.ts
+++ b/frontend/src/lib/tableImport.ts
@@ -90,6 +90,27 @@ interface ParseDelimitedRowsOptions {
   preserveQuotesInUnquotedValues?: boolean;
 }
 
+function hasDelimitedClosingQualifier(
+  text: string,
+  openingIndex: number,
+  qualifier: string,
+  delimiter: ImportFieldDelimiter,
+  recordDelimiter: ImportRecordDelimiter
+): boolean {
+  for (let i = openingIndex + 1; i < text.length; i++) {
+    if (text[i] !== qualifier) continue;
+    if (text[i + 1] === qualifier) {
+      i++;
+      continue;
+    }
+    const nextIndex = i + 1;
+    return (
+      nextIndex === text.length || text[nextIndex] === delimiter || newlineAt(text, nextIndex, recordDelimiter).match
+    );
+  }
+  return false;
+}
+
 function parseDelimitedRows(
   text: string,
   delimiter: ImportFieldDelimiter = detectDelimiter(text),
@@ -109,11 +130,11 @@ function parseDelimitedRows(
     const ch = text[i];
     const next = text[i + 1];
 
-    if (
-      useQualifier &&
-      ch === qualifier &&
-      (!options.preserveQuotesInUnquotedValues || inQuotes || current.length === 0)
-    ) {
+    const canToggleQualifier =
+      !options.preserveQuotesInUnquotedValues ||
+      inQuotes ||
+      (current.length === 0 && hasDelimitedClosingQualifier(text, i, qualifier, delimiter, recordDelimiter));
+    if (useQualifier && ch === qualifier && canToggleQualifier) {
       rowStarted = true;
       if (inQuotes && next === qualifier) {
         current += qualifier;

--- a/frontend/src/lib/tableImport.ts
+++ b/frontend/src/lib/tableImport.ts
@@ -86,6 +86,7 @@ function newlineAt(text: string, i: number, mode: ImportRecordDelimiter): Newlin
 interface ParseDelimitedRowsOptions {
   recordDelimiter?: ImportRecordDelimiter;
   textQualifier?: ImportTextQualifier;
+  preserveEmptyRows?: boolean;
 }
 
 function parseDelimitedRows(
@@ -101,12 +102,14 @@ function parseDelimitedRows(
   let currentRow: string[] = [];
   let current = "";
   let inQuotes = false;
+  let rowStarted = false;
 
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
     const next = text[i + 1];
 
-    if (useQualifier && ch === qualifier) {
+    if (useQualifier && ch === qualifier && (inQuotes || current.length === 0)) {
+      rowStarted = true;
       if (inQuotes && next === qualifier) {
         current += qualifier;
         i++;
@@ -117,6 +120,7 @@ function parseDelimitedRows(
     }
 
     if (ch === delimiter && !inQuotes) {
+      rowStarted = true;
       currentRow.push(current);
       current = "";
       continue;
@@ -127,18 +131,20 @@ function parseDelimitedRows(
       if (nl.match) {
         i += nl.len - 1;
         currentRow.push(current);
-        if (currentRow.some((cell) => cell !== "")) rows.push(currentRow);
+        if (options.preserveEmptyRows || currentRow.some((cell) => cell !== "")) rows.push(currentRow);
         currentRow = [];
         current = "";
+        rowStarted = false;
         continue;
       }
     }
 
     current += ch;
+    rowStarted = true;
   }
 
   currentRow.push(current);
-  if (currentRow.some((cell) => cell !== "")) rows.push(currentRow);
+  if (currentRow.some((cell) => cell !== "") || (options.preserveEmptyRows && rowStarted)) rows.push(currentRow);
 
   return rows;
 }
@@ -155,7 +161,7 @@ export function parseDelimitedText(text: string, delimiter: Delimiter = detectDe
  * table has no trustworthy first row, and a value containing commas must stay one cell.
  */
 export function parseTabSeparatedRows(text: string): string[][] {
-  return parseDelimitedRows(text, "\t");
+  return parseDelimitedRows(text, "\t", { preserveEmptyRows: true });
 }
 
 function normalizeCell(value: unknown): string {

--- a/frontend/src/lib/tableImport.ts
+++ b/frontend/src/lib/tableImport.ts
@@ -149,6 +149,15 @@ export function parseDelimitedText(text: string, delimiter: Delimiter = detectDe
   return { headers, rows: rows.slice(1) };
 }
 
+/**
+ * Parses clipboard-style tab-separated text into rows of cells. Unlike
+ * {@link parseDelimitedText} there is no header row and no delimiter detection: a pasted
+ * table has no trustworthy first row, and a value containing commas must stay one cell.
+ */
+export function parseTabSeparatedRows(text: string): string[][] {
+  return parseDelimitedRows(text, "\t");
+}
+
 function normalizeCell(value: unknown): string {
   if (value == null) return "";
   if (typeof value === "string") return value;


### PR DESCRIPTION
## 变更说明 / Summary

修复"内容面按 `Ctrl/Cmd+C` 复制到的是资产引用而非选中内容"这一反馈问题，并让数据库结果网格支持键盘复制/粘贴行；同时修掉两处相关缺陷。

- **资产引用快捷键限定在资产侧栏**：原先全局捕获的 `Ctrl/Cmd+C` 不再抢占内容面的按键；侧栏聚焦时仍复制资产引用，其他内容面把按键交还各自持有者。这同时让 SFTP 文件管理器被吞掉的复制/剪切/粘贴恢复。
- **结果网格键盘复制**（可编辑表、SQL 结果、MongoDB 结果共用同一条序列化路径）：优先级为 选中行 → 选中列 → 聚焦单元格，TSV 与右键复制结果一致，复制后给出"已复制"提示。
- **可编辑网格键盘粘贴**：剪贴板 TSV 从锚点单元格写入为待提交编辑，行列溢出时追加未保存行；只读网格不粘贴且不拦截按键；粘贴本身不执行任何语句，仍走既有的预览/确认保存流程。
- **OSS 对象列表 / Redis 键列表** 支持 `Ctrl/Cmd+C` 复制选中键并确认；OSS 详情页"复制键名"的成功提示由按钮文案改为"已复制"。
- **关闭单元格编辑器后焦点回到网格**：因此"新增行 → 直接粘贴"不再需要先点一下新行。
- 一致性：网格右键复制项旁标注复制键位；设置中的资产引用项注明作用范围（资产侧栏聚焦时）。

规格：`docs/specs/2026-09-10-content-clipboard-ux.md`

分支基于 `835ac68c`，落后 `main` 一个提交（`2fc4da21`），两者改动文件无重叠。

## 关联 Issue / Related Issue

Closes #<!-- 该反馈若已有 issue 编号请填；本次来自用户现场报告：数据库表中 Ctrl/Cmd+C 复制到"已复制资产引用"而非选中数据 -->

## 截图 / Screenshots

真机证据在本地 gitignored 目录 `e2e/scratch/2026-09-10-content-clipboard-ux/`（含逐条判定报告 `report.md` 与修订轮 `report-correction-1.md`）。建 PR 后可拖入以下关键图：

- 关闭编辑器后焦点回到网格、直接粘贴填充新增行：`correction-1-focus-paste.png`
- 网格复制的确认提示：`consistency-1-toast.png`
- 右键菜单复制项的键位标注：`consistency-2-cellmenu.png`
- 保存前的预览确认：`correction-2-preview.png`

## 自检 / Checklist

- [x]  Fixes mentioned issues / 修复已提及的问题
- [ ]  Code reviewed by human / 代码通过人工检查
- [x]  Changes tested / 已完成测试

## 验证结论 / Verification

主会话在 dev-sandbox 上驱动真实 Wails 应用完成真机验证，目标为 `.env` 中的真实 MySQL / Redis / SSH / MinIO：

- 第 1 轮 24 条规格要求全部 `holds`（`report.md`）；
- 修订轮 27 条全部 `holds`（`report-correction-1.md`），含新增的"关闭单元格编辑器归还焦点"一条；
- 无 `does not hold`、无未观测项、无 blocked。
- 唯一现场观察（不计入判定、本轮未改动其代码路径）：网格右键 `Delete Record` 只预览并执行自身的 `DELETE`，当次并存的暂存单元格编辑不随之提交。

测试：`cd frontend && npx pnpm@10.11.0 test --run` → 246 files / 2374 tests 全绿；`npx pnpm@10.11.0 lint`、`tsc --noEmit` 干净；`make test`（Go，本分支未改动）全 ok。
